### PR TITLE
API client: send `refresh_token` and handle `{ access_token, expires_at }` refresh response

### DIFF
--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -78,15 +78,40 @@ export class APIClient {
     try {
       const response = await axios.post(
         `${this.config.baseURL}/auth/refresh`,
-        { refreshToken: this.authTokens.refreshToken }
+        { refresh_token: this.authTokens.refreshToken }
       );
 
-      if (response.data.success && response.data.data.tokens) {
-        this.setAuthTokens(response.data.data.tokens);
-        this.saveTokensToStorage(response.data.data.tokens);
-      } else {
+      const { access_token, expires_at } = response.data as {
+        access_token?: string;
+        expires_at?: string | number | Date;
+      };
+
+      if (!access_token) {
         throw new Error('Token refresh failed');
       }
+
+      let expiresAtMs: number | null = null;
+      if (expires_at instanceof Date) {
+        expiresAtMs = expires_at.getTime();
+      } else if (typeof expires_at === 'string') {
+        const parsed = Date.parse(expires_at);
+        expiresAtMs = Number.isNaN(parsed) ? null : parsed;
+      } else if (typeof expires_at === 'number') {
+        expiresAtMs = expires_at > 1e12 ? expires_at : expires_at * 1000;
+      }
+
+      const expiresIn = expiresAtMs
+        ? Math.max(0, Math.floor((expiresAtMs - Date.now()) / 1000))
+        : this.authTokens.expiresIn;
+
+      const updatedTokens: AuthTokens = {
+        accessToken: access_token,
+        refreshToken: this.authTokens.refreshToken,
+        expiresIn,
+      };
+
+      this.setAuthTokens(updatedTokens);
+      this.saveTokensToStorage(updatedTokens);
     } catch (error) {
       this.clearAuthTokens();
       throw error;


### PR DESCRIPTION
### Motivation
- The backend `/auth/refresh` endpoint expects a `refresh_token` payload and returns a direct `{ access_token, expires_at }` shape instead of the previous `success` wrapper, so the client must adapt to update stored tokens and expiry correctly.

### Description
- Change `refreshAuthTokens()` to send `{ refresh_token: this.authTokens.refreshToken }` to the refresh endpoint.
- Remove checks for `response.data.success` and `response.data.data.tokens` and instead read `access_token` and `expires_at` directly from `response.data`.
- Derive `expiresIn` from `expires_at` (supports ISO strings, epoch seconds, or milliseconds), preserve the existing `refreshToken`, and update storage via `setAuthTokens` and `saveTokensToStorage`.
- Modified file: `frontend/src/services/api/client.ts`.

### Testing
- No automated tests were executed as part of this change.
- Existing test suites were not run; recommend running frontend auth tests and integration tests locally to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974845587b4832787e8b8521a7339bb)