### PR TITLE
ci: verify pull requests with type-check, build and the full test suite

### DIFF
--- a/.github/workflows/autoFormatCode.yml
+++ b/.github/workflows/autoFormatCode.yml
@@ -1,5 +1,9 @@
 name: Auto Format Code with Prettier
-# This action automatically formats code with Prettier when a push is made to the main branch.
+# Formats the v1 backend/ and frontend/ directories when a push is made to main.
+#
+# Scope note: this does NOT cover web/, apps/ or packages/ — v2 has no Prettier
+# configuration yet, and adding one would produce a diff touching every file.
+# Tracked separately. Pull requests are verified by verify.yml.
 
 on:
   push:
@@ -16,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "22.x"
 
       - name: Install dependencies
         run: npm install --prefix backend && npm install --prefix frontend

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,137 @@
+name: Verify
+
+# Runs on every pull request, and on main so the default branch always has a
+# known-good signal. Nothing here writes to the repository.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A new push to the same branch makes the previous run irrelevant.
+concurrency:
+  group: verify-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Type-check, build, test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        # Must match docker-compose.yml — the schema uses uuidv7(), which is
+        # native in Postgres 18 and does not exist in 17.
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: snapurl
+          POSTGRES_PASSWORD: snapurl
+          POSTGRES_DB: snapurl
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U snapurl -d snapurl"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      DATABASE_URL: postgres://snapurl:snapurl@localhost:5433/snapurl
+      DATABASE_SSL: "false"
+      NODE_ENV: test
+      # Throwaway values. Real deployments read these from SSM Parameter Store;
+      # these exist only so the apps will boot in CI.
+      JWT_ACCESS_SECRET: ci-access-secret-not-used-anywhere-real-0000
+      JWT_REFRESH_SECRET: ci-refresh-secret-not-used-anywhere-real-000
+      WEB_ORIGIN: http://localhost:3000
+      DEFAULT_DOMAIN: localhost:3002
+      REDIRECT_ORIGIN: http://localhost:3002
+      MAIL_TRANSPORT: outbox
+      # The smoke suites make several hundred requests in a couple of minutes.
+      # The production default of 120/min would throttle them and fail the run
+      # for a reason that has nothing to do with the change under test.
+      THROTTLE_LIMIT: "100000"
+      LOG_LEVEL: warn
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # --frozen-lockfile fails if pnpm-lock.yaml disagrees with any
+      # package.json, which catches a dependency added without committing the
+      # lockfile.
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm type-check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Unit tests
+        run: pnpm test
+
+      # Proves the migrations apply to an empty database, not just to whatever
+      # state a developer's machine happens to be in.
+      - name: Migrate
+        run: pnpm db:migrate
+
+      - name: Start the API and redirect service
+        run: |
+          # PORT is set per-process, not on the step: a step-level PORT would
+          # apply to both and the second service would fail to bind.
+          PORT=3001 node apps/api/dist/main.js > /tmp/api.log 2>&1 &
+          echo "API_PID=$!" >> "$GITHUB_ENV"
+          PORT=3002 node apps/redirect/dist/main.js > /tmp/redirect.log 2>&1 &
+          echo "REDIRECT_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for both to be healthy
+        run: |
+          # Poll rather than sleep: a fixed delay is either too short on a slow
+          # runner or wasted time on a fast one.
+          for name in "api:3001/api/v1/health" "redirect:3002/health"; do
+            label="${name%%:*}"; url="http://localhost:${name#*:}"
+            for i in $(seq 1 40); do
+              if curl -fsS "$url" >/dev/null 2>&1; then
+                echo "$label is up"; break
+              fi
+              if [ "$i" = "40" ]; then
+                echo "::error::$label did not become healthy within 40s"
+                echo "--- api.log ---";      tail -50 /tmp/api.log      || true
+                echo "--- redirect.log ---"; tail -50 /tmp/redirect.log || true
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
+      - name: Smoke — dashboard API
+        run: bash scripts/smoke.sh
+
+      - name: Smoke — redirect path
+        run: bash scripts/smoke-redirect.sh
+
+      # Without this a failed smoke run shows only which assertion failed, not
+      # the server-side reason for it.
+      - name: Service logs
+        if: failure()
+        run: |
+          echo "--- api ---";      tail -200 /tmp/api.log      || true
+          echo "--- redirect ---"; tail -200 /tmp/redirect.log || true
+
+      - name: Stop services
+        if: always()
+        run: kill "$API_PID" "$REDIRECT_PID" 2>/dev/null || true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,8 +6,8 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "nest build",
-    "dev": "node --env-file=.env --watch dist/main.js",
-    "start": "node --env-file=.env dist/main.js",
+    "dev": "node --env-file-if-exists=.env --watch dist/main.js",
+    "start": "node --env-file-if-exists=.env dist/main.js",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "dev:nest": "nest start --watch"

