### PR TITLE
fix(security): revoke the refresh token on sign-out, and gate the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/
 dist/
 logs/
 *.tsbuildinfo
+
+# Background-agent worktrees are local scratch, never part of the repo.
+.claude/worktrees/

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -1,11 +1,48 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Sidebar, Topbar } from "@/components/app-shell";
 import { CreateLinkDrawer } from "@/components/links/create-link-drawer";
-import { useBioPages, useDomains, useLinks, useMembers } from "@/lib/api/hooks";
+import { useBioPages, useDomains, useLinks, useMe, useMembers } from "@/lib/api/hooks";
 
+/**
+ * The gate for every authenticated route.
+ *
+ * Without this, an unauthenticated visit to /links mounted the whole shell and
+ * fired five parallel requests that all 401'd, leaving the visitor looking at a
+ * half-rendered dashboard full of errors instead of a sign-in page.
+ *
+ * The workspace queries live in AuthedShell rather than here on purpose: hooks
+ * cannot be called conditionally, so the only way to stop them firing before we
+ * know who the visitor is, is to not mount the component that owns them.
+ */
 export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const { data: me, isPending, isError } = useMe();
+
+  useEffect(() => {
+    // `replace`, not `push` — a signed-out visitor should not be able to press
+    // Back into a dashboard that cannot load.
+    if (isError) router.replace("/login");
+  }, [isError, router]);
+
+  if (isPending) return <Booting />;
+  if (isError || !me) return null; // redirecting
+
+  return <AuthedShell>{children}</AuthedShell>;
+}
+
+/** Shown only while the session check is in flight, so it should not flash. */
+function Booting() {
+  return (
+    <div className="min-h-screen grid place-items-center" role="status" aria-live="polite">
+      <span className="font-mono text-[12px] text-ink-3">Checking your session…</span>
+    </div>
+  );
+}
+
+function AuthedShell({ children }: { children: React.ReactNode }) {
   const [creating, setCreating] = useState(false);
   const { data: links } = useLinks();
   const { data: bio } = useBioPages();

--- a/web/src/app/(auth)/register/page.tsx
+++ b/web/src/app/(auth)/register/page.tsx
@@ -12,7 +12,11 @@ import { useRegister } from "@/lib/api/hooks";
 const Schema = z.object({
   name: z.string().min(2, "What should we call you?"),
   email: z.string().min(1, "Enter your email address").email("That doesn't look like an email address"),
-  password: z.string().min(8, "Use at least 8 characters"),
+  // Must match RegisterInput in @snapurl/contract. When this said 8, an
+  // 8-character password passed client validation and then failed with a 400
+  // from the API — the user saw a server error for something the form had
+  // already told them was fine.
+  password: z.string().min(12, "Use at least 12 characters — length beats complexity"),
 });
 type Values = z.infer<typeof Schema>;
 
@@ -39,7 +43,7 @@ export default function RegisterPage() {
         <Field label="Email" error={formState.errors.email?.message}>
           <Input {...register("email")} type="email" autoComplete="email" placeholder="you@company.com" />
         </Field>
-        <Field label="Password" help="At least 8 characters." error={formState.errors.password?.message}>
+        <Field label="Password" help="At least 12 characters." error={formState.errors.password?.message}>
           <Input {...register("password")} type="password" autoComplete="new-password" placeholder="••••••••" />
         </Field>
         {signup.isError ? <p className="text-[12.5px] text-bad m-0">{(signup.error as Error).message}</p> : null}

--- a/web/src/components/app-shell/index.tsx
+++ b/web/src/components/app-shell/index.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import * as React from "react";
 import { Button } from "@/components/ui";
-import { useWorkspace } from "@/lib/api/hooks";
+import { useLogout, useMe, useWorkspace } from "@/lib/api/hooks";
 import { cn, compact } from "@/lib/utils";
 
 const NAV: { group: string; items: { href: string; label: string; icon: string; count?: keyof Counts }[] }[] = [
@@ -108,7 +108,6 @@ export function Sidebar({ counts, onCreate }: { counts: Counts; onCreate: () => 
 }
 
 export function Topbar({ onCreate }: { onCreate: () => void }) {
-  const { data: ws } = useWorkspace();
   return (
     <div className="flex items-center gap-3 px-[22px] h-14 border-b border-line bg-surface sticky top-0 z-20">
       <button
@@ -129,10 +128,95 @@ export function Topbar({ onCreate }: { onCreate: () => void }) {
         <Button size="sm" variant="ghost" className="hidden sm:inline-flex">
           Import from Bitly
         </Button>
-        <span className="w-[29px] h-[29px] rounded-full bg-teal text-white grid place-items-center text-[11.5px] font-bold shrink-0">
-          {ws?.initials ? "DT" : "··"}
-        </span>
+        <AccountMenu />
       </div>
+    </div>
+  );
+}
+
+/**
+ * The avatar, and the only way to sign out of the app.
+ *
+ * Until now there was no sign-out control anywhere in the product — the hook
+ * existed with zero call sites, so a signed-in user had no way to leave except
+ * clearing site data.
+ */
+function AccountMenu() {
+  const { data: me } = useMe();
+  const { data: ws } = useWorkspace();
+  const logout = useLogout();
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const wrapRef = React.useRef<HTMLDivElement>(null);
+
+  // Close on outside click and on Escape. Both listeners are only attached
+  // while the menu is open, so a closed menu costs nothing.
+  React.useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const signOut = () => {
+    setOpen(false);
+    logout();
+    router.replace("/login");
+  };
+
+  const initials = me?.initials ?? ws?.initials ?? "··";
+
+  return (
+    <div className="relative" ref={wrapRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={me ? `Account menu for ${me.name}` : "Account menu"}
+        className="w-[29px] h-[29px] rounded-full bg-teal text-white grid place-items-center text-[11.5px] font-bold shrink-0 hover:opacity-90 transition-opacity"
+      >
+        {initials}
+      </button>
+
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-[calc(100%+7px)] min-w-[196px] bg-surface border border-line rounded-[var(--radius-sm)] shadow-lg py-[5px] z-30"
+        >
+          {me ? (
+            <div className="px-[11px] py-[7px] border-b border-line mb-[4px]">
+              <div className="text-[12.5px] font-semibold truncate">{me.name}</div>
+              <div className="text-[11.5px] text-ink-3 truncate">{me.email}</div>
+            </div>
+          ) : null}
+          <Link
+            href="/settings"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="block px-[11px] py-[6px] text-[13px] text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors"
+          >
+            Settings
+          </Link>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={signOut}
+            className="w-full text-left px-[11px] py-[6px] text-[13px] text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -84,6 +84,15 @@ type RequestOptions = {
   signal?: AbortSignal;
   /** Skip the Authorization header (login, register, public preview). */
   anonymous?: boolean;
+  /**
+   * Let the request outlive the page that started it.
+   *
+   * Sign-out fires `POST /auth/logout` and immediately navigates to /login.
+   * Without this the browser is free to cancel the in-flight request, and the
+   * refresh token silently stays valid — the exact bug the logout call exists
+   * to fix, reintroduced by a race. `keepalive` tells the browser to finish it.
+   */
+  keepalive?: boolean;
 };
 
 let refreshInFlight: Promise<boolean> | null = null;
@@ -121,6 +130,7 @@ async function rawRequest<T>(path: string, schema: z.ZodType<T>, opts: RequestOp
     headers,
     body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
     signal: opts.signal,
+    keepalive: opts.keepalive,
   });
 
   // One transparent refresh-and-retry on expiry.

--- a/web/src/lib/api/hooks.ts
+++ b/web/src/lib/api/hooks.ts
@@ -139,9 +139,34 @@ export function useRegister() {
   });
 }
 
+/**
+ * Sign out, on the server as well as in this tab.
+ *
+ * Clearing localStorage alone left the refresh token valid for its full
+ * 30-day life, so anyone who had captured it kept access after the user
+ * believed they had signed out. `POST /auth/logout` revokes the whole token
+ * family server-side.
+ *
+ * The request is deliberately not awaited: a network failure must not trap
+ * someone in a session they asked to leave. Local state is cleared either way,
+ * and an unrevoked token expires on its own — the failure mode is the old
+ * behaviour, not something worse.
+ */
 export function useLogout() {
   const qc = useQueryClient();
-  return () => {
+  return (allDevices = false) => {
+    const refreshToken = tokens.refresh;
+    if (refreshToken) {
+      void request("/auth/logout", z.undefined(), {
+        method: "POST",
+        body: { refreshToken, allDevices },
+        // The access token may already have expired by the time someone clicks
+        // sign out; the refresh token in the body is the credential here.
+        anonymous: true,
+      }).catch(() => {
+        /* Already leaving. Nothing useful to show the user. */
+      });
+    }
     tokens.clear();
     qc.clear();
   };

--- a/web/src/lib/api/hooks.ts
+++ b/web/src/lib/api/hooks.ts
@@ -163,6 +163,10 @@ export function useLogout() {
         // The access token may already have expired by the time someone clicks
         // sign out; the refresh token in the body is the credential here.
         anonymous: true,
+        // We navigate to /login immediately after this call. Without keepalive
+        // the browser may cancel it mid-flight and the token stays valid —
+        // reintroducing the exact bug this call exists to fix.
+        keepalive: true,
       }).catch(() => {
         /* Already leaving. Nothing useful to show the user. */
       });


### PR DESCRIPTION
Fixes #211

## What this fixes

**The vulnerability.** `useLogout` cleared `localStorage` and nothing else, so the refresh token stayed valid for its full 30 days after the user believed they had signed out. It now calls `POST /auth/logout`, which revokes the whole token family server-side.

**There was no sign-out control at all.** `useLogout` had zero call sites anywhere in the app — a signed-in user's only way out was clearing site data. The avatar is now an account menu showing the signed-in identity, with Settings and Sign out.

**No session gate.** `(app)/layout.tsx` had no auth check, so visiting `/links` signed-out mounted the entire shell and fired five parallel requests that all 401'd. The visitor saw a broken dashboard instead of a sign-in page.

Plus two smaller ones in the same surface: the topbar rendered a hardcoded `"DT"` instead of real initials (the ternary tested `ws?.initials` then discarded it), and the register form required 8 characters where the API requires 12 — so an 8-character password passed client validation and came back as a 400.

## Decisions worth reviewing

**The logout request is not awaited.** A network failure must not trap someone in a session they asked to leave. Local state clears either way, and an unrevoked token still expires on its own — so the failure mode is the old behaviour, not something worse.

**Workspace queries moved into an inner `AuthedShell`.** Hooks cannot be called conditionally, so the only way to stop `useLinks`/`useBioPages`/`useDomains`/`useMembers` firing before we know who the visitor is, is to not mount the component that owns them.

**`router.replace()`, not `push()`.** A signed-out visitor should not be able to press Back into a dashboard that cannot load.

## Testing

`pnpm type-check` (7 packages), `pnpm build`, `pnpm test` (83 tests) all pass locally. CI runs those plus 68 smoke assertions against a live API and a real Postgres.

Verified in the browser against the real API with `NEXT_PUBLIC_USE_FIXTURES=false` — results in a follow-up comment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)