### PR TITLE
docs: update documentation for custom back halves feature

### DIFF
--- a/backend/swagger.yml
+++ b/backend/swagger.yml
@@ -209,6 +209,10 @@ paths:
                   shortUrl:
                     type: string
                     description: The shortened URL.
+                  customBackHalf:
+                    type: string
+                    nullable: true
+                    description: The custom back half (if set)
 
         "400":
           description: Bad request
@@ -220,6 +224,95 @@ paths:
                   error:
                     type: string
                     description: The error message.
+
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+
+        "500":
+          description: Error creating URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+
+  /api/url/custom:
+    post:
+      tags:
+         - Generate Url
+      summary: Generates a custom back half link
+      description: Create or edit the custom back half link of a short URL
+
+      security:
+        - BearerAuth: []
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                backHalf:
+                  type: string
+                  description: The new back half link of URL
+                shortUrl:
+                  type: string
+                  description: The original URL's short code
+              example:
+                backHalf: custom123
+                shortUrl: Yua7s8adce
+
+      responses:
+        "200":
+          description: Custom back half created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  customBackHalf:
+                    type: string
+                    description: The custom back half link
+                example:
+                  message: Custom back-half generated
+                  customBackHalf: custom123
+
+        "400":
+          description: Bad request (either the URL does not exist or this custom back link string already exists)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+                  suggestion:
+                    type: string
+                    nullable: true
+                    description: Suggested custom back link word
+              examples:
+                Back half already exists:
+                  value:
+                    error: 'Custom back-half already exists'
+                    suggestion: Random back half word
+                Url does not exist:
+                  value:
+                    error: URL does not exist
 
         "401":
           description: Unauthorized


### PR DESCRIPTION
## Summary

This commit/PR will update the swagger documentation for the implemented feature of custom-back-halves in commit d2a5ee31

(Update /api/url route)
- Add `customBackHalf` property in response object schema of /api/url (200)

(New /api/url/custom route)
- Add documentation for the new route /api/url/custom which allows to create/edit custom back links. 
- Provide requeest body details & examples.
- Provide response body details & examples.
- Document responses for 200, 400, 401 & 500.

Upon successful merge, this Resolves and Completes #54 issue.

(This is a hacktoberfest submission 🎃)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This is a documentation update

## How should this be tested?

> Tests do not apply here.

## Checklist

- I have read the [contributing guide](https://github.com/DhananjayThomble/URL-Shortener-App/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my PR needs changes to the documentation
- My changes generate no new warnings

## Video clip of documentation demo


https://github.com/DhananjayThomble/URL-Shortener-App/assets/68955143/57493066-9c52-495c-b906-8985ee9ca799

