### PR TITLE
Align frontend analytics with backend and replace WebSocket realtime with polling

### DIFF
--- a/frontend/src/hooks/useRealTimeAnalytics.tsx
+++ b/frontend/src/hooks/useRealTimeAnalytics.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { analyticsService } from '@/services/analytics.service';
-import { RealTimeUpdate, RealTimeAnalytics } from '@/services/api/dto';
+import { RealTimeAnalytics } from '@/services/api/dto';
 import { useAuth } from './useAuth';
 
 export interface UseRealTimeAnalyticsOptions {
   urlId?: string;
   enabled?: boolean;
-  onUpdate?: (update: RealTimeUpdate) => void;
+  onUpdate?: (data: RealTimeAnalytics) => void;
 }
 
 export const useRealTimeAnalytics = (options: UseRealTimeAnalyticsOptions = {}) => {
@@ -17,34 +17,11 @@ export const useRealTimeAnalytics = (options: UseRealTimeAnalyticsOptions = {}) 
   const [loading, setLoading] = useState(true);
   const unsubscribeRef = useRef<(() => void) | null>(null);
 
-  const handleRealTimeUpdate = useCallback((update: RealTimeUpdate) => {
-    // Update real-time data based on the update
-    setRealTimeData(prev => {
-      if (!prev) return prev;
+  const handleRealTimeUpdate = useCallback((data: RealTimeAnalytics) => {
+    setRealTimeData(data);
 
-      const newData = { ...prev };
-      
-      if (update.type === 'click') {
-        newData.activeVisitors = Math.max(0, newData.activeVisitors);
-        newData.recentClicks = [
-          {
-            timestamp: update.data.timestamp,
-            country: update.data.country,
-            device: update.data.device,
-            referrer: update.data.referrer,
-          },
-          ...newData.recentClicks.slice(0, 9) // Keep only last 10 clicks
-        ];
-      } else if (update.type === 'visitor') {
-        newData.activeVisitors += 1;
-      }
-
-      return newData;
-    });
-
-    // Call external update handler if provided
     if (onUpdate) {
-      onUpdate(update);
+      onUpdate(data);
     }
   }, [onUpdate]);
 
@@ -64,13 +41,12 @@ export const useRealTimeAnalytics = (options: UseRealTimeAnalyticsOptions = {}) 
         setRealTimeData(initialData);
       }
 
-      // Subscribe to real-time updates (temporarily disabled until WebSocket is implemented)
-      // const unsubscribe = urlId
-      //   ? analyticsService.subscribeToRealTime(urlId, handleRealTimeUpdate)
-      //   : analyticsService.subscribeToDashboardRealTime(handleRealTimeUpdate);
+      const unsubscribe = urlId
+        ? analyticsService.subscribeToRealTime(urlId, handleRealTimeUpdate)
+        : analyticsService.subscribeToDashboardRealTime(handleRealTimeUpdate);
 
-      // unsubscribeRef.current = unsubscribe;
-      setIsConnected(true); // Simulate connection for now
+      unsubscribeRef.current = unsubscribe;
+      setIsConnected(true);
     } catch (error) {
       console.error('Error connecting to real-time analytics:', error);
       setIsConnected(false);
@@ -162,41 +138,45 @@ export const useAnalyticsNotifications = () => {
 export const useRealTimeAnalyticsWithNotifications = (options: UseRealTimeAnalyticsOptions = {}) => {
   const { addNotification } = useAnalyticsNotifications();
   const previousClickCount = useRef<number>(0);
+  const seenClickIds = useRef<Set<string>>(new Set());
 
-  const handleUpdateWithNotifications = useCallback((update: RealTimeUpdate) => {
-    // Handle milestone notifications
-    if (update.type === 'click') {
-      const currentCount = previousClickCount.current + 1;
-      previousClickCount.current = currentCount;
+  const handleUpdateWithNotifications = useCallback((data: RealTimeAnalytics) => {
+    const clickIds = new Set(
+      data.recentClicks.map(click =>
+        `${click.timestamp}-${click.country}-${click.device}-${click.referrer ?? ''}`,
+      ),
+    );
 
-      // Check for milestones
+    const newClicks = Array.from(clickIds).filter(id => !seenClickIds.current.has(id));
+    if (newClicks.length > 0) {
+      newClicks.forEach(id => seenClickIds.current.add(id));
+      previousClickCount.current += newClicks.length;
+      const currentCount = previousClickCount.current;
+
       const milestones = [10, 50, 100, 500, 1000, 5000, 10000];
       if (milestones.includes(currentCount)) {
         addNotification({
           type: 'milestone',
           title: 'Milestone Reached!',
           message: `Your link has reached ${currentCount.toLocaleString()} clicks!`,
-          data: { clicks: currentCount, urlId: update.data.urlId }
+          data: { clicks: currentCount, urlId: options.urlId }
         });
       }
 
-      // Detect traffic spikes (simplified logic)
-      // In a real implementation, you'd compare against historical averages
       if (currentCount > 0 && currentCount % 20 === 0) {
         addNotification({
           type: 'spike',
           title: 'Traffic Spike Detected',
           message: `Increased activity detected on your link`,
-          data: { urlId: update.data.urlId }
+          data: { urlId: options.urlId }
         });
       }
     }
 
-    // Call original handler if provided
     if (options.onUpdate) {
-      options.onUpdate(update);
+      options.onUpdate(data);
     }
-  }, [addNotification, options.onUpdate]);
+  }, [addNotification, options.onUpdate, options.urlId]);
 
   return useRealTimeAnalytics({
     ...options,

--- a/frontend/src/services/analytics.service.ts
+++ b/frontend/src/services/analytics.service.ts
@@ -10,32 +10,29 @@ import {
   AnalyticsData,
   DashboardAnalytics,
   RealTimeAnalytics,
-  RealTimeUpdate
 } from './api/dto';
 import { APIResponse } from './api/types';
 
 export class AnalyticsService {
   private readonly baseEndpoint = '/analytics';
-  private wsConnections: Map<string, WebSocket> = new Map();
-  private reconnectAttempts: Map<string, number> = new Map();
-  private maxReconnectAttempts = 5;
-  private baseReconnectDelay = 1000; // 1 second
+  private pollingIntervals: Map<string, number> = new Map();
+  private pollingIntervalMs = 15000;
 
   /**
    * Get analytics data for a specific URL
    */
-  async getURLAnalytics(urlId: string, params: AnalyticsParams = {}): Promise<AnalyticsData | null> {
+  async getURLAnalytics(linkId: string, params: AnalyticsParams = {}): Promise<AnalyticsData | null> {
     try {
       const queryParams = new URLSearchParams();
       
-      if (params.startDate) queryParams.append('startDate', params.startDate);
-      if (params.endDate) queryParams.append('endDate', params.endDate);
-      if (params.granularity) queryParams.append('granularity', params.granularity);
+      if (params.limit) queryParams.append('limit', params.limit.toString());
+      if (params.offset) queryParams.append('offset', params.offset.toString());
+      queryParams.append('linkId', linkId);
 
       const queryString = queryParams.toString();
       const endpoint = queryString 
-        ? `${this.baseEndpoint}/urls/${urlId}?${queryString}` 
-        : `${this.baseEndpoint}/urls/${urlId}`;
+        ? `${this.baseEndpoint}/link/${linkId}/stats?${queryString}` 
+        : `${this.baseEndpoint}/link/${linkId}/stats`;
       
       const response = await apiClient.get<AnalyticsData>(endpoint);
       
@@ -85,9 +82,17 @@ export class AnalyticsService {
   /**
    * Get real-time analytics for a URL
    */
-  async getRealTimeAnalytics(urlId: string): Promise<RealTimeAnalytics | null> {
+  async getRealTimeAnalytics(linkId?: string): Promise<RealTimeAnalytics | null> {
     try {
-      const response = await apiClient.get<RealTimeAnalytics>(`${this.baseEndpoint}/real-time`);
+      const queryParams = new URLSearchParams();
+      if (linkId) queryParams.append('linkId', linkId);
+
+      const queryString = queryParams.toString();
+      const endpoint = queryString 
+        ? `${this.baseEndpoint}/real-time?${queryString}`
+        : `${this.baseEndpoint}/real-time`;
+
+      const response = await apiClient.get<RealTimeAnalytics>(endpoint);
       
       if (response.success && response.data) {
         return response.data;
@@ -133,98 +138,43 @@ export class AnalyticsService {
   }
 
   /**
-   * Subscribe to real-time analytics updates via WebSocket
+   * Subscribe to real-time analytics updates via polling
    */
-  subscribeToRealTime(urlId: string, callback: (data: RealTimeUpdate) => void): () => void {
-    const wsKey = `realtime-${urlId}`;
-    
-    // Close existing connection if any
-    this.unsubscribeFromRealTime(wsKey);
+  subscribeToRealTime(linkId: string | null, callback: (data: RealTimeAnalytics) => void): () => void {
+    const pollKey = `realtime-${linkId ?? 'dashboard'}`;
 
-    try {
-      const baseURL = apiClient.getBaseURL();
-      const wsURL = baseURL.replace(/^http/, 'ws') + `/analytics/ws/${urlId}`;
-      
-      const ws = new WebSocket(wsURL);
-      this.wsConnections.set(wsKey, ws);
-      this.reconnectAttempts.set(wsKey, 0);
+    this.unsubscribeFromRealTime(pollKey);
 
-      ws.onopen = () => {
-        console.log(`WebSocket connected for URL ${urlId}`);
-        this.reconnectAttempts.set(wsKey, 0);
-      };
-
-      ws.onmessage = (event) => {
-        try {
-          const data: RealTimeUpdate = JSON.parse(event.data);
-          callback(data);
-        } catch (error) {
-          console.error('Error parsing WebSocket message:', error);
-        }
-      };
-
-      ws.onclose = (event) => {
-        console.log(`WebSocket closed for URL ${urlId}:`, event.code, event.reason);
-        this.wsConnections.delete(wsKey);
-        
-        // Attempt reconnection if not manually closed
-        if (event.code !== 1000) {
-          this.handleReconnection(wsKey, urlId, callback);
-        }
-      };
-
-      ws.onerror = (error) => {
-        console.error(`WebSocket error for URL ${urlId}:`, error);
-      };
-
-      // Return unsubscribe function
-      return () => this.unsubscribeFromRealTime(wsKey);
-    } catch (error) {
-      console.error('Error creating WebSocket connection:', error);
-      return () => {};
-    }
-  }
-
-  /**
-   * Handle WebSocket reconnection with exponential backoff
-   */
-  private handleReconnection(wsKey: string, urlId: string, callback: (data: RealTimeUpdate) => void): void {
-    const attempts = this.reconnectAttempts.get(wsKey) || 0;
-    
-    if (attempts >= this.maxReconnectAttempts) {
-      console.error(`Max reconnection attempts reached for ${wsKey}`);
-      return;
-    }
-
-    const delay = this.baseReconnectDelay * Math.pow(2, attempts);
-    this.reconnectAttempts.set(wsKey, attempts + 1);
-
-    console.log(`Attempting to reconnect ${wsKey} in ${delay}ms (attempt ${attempts + 1})`);
-    
-    setTimeout(() => {
-      if (!this.wsConnections.has(wsKey)) {
-        this.subscribeToRealTime(urlId, callback);
+    const poll = async () => {
+      const data = await this.getRealTimeAnalytics(linkId ?? undefined);
+      if (data) {
+        callback(data);
       }
-    }, delay);
+    };
+
+    poll();
+    const intervalId = window.setInterval(poll, this.pollingIntervalMs);
+    this.pollingIntervals.set(pollKey, intervalId);
+
+    return () => this.unsubscribeFromRealTime(pollKey);
   }
 
   /**
    * Unsubscribe from real-time updates
    */
-  private unsubscribeFromRealTime(wsKey: string): void {
-    const ws = this.wsConnections.get(wsKey);
-    if (ws) {
-      ws.close(1000, 'Manual disconnect');
-      this.wsConnections.delete(wsKey);
-      this.reconnectAttempts.delete(wsKey);
+  private unsubscribeFromRealTime(pollKey: string): void {
+    const intervalId = this.pollingIntervals.get(pollKey);
+    if (intervalId) {
+      window.clearInterval(intervalId);
+      this.pollingIntervals.delete(pollKey);
     }
   }
 
   /**
    * Subscribe to dashboard real-time updates
    */
-  subscribeToDashboardRealTime(callback: (data: RealTimeUpdate) => void): () => void {
-    return this.subscribeToRealTime('dashboard', callback);
+  subscribeToDashboardRealTime(callback: (data: RealTimeAnalytics) => void): () => void {
+    return this.subscribeToRealTime(null, callback);
   }
 
   /**
@@ -325,14 +275,13 @@ export class AnalyticsService {
   }
 
   /**
-   * Clean up all WebSocket connections
+   * Clean up all polling intervals
    */
   cleanup(): void {
-    this.wsConnections.forEach((ws, key) => {
-      this.unsubscribeFromRealTime(key);
+    this.pollingIntervals.forEach((intervalId) => {
+      window.clearInterval(intervalId);
     });
-    this.wsConnections.clear();
-    this.reconnectAttempts.clear();
+    this.pollingIntervals.clear();
   }
 }
 

--- a/frontend/src/services/api/dto.ts
+++ b/frontend/src/services/api/dto.ts
@@ -169,9 +169,8 @@ export interface Tag {
 // ============================================================================
 
 export interface AnalyticsParams {
-  startDate?: string;
-  endDate?: string;
-  granularity?: 'hour' | 'day' | 'week' | 'month';
+  limit?: number;
+  offset?: number;
 }
 
 export interface DashboardAnalyticsParams {


### PR DESCRIPTION
### Motivation
- Backend analytics endpoint expects `linkId`, `limit`, and `offset` and exposes link analytics at `/analytics/link/:linkId/stats`, so the frontend needs to match that contract.
- The backend does not provide a WebSocket realtime endpoint, so the frontend realtime subscription logic must be replaced with a supported transport (polling) to receive updates reliably.

### Description
- Updated DTO `AnalyticsParams` to use `limit` and `offset` in `frontend/src/services/api/dto.ts`.
- Changed `getURLAnalytics` to accept `linkId`, append `linkId`, `limit`, and `offset` as query parameters, and call `/analytics/link/:linkId/stats` in `frontend/src/services/analytics.service.ts`.
- Made `getRealTimeAnalytics` accept an optional `linkId` and include it in requests to `/analytics/real-time` when provided in `frontend/src/services/analytics.service.ts`.
- Replaced WebSocket-based `subscribeToRealTime` with a polling implementation that fetches snapshots on an interval, added polling management and cleanup, and adjusted `subscribeToDashboardRealTime` accordingly in `frontend/src/services/analytics.service.ts`.
- Updated `useRealTimeAnalytics` hook to consume polling snapshots, wire up subscribe/unsubscribe behavior, and update types to `RealTimeAnalytics` in `frontend/src/hooks/useRealTimeAnalytics.tsx`.
- Adjusted the notifications wrapper (`useRealTimeAnalyticsWithNotifications`) to derive deltas from polling snapshots and deduplicate clicks before generating milestone/spike notifications in `frontend/src/hooks/useRealTimeAnalytics.tsx`.
- Removed unused `RealTimeUpdate` import and related event-based handling from the frontend service and hooks.

### Testing
- No automated tests were run as part of this change (no CI/test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974845a51a08327a04b88cb05892dfc)