### PR TITLE
Update URL list parsing for new backend response

### DIFF
--- a/frontend/src/services/__tests__/url.service.test.ts
+++ b/frontend/src/services/__tests__/url.service.test.ts
@@ -90,7 +90,7 @@ describe('URLService', () => {
   describe('getURLs', () => {
     it('should successfully fetch URLs with default parameters', async () => {
       const mockResponse = {
-        data: [
+        urls: [
           {
             id: '1',
             shortCode: 'abc123',
@@ -104,14 +104,7 @@ describe('URLService', () => {
             updatedAt: '2023-01-01T00:00:00Z'
           }
         ],
-        pagination: {
-          total: 1,
-          page: 1,
-          limit: 10,
-          pages: 1,
-          hasNext: false,
-          hasPrev: false
-        }
+        total: 1
       };
 
       mockApiClient.get.mockResolvedValue({
@@ -122,28 +115,36 @@ describe('URLService', () => {
       const result = await urlService.getURLs();
 
       expect(mockApiClient.get).toHaveBeenCalledWith('/urls');
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual({
+        data: mockResponse.urls,
+        pagination: {
+          total: 1,
+          page: 1,
+          limit: 10,
+          pages: 1,
+          hasNext: false,
+          hasPrev: false
+        }
+      });
     });
 
     it('should build query parameters correctly', async () => {
       const params: URLListParams = {
         page: 2,
         limit: 20,
-        search: 'test',
         isActive: true,
-        tags: ['tag1', 'tag2'],
-        tagOperator: 'AND'
+        category: 'marketing'
       };
 
       mockApiClient.get.mockResolvedValue({
         success: true,
-        data: { data: [], pagination: { total: 0, page: 1, limit: 10, pages: 0, hasNext: false, hasPrev: false } }
+        data: { urls: [], total: 0 }
       });
 
       await urlService.getURLs(params);
 
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        '/urls?page=2&limit=20&search=test&isActive=true&tags=tag1&tags=tag2&tagOperator=AND'
+        '/urls?page=2&limit=20&isActive=true&category=marketing'
       );
     });
   });

--- a/frontend/src/services/url.service.ts
+++ b/frontend/src/services/url.service.ts
@@ -57,27 +57,37 @@ export class URLService {
       // Add pagination parameters
       if (params.page) queryParams.append('page', params.page.toString());
       if (params.limit) queryParams.append('limit', params.limit.toString());
-      if (params.sortBy) queryParams.append('sortBy', params.sortBy);
-      if (params.order) queryParams.append('order', params.order);
       
       // Add filtering parameters
-      if (params.search) queryParams.append('search', params.search);
       if (params.isActive !== undefined) queryParams.append('isActive', params.isActive.toString());
       if (params.category) queryParams.append('category', params.category);
-      
-      // Add tag filtering
-      if (params.tags && params.tags.length > 0) {
-        params.tags.forEach(tag => queryParams.append('tags', tag));
-      }
-      if (params.tagOperator) queryParams.append('tagOperator', params.tagOperator);
 
       const queryString = queryParams.toString();
       const endpoint = queryString ? `${this.baseEndpoint}?${queryString}` : this.baseEndpoint;
       
-      const response = await apiClient.get<PaginatedResponse<URL>>(endpoint);
+      const response = await apiClient.get<{ urls: URL[]; total: number } | PaginatedResponse<URL>>(endpoint);
       
       if (response.success && response.data) {
-        return response.data;
+        if ('data' in response.data && 'pagination' in response.data) {
+          return response.data;
+        }
+
+        const page = params.page ?? 1;
+        const limit = params.limit ?? 10;
+        const total = response.data.total ?? 0;
+        const pages = limit > 0 ? Math.ceil(total / limit) : 0;
+
+        return {
+          data: response.data.urls,
+          pagination: {
+            total,
+            page,
+            limit,
+            pages,
+            hasNext: page < pages,
+            hasPrev: page > 1,
+          },
+        };
       } else {
         console.error('Failed to fetch URLs:', response.error);
         return null;


### PR DESCRIPTION
### Motivation
- Backend now returns URL lists as `{ urls, total }` (instead of the older paginated shape), and the frontend must remain compatible without requiring backend changes. 
- Remove unsupported/unstable query parameters from requests (sorting/search/tags) until backend adds support.

### Description
- Adapted `frontend/src/services/url.service.ts` to accept either the existing `PaginatedResponse<T>` or the new `{ urls, total }` shape and map the latter into the `PaginatedResponse` consumers expect, computing `pages`, `hasNext`, and `hasPrev` and defaulting `limit` to `10` when not provided. 
- Removed construction of unsupported query parameters: `sortBy`, `order`, `search`, `tags`, and `tagOperator` from the outbound query string; retained `page`, `limit`, `isActive`, and `category`. 
- Updated tests in `frontend/src/services/__tests__/url.service.test.ts` to reflect the new backend response format and to assert the adjusted query string expectations.

### Testing
- Updated unit tests in `frontend/src/services/__tests__/url.service.test.ts` to validate the new response shape and query string behavior. 
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69748456bb688327a807bbf01026382f)