### PR TITLE
Fixed the misalignment between the icons and their names in the Navigation bar 

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -140,7 +140,7 @@ function Navbar() {
                       >
                         {page.icon}
 
-                        <Typography textAlign="center">{page.name}</Typography>
+                        <Typography m="5px" textAlign="center">{page.name}</Typography>
                       </MenuItem>
                     </NavLink>
                   ))
@@ -160,7 +160,7 @@ function Navbar() {
                     >
                       <MenuItem onClick={handleCloseNavMenu}>
                         {page.icon}
-                        <Typography textAlign="center">{page.name}</Typography>
+                        <Typography m="5px" textAlign="center">{page.name}</Typography>
                       </MenuItem>
                     </NavLink>
                   ))}
@@ -212,7 +212,7 @@ function Navbar() {
                     }}
                   >
                     <MenuItem onClick={handleCloseNavMenu}>
-                      <Typography textAlign="center">
+                      <Typography display="flex" gap="4px" textAlign="center">
                         {page.icon}
                         {page.name}
                       </Typography>{' '}
@@ -235,7 +235,7 @@ function Navbar() {
                     }}
                   >
                     <MenuItem onClick={handleCloseNavMenu}>
-                      <Typography textAlign="center">
+                      <Typography display="flex" gap="4px" textAlign="center">
                         {page.icon}
                         {page.name}
                       </Typography>{' '}


### PR DESCRIPTION
The misalignment between the icons and their names in the Navigation bar has been fixed. 
Also, some spacing between the icons and their names has been added to make a better front end.

### Before the fix :
![image](https://github.com/DhananjayThomble/URL-Shortener-App/assets/86215447/d1fbaedd-1530-48ec-9202-f5a54862affb)
![image](https://github.com/DhananjayThomble/URL-Shortener-App/assets/86215447/8b188bb5-98c7-46a7-bf0b-476f7de7bece)

### After the fix :
![image](https://github.com/DhananjayThomble/URL-Shortener-App/assets/86215447/3c2e41af-14fb-4738-bdd4-ec9d5d9ad779)
![Screenshot 2023-10-26 033929](https://github.com/DhananjayThomble/URL-Shortener-App/assets/86215447/70d85e13-f5c8-419b-bf10-491270c9a5ff)

Fixes #154
