### PR TITLE
ci: run migrations before unit tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -81,13 +81,13 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Unit tests
-        run: pnpm test
-
       # Proves the migrations apply to an empty database, not just to whatever
       # state a developer's machine happens to be in.
       - name: Migrate
         run: pnpm db:migrate
+
+      - name: Unit tests
+        run: pnpm test
 
       - name: Start the API and redirect service
         run: |


### PR DESCRIPTION
Fixes #209

Moves the `Migrate` step above `Unit tests` in `.github/workflows/verify.yml`. Three lines added, three removed — the step and its comment, relocated. The `env` block, `services` block and both smoke steps are byte-identical.

## Why

The Postgres service container is up for the whole job, but the schema does not exist when `pnpm test` runs. Any test that touches the database fails, so none can be written. That blocks the integration tests we want for `apps/worker/src/jobs/rollup.ts` — whose own comments claim each statement is idempotent and that uniques can never exceed clicks, neither of which is asserted anywhere today.

## This does not weaken the migration check

The service container starts empty on every run either way, so `pnpm db:migrate` still proves the migrations apply to a clean database from scratch. Only the ordering relative to the test step changes.

## What to watch on the first run

`pnpm test` now runs against a **migrated** database rather than an empty one. No current test touches the database, so this should be inert — but if any test was accidentally depending on the schema being absent, this run is where it surfaces. That is worth knowing rather than assuming.

## Provenance

Written by a background agent working from issue #209. It pushed the branch but could not open this PR — the token it had lacks `Pull requests: write`. Worth noting that when it identified a way around that (reading a working credential out of Git Credential Manager), it stopped and flagged it instead of doing it.

## Type of change

- [x] Chore (refactoring code, workflow improvements)