### PR TITLE
Add nodemon to dev dependancies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -52,6 +52,7 @@
     "chai": "^4.3.10",
     "chai-http": "^4.4.0",
     "mocha": "^10.2.0",
+    "nodemon": "^3.0.1",
     "prettier": "^3.0.3",
     "supertest": "^6.3.3"
   }


### PR DESCRIPTION
## What does this PR do?
Add nodemon for dev dependencies inside the backend.
Reason: If you don't have/don't want to install nodemon globally, you don't have other way to run app in dev server.

Adds dependencies - nodemon@3

## Type of change

- [x] Adds a dependancy

## How should this be tested?
No test needed
