### PR TITLE
feat(urls): add QR code generation endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -94,6 +94,7 @@
     "passport-local": "^1.0.0",
     "pg": "^8.11.3",
     "prom-client": "^15.1.3",
+    "qrcode": "^1.5.3",
     "redis": "^4.6.10",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.17",

--- a/backend/src/modules/urls/dto/qr-code-options.dto.ts
+++ b/backend/src/modules/urls/dto/qr-code-options.dto.ts
@@ -1,0 +1,55 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+class QRCodeColorDto {
+  @ApiPropertyOptional({ example: '#000000' })
+  @IsOptional()
+  @IsString()
+  dark?: string;
+
+  @ApiPropertyOptional({ example: '#FFFFFF' })
+  @IsOptional()
+  @IsString()
+  light?: string;
+}
+
+export class QRCodeOptionsDto {
+  @ApiPropertyOptional({ example: 256, description: 'Pixel size of the QR code' })
+  @IsOptional()
+  @IsInt()
+  @Min(64)
+  @Max(1024)
+  size?: number;
+
+  @ApiPropertyOptional({ example: 'png', enum: ['png', 'svg'] })
+  @IsOptional()
+  @IsIn(['png', 'svg'])
+  format?: 'png' | 'svg';
+
+  @ApiPropertyOptional({ example: 'M', enum: ['L', 'M', 'Q', 'H'] })
+  @IsOptional()
+  @IsIn(['L', 'M', 'Q', 'H'])
+  errorCorrectionLevel?: 'L' | 'M' | 'Q' | 'H';
+
+  @ApiPropertyOptional({ example: 2, description: 'Margin around the QR code' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(10)
+  margin?: number;
+
+  @ApiPropertyOptional({ type: QRCodeColorDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => QRCodeColorDto)
+  color?: QRCodeColorDto;
+}

--- a/backend/src/modules/urls/urls.controller.ts
+++ b/backend/src/modules/urls/urls.controller.ts
@@ -20,6 +20,7 @@ import { Public } from '../../common/decorators/public.decorator';
 import { UrlsService } from './urls.service';
 import { CreateUrlDto } from './dto/create-url.dto';
 import { UpdateUrlDto } from './dto/update-url.dto';
+import { QRCodeOptionsDto } from './dto/qr-code-options.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('urls')
@@ -190,6 +191,20 @@ export class UrlsController {
   async getPopular(@Request() req, @Query('limit') limit = 10) {
     return this.urlsService.getPopularUrls(req.user.id, +limit);
   }
+
+  @Post(':id/qr-code')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Generate a QR code for a URL' })
+  @ApiResponse({ status: 200, description: 'QR code generated successfully' })
+  @ApiResponse({ status: 404, description: 'URL not found' })
+  async generateQrCode(
+    @Param('id') id: string,
+    @Body() options: QRCodeOptionsDto,
+    @Request() req,
+  ) {
+    return this.urlsService.generateQrCode(id, req.user.id, options);
+  }
 }
 
 // Separate controller for public URL redirection
@@ -264,4 +279,3 @@ export class RedirectController {
     return { valid: isValid };
   }
 }
-

--- a/backend/src/modules/urls/urls.service.ts
+++ b/backend/src/modules/urls/urls.service.ts
@@ -1,15 +1,18 @@
 import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { nanoid } from 'nanoid';
 import * as crypto from 'crypto';
 import * as bcrypt from 'bcrypt';
+import * as QRCode from 'qrcode';
 
 import { Url, UrlDocument } from './schemas/url.schema';
 import { ClickAnalytics, ClickAnalyticsDocument } from './schemas/click-analytics.schema';
 import { UrlStats, UrlStatsDocument } from './schemas/url-stats.schema';
 import { CreateUrlDto } from './dto/create-url.dto';
 import { UpdateUrlDto } from './dto/update-url.dto';
+import { QRCodeOptionsDto } from './dto/qr-code-options.dto';
 import { CacheService } from '../../common/services/cache.service';
 import { AuditLogService } from '../users/services/audit-log.service';
 
@@ -23,6 +26,7 @@ export class UrlsService {
     @InjectModel(UrlStats.name) private urlStatsModel: Model<UrlStatsDocument>,
     private cacheService: CacheService,
     private auditLogService: AuditLogService,
+    private configService: ConfigService,
   ) {}
 
   async create(createUrlDto: CreateUrlDto, userId: string): Promise<UrlDocument> {
@@ -313,6 +317,41 @@ export class UrlsService {
         geoDistribution: geoAnalytics,
         deviceDistribution: deviceAnalytics,
       },
+    };
+  }
+
+  async generateQrCode(
+    id: string,
+    userId: string,
+    options: QRCodeOptionsDto = {},
+  ): Promise<{ qrCodeUrl: string; format: string; size: number }> {
+    const url = await this.findOne(id, userId);
+    const baseUrl = this.configService.get<string>('baseUrl', 'http://localhost:3000');
+    const shortUrl = new URL(`/r/${url.shortCode}`, baseUrl).toString();
+    const format = options.format ?? 'png';
+    const size = options.size ?? 256;
+
+    const qrOptions: QRCode.QRCodeToDataURLOptions & QRCode.QRCodeToStringOptions = {
+      errorCorrectionLevel: options.errorCorrectionLevel ?? 'M',
+      margin: options.margin ?? 2,
+      color: options.color,
+      width: size,
+    };
+
+    let qrCodeUrl: string;
+
+    if (format === 'svg') {
+      const svg = await QRCode.toString(shortUrl, { ...qrOptions, type: 'svg' });
+      const encodedSvg = Buffer.from(svg).toString('base64');
+      qrCodeUrl = `data:image/svg+xml;base64,${encodedSvg}`;
+    } else {
+      qrCodeUrl = await QRCode.toDataURL(shortUrl, qrOptions);
+    }
+
+    return {
+      qrCodeUrl,
+      format,
+      size,
     };
   }
 


### PR DESCRIPTION
### Motivation
- Provide built-in QR code support so the frontend can request generated QR images for short links using a validated options payload.

### Description
- Add a new `QRCodeOptionsDto` at `backend/src/modules/urls/dto/qr-code-options.dto.ts` to validate QR options (size, format, error correction, margin, color).
- Expose `POST /urls/:id/qr-code` in `UrlsController` which accepts `QRCodeOptionsDto` and is protected by `JwtAuthGuard` and returns generated QR payload.
- Implement `generateQrCode` in `UrlsService` which builds the public short URL using the configured base URL and returns `{ qrCodeUrl, format, size }` (data URL for PNG or base64-encoded SVG) compatible with the frontend `QRCodeResponse` shape.
- Add the `qrcode` dependency to `backend/package.json` and wire `ConfigService` into the service to resolve the configured base URL.

### Testing
- Automated tests: none were executed as part of this change (no test commands were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69748459c9a88327b704886cf65b0dee)