### PR TITLE
Update frontend API base URL references to /api/v1

### DIFF
--- a/frontend/src/services/api/README.md
+++ b/frontend/src/services/api/README.md
@@ -49,7 +49,7 @@ const response = await apiClient.get('/health');
 Add to your `.env` file:
 
 ```env
-VITE_NESTJS_API_URL="http://localhost:3000/api"
+VITE_NESTJS_API_URL="http://localhost:3000/api/v1"
 ```
 
 ### Authentication

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -5,7 +5,7 @@ Object.defineProperty(globalThis, 'import', {
   value: {
     meta: {
       env: {
-        VITE_NESTJS_API_URL: 'http://localhost:3000/api',
+        VITE_NESTJS_API_URL: 'http://localhost:3000/api/v1',
         DEV: true,
         PROD: false,
       },
@@ -16,14 +16,14 @@ Object.defineProperty(globalThis, 'import', {
 // Mock the config module to avoid import.meta.env issues
 jest.mock('./services/api/config', () => ({
   defaultAPIConfig: {
-    baseURL: 'http://localhost:3000/api',
+    baseURL: 'http://localhost:3000/api/v1',
     timeout: 30000,
     retryAttempts: 3,
     retryDelay: 1000,
   },
   validateAPIConfiguration: jest.fn(),
   getEnvironmentConfig: jest.fn(() => ({
-    apiBaseURL: 'http://localhost:3000/api',
+    apiBaseURL: 'http://localhost:3000/api/v1',
     isDevelopment: true,
     isProduction: false,
   })),

--- a/frontend/verify-auth.cjs
+++ b/frontend/verify-auth.cjs
@@ -71,6 +71,9 @@ try {
       const match = envContent.match(/VITE_NESTJS_API_URL\s*=\s*"([^"]+)"/);
       if (match) {
         console.log(`   URL: ${match[1]}`);
+        if (!match[1].includes('/api/v1')) {
+          console.log('⚠️  Expected VITE_NESTJS_API_URL to include /api/v1 for health checks.');
+        }
       }
     } else {
       console.log('❌ VITE_NESTJS_API_URL missing from .env');


### PR DESCRIPTION
### Motivation
- Align frontend configuration, tests, and local verification with the backend API prefix so health checks and example envs use the same `/api/v1` base path.

### Description
- Update the example environment variable in `frontend/src/services/api/README.md` to `VITE_NESTJS_API_URL="http://localhost:3000/api/v1"`.
- Update Jest/test mocks in `frontend/src/setupTests.ts` to use `http://localhost:3000/api/v1` for `VITE_NESTJS_API_URL`, `defaultAPIConfig.baseURL`, and `getEnvironmentConfig().apiBaseURL`.
- Add a warning in `frontend/verify-auth.cjs` to flag when the configured `VITE_NESTJS_API_URL` does not include `/api/v1` so local health checks are consistent.

### Testing
- No automated tests were run as part of this change; edits were validated by inspecting the updated files and committing the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69748454ded88327a3584253752d605e)