--- a/apps/redirect/package.json
+++ b/apps/redirect/package.json
@@ -2,12 +2,12 @@
   "name": "@snapurl/redirect",
   "version": "2.0.0",
   "private": true,
-  "description": "The redirect hot path. Deliberately not NestJS — it carries the least of any app here.",
+  "description": "The redirect hot path. Deliberately not NestJS \u2014 it carries the least of any app here.",
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "node --env-file=.env --watch dist/main.js",
-    "start": "node --env-file=.env dist/main.js",
+    "dev": "node --env-file-if-exists=.env --watch dist/main.js",
+    "start": "node --env-file-if-exists=.env dist/main.js",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,9 +6,9 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "dev": "node --env-file=.env --watch dist/main.js",
-    "start": "node --env-file=.env dist/main.js",
-    "once": "node --env-file=.env dist/main.js --once",
+    "dev": "node --env-file-if-exists=.env --watch dist/main.js",
+    "start": "node --env-file-if-exists=.env dist/main.js",
+    "once": "node --env-file-if-exists=.env dist/main.js --once",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },

--- a/package.json
+++ b/package.json
@@ -2,21 +2,22 @@
   "name": "snapurl",
   "version": "2.0.0",
   "private": true,
-  "description": "SnapURL — short links, dynamic QR codes and cookieless analytics.",
+  "description": "SnapURL \u2014 short links, dynamic QR codes and cookieless analytics.",
   "packageManager": "pnpm@11.24.0",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "pnpm --parallel --filter \"./apps/*\" dev",
     "dev:web": "pnpm --filter snapurl-web dev",
     "dev:api": "pnpm --filter @snapurl/api dev",
     "dev:redirect": "pnpm --filter @snapurl/redirect dev",
     "dev:worker": "pnpm --filter @snapurl/worker dev",
-
     "build": "pnpm -r build",
-    "type-check": "pnpm -r type-check",
-    "test": "pnpm -r test",
+    "build:packages": "pnpm --filter \"./packages/*\" build",
+    "type-check": "pnpm build:packages && pnpm -r type-check",
+    "test": "pnpm build:packages && pnpm -r test",
     "lint": "pnpm -r lint",
-
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "db:generate": "pnpm --filter @snapurl/database generate",
@@ -24,7 +25,6 @@
     "db:seed": "pnpm --filter @snapurl/database seed",
     "db:studio": "pnpm --filter @snapurl/database studio",
     "db:reset": "docker compose down -v && docker compose up -d postgres && pnpm db:migrate && pnpm db:seed",
-
     "v1:backend": "cd backend && npm start",
     "v1:frontend": "cd frontend && npm start"
   },

--- a/scripts/smoke-redirect.sh
+++ b/scripts/smoke-redirect.sh
@@ -13,6 +13,16 @@ PASSES=0; FAILS=0
 ok()  { PASSES=$((PASSES+1)); echo "  PASS  $1"; }
 bad() { FAILS=$((FAILS+1));  echo "  FAIL  $1"; echo "        $2"; }
 
