### PR TITLE
Send `newPassword` in reset-password request

### DIFF
--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -328,7 +328,7 @@ class AuthServiceImpl implements AuthService {
     try {
       const response = await apiClient.post('/auth/reset-password', {
         token,
-        password: newPassword,
+        newPassword,
       });
 
       if (response.success) {


### PR DESCRIPTION
### Motivation
- The backend/reset DTO uses `newPassword` and the frontend DTO `ResetPasswordRequest` already defines `newPassword`, so the request payload must use that field to match the API contract.

### Description
- Updated `resetPassword` in `frontend/src/services/auth.service.ts` to send `{ token, newPassword }` to the `/auth/reset-password` endpoint and left `frontend/src/services/api/dto.ts` unchanged since it already declares `newPassword`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974845552508327a9bf8bf7939fc003)