+# Reach the database whichever way this environment allows: psql directly when
+# the client is installed (CI, where Postgres is a service container), or
+# through the Compose container (local development).
+DB_URL="${DATABASE_URL:-postgres://snapurl:snapurl@localhost:5433/snapurl}"
+if command -v psql >/dev/null 2>&1; then
+  dbq() { psql "$DB_URL" -tAc "$1" 2>/dev/null; }
+else
+  dbq() { docker exec snapurl-postgres psql -U snapurl -d snapurl -tAc "$1" 2>/dev/null; }
+fi
+
 # loc <path> [extra curl args...] -> prints "STATUS|LOCATION"
 loc() {
   local path="$1"; shift
@@ -85,11 +95,10 @@ contains "trailing + goes to the trust page" "/p/$RUN-plain" "$(loc "$RUN-plain%
 
 echo
 echo "== privacy =="
-if docker exec snapurl-postgres psql -U snapurl -d snapurl -tAc "\d click_events" 2>/dev/null | grep -qi '^ip\b'; then
+if dbq "select column_name from information_schema.columns where table_name='click_events' and column_name='ip'" | grep -q .; then
   bad "click_events stores no IP" "an ip column exists"
 else ok "click_events has no ip column"; fi
-HASHES=$(docker exec snapurl-postgres psql -U snapurl -d snapurl -tAc \
-  "select count(distinct visitor_hash) from click_events where link_id in (select id from links where slug like '$RUN%')" 2>/dev/null | tr -d '[:space:]')
+HASHES=$(dbq "select count(distinct visitor_hash) from click_events where link_id in (select id from links where slug like '$RUN%')" | tr -d '[:space:]')
 [ -n "$HASHES" ] && ok "clicks recorded with visitor hashes ($HASHES distinct)" || bad "click recording" "no rows"
 
 echo


### PR DESCRIPTION
## What does this PR do?

Adds a `Verify` workflow that runs on every pull request, so the tests merged in #205 actually run somewhere.

Fixes #206

Before this, the only workflow was `autoFormatCode.yml` — Prettier on the v1 directories, on push to `main`, on Node 14. No pull request was checked at all. A change that broke `tsc` or a test merged green.

### What runs

| Step | Catches |
| --- | --- |
| `pnpm install --frozen-lockfile` | A lockfile that drifted from `package.json` |
| `pnpm type-check` | Type errors across all 7 packages |
| `pnpm build` | Something that type-checks but doesn't compile |
| `pnpm test` | The 83 unit tests |
| `pnpm db:migrate` | A migration that doesn't apply to an empty database |
| `scripts/smoke.sh` | 47 assertions against a real running API |
| `scripts/smoke-redirect.sh` | 21 assertions against the API + redirect service |

Postgres 18 runs as a service container — 18 specifically, because the schema uses `uuidv7()`, which doesn't exist in 17. Same pin as `docker-compose.yml`.

Because it starts from a clean checkout, the run also proves a fresh clone works end to end: install, migrate, boot, serve. That has only ever been verified on one machine until now.

### Supporting changes

- **The smoke suite reached the database with `docker exec snapurl-postgres`** — correct locally, wrong in CI where Postgres is a service container. It now uses `psql` when the client is present and falls back to the Compose container otherwise, so nothing changes for local development.
- **App start scripts use `--env-file-if-exists`**, so CI supplies configuration as environment variables rather than fabricating `.env` files.
- **`autoFormatCode.yml` moves off Node 14**, which is years past end of life. Its scope is unchanged and now documented in the file.

## Type of change

- [x] Chore (refactoring code, workflow improvements)

## How should this be tested?

**This PR tests itself** — the `Verify` check on this pull request is the feature. If it's green, the workflow works.

Beyond that:

```bash
pnpm db:up && pnpm db:migrate
pnpm build
pnpm dev:api & pnpm dev:redirect &
bash scripts/smoke.sh           # 47 assertions, should be unchanged
bash scripts/smoke-redirect.sh  # 21 assertions, should be unchanged
```

The point of the smoke-script change is that local behaviour is identical. Verified locally: 21/21 still passing through the Docker fallback path, and `pnpm type-check` (7 packages) and `pnpm test` (83 tests) both green.

## Notes for review

**The throttle limit is raised in CI deliberately.** The smoke suites make several hundred requests in a couple of minutes and the production default of 120/min would fail the run for a reason unrelated to the change under test. It's set on the job, not in any committed `.env`.

**The JWT secrets in the workflow are throwaway CI values**, not secrets. They exist only so the apps will boot. Real deployments read these from SSM Parameter Store.

**`permissions: contents: read`** — this workflow only reads. Unlike `autoFormatCode.yml`, it never commits.

## Follow-ups this deliberately doesn't do

- **Prettier/ESLint across v2.** Adding config now would produce a diff touching every file and bury the CI change. Worth its own issue.
- **Reworking `autoFormatCode.yml`.** It commits to `main` as a bot, which is worth revisiting, but not here.
- **Branch protection.** Once this is green on `main`, requiring the `Verify` check before merge is a repository setting, not a code change — worth turning on.
