### PR TITLE
fix: emit audit entries and webhook events on the writes that matter

### DIFF
--- a/apps/api/src/common/activity.test.ts
+++ b/apps/api/src/common/activity.test.ts
@@ -1,0 +1,154 @@
+import { Logger } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import type { Executor } from "@snapurl/database";
+import { recordActivity, toActor } from "./activity.js";
+
+/* recordActivity runs after the change it describes has already committed, so
+   its failure modes matter more than its happy path: anything it throws turns
+   a successful write into a 500 for the caller. These pin that down without a
+   database — the SQL itself is exercised by scripts/smoke.sh. */
+
+function fakeDb() {
+  const audits: unknown[] = [];
+  const queued: Array<{ event: unknown }> = [];
+  const db = {
+    insert: () => ({
+      values: async (row: unknown) => {
+        audits.push(row);
+      },
+    }),
+    execute: async (query: unknown) => {
+      queued.push({ event: query });
+      return [{ n: 1 }];
+    },
+  } as unknown as Executor;
+  return { db, audits, queued };
+}
+
+/** A logger that stays quiet; the tests assert on it rather than the console. */
+function silentLogger() {
+  const logger = new Logger("test");
+  vi.spyOn(logger, "error").mockImplementation(() => undefined);
+  return logger;
+}
+
+const actor = { userId: "u1", label: "sam@example.com" };
+
+describe("toActor", () => {
+  it("keeps only who-did-it, discarding the rest of the request actor", () => {
+    expect(toActor({ userId: "u1", label: "sam@example.com", workspaceId: "w1", role: "owner" } as never)).toEqual({
+      userId: "u1",
+      label: "sam@example.com",
+    });
+  });
+
+  it("carries a null userId through, as an API-key caller has none", () => {
+    expect(toActor({ userId: null, label: "key: deploy-bot" })).toEqual({ userId: null, label: "key: deploy-bot" });
+  });
+});
+
+describe("recordActivity", () => {
+  it("writes an audit row and queues a webhook when both are asked for", async () => {
+    const { db, audits, queued } = fakeDb();
+    await recordActivity(db, silentLogger(), {
+      workspaceId: "w1",
+      actor,
+      auditAction: "link.created",
+      webhookEvent: "link.created",
+      targetType: "link",
+      targetId: "lnk1",
+      metadata: { slug: "spring-sale" },
+    });
+    expect(audits).toHaveLength(1);
+    expect(queued).toHaveLength(1);
+    expect(audits[0]).toMatchObject({
+      workspaceId: "w1",
+      actorId: "u1",
+      actorLabel: "sam@example.com",
+      action: "link.created",
+      targetId: "lnk1",
+    });
+  });
+
+  it("writes no audit row when only a webhook is asked for", async () => {
+    // Conversion ingest is machine traffic; it emits an event but must not
+    // bury the member and link entries the audit page exists to show.
+    const { db, audits, queued } = fakeDb();
+    await recordActivity(db, silentLogger(), {
+      workspaceId: "w1",
+      actor,
+      webhookEvent: "conversion.recorded",
+      targetId: "cnv1",
+    });
+    expect(audits).toHaveLength(0);
+    expect(queued).toHaveLength(1);
+  });
+
+  it("queues no webhook when only an audit entry is asked for", async () => {
+    const { db, audits, queued } = fakeDb();
+    await recordActivity(db, silentLogger(), { workspaceId: "w1", actor, auditAction: "member.invited" });
+    expect(audits).toHaveLength(1);
+    expect(queued).toHaveLength(0);
+  });
+
+  it("does not throw when the audit insert fails, and still queues the webhook", async () => {
+    // The link was already created. Surfacing this would make a successful
+    // write look like a 500, and the retry would hit a duplicate-slug error.
+    const failing = {
+      insert: () => ({
+        values: async () => {
+          throw new Error("audit_log is unreachable");
+        },
+      }),
+      execute: async () => [{ n: 1 }],
+    } as unknown as Executor;
+    const logger = silentLogger();
+
+    await expect(
+      recordActivity(failing, logger, {
+        workspaceId: "w1",
+        actor,
+        auditAction: "link.created",
+        webhookEvent: "link.created",
+      }),
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw when the webhook enqueue fails", async () => {
+    const failing = {
+      insert: () => ({ values: async () => undefined }),
+      execute: async () => {
+        throw new Error("webhook_deliveries is unreachable");
+      },
+    } as unknown as Executor;
+    const logger = silentLogger();
+
+    await expect(
+      recordActivity(failing, logger, { workspaceId: "w1", actor, webhookEvent: "link.deleted" }),
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledOnce();
+  });
+
+  it("logs both failures rather than stopping at the first", async () => {
+    const failing = {
+      insert: () => ({
+        values: async () => {
+          throw new Error("down");
+        },
+      }),
+      execute: async () => {
+        throw new Error("also down");
+      },
+    } as unknown as Executor;
+    const logger = silentLogger();
+
+    await recordActivity(failing, logger, {
+      workspaceId: "w1",
+      actor,
+      auditAction: "link.updated",
+      webhookEvent: "link.updated",
+    });
+    expect(logger.error).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/common/activity.ts
+++ b/apps/api/src/common/activity.ts
@@ -1,0 +1,84 @@
+import type { Logger } from "@nestjs/common";
+import {
+  enqueueWebhookEvent,
+  writeAuditEntry,
+  type Executor,
+  type WebhookEvent,
+} from "@snapurl/database";
+
+/* ============================================================
+   Recording that something happened.
+
+   Two subsystems were fully built and never invoked: the audit trail, which
+   the team page claims logs every action, and the webhook queue, which the
+   worker has been draining every thirty seconds against nothing. Both are fed
+   from the same handful of places, so they are fed by the same call.
+   ============================================================ */
+
+/** Who did it. Assembled from RequestActor at the controller boundary so the
+ *  services stay free of auth types. `userId` is null for an API-key caller. */
+export interface Actor {
+  userId: string | null;
+  label: string;
+}
+
+/** Narrow a RequestActor down to just who-did-it. Structural, so it takes any
+ *  RequestActor without common/ having to import from auth/. */
+export function toActor(actor: { userId: string | null; label: string }): Actor {
+  return { userId: actor.userId, label: actor.label };
+}
+
+export interface ActivityInput {
+  workspaceId: string;
+  actor: Actor;
+  /** Omit to emit a webhook without an audit row. */
+  auditAction?: string;
+  /** Omit to write an audit row without a webhook. */
+  webhookEvent?: WebhookEvent;
+  targetType?: string;
+  targetId?: string;
+  /** Goes to describe() for the audit sentence, and to the webhook body. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Write the audit entry and queue the webhooks for one change.
+ *
+ * **This never throws.** The change it describes has already been committed,
+ * so letting a failed audit insert or a failed enqueue bubble up would turn a
+ * link that was successfully created into a 500 — the user retries, gets a
+ * duplicate-slug conflict, and the operation looks broken when it worked. The
+ * failure is logged instead, at error level, because a silently empty audit
+ * trail is its own bug.
+ *
+ * Call it after the transaction commits, never inside it: a delivery queued in
+ * a transaction that later rolls back tells a receiver about a link that does
+ * not exist.
+ */
+export async function recordActivity(db: Executor, logger: Logger, input: ActivityInput): Promise<void> {
+  const { workspaceId, actor, auditAction, webhookEvent, targetType, targetId, metadata } = input;
+
+  if (auditAction) {
+    try {
+      await writeAuditEntry(db, {
+        workspaceId,
+        actorId: actor.userId,
+        actorLabel: actor.label,
+        action: auditAction,
+        targetType: targetType ?? null,
+        targetId: targetId ?? null,
+        metadata: metadata ?? null,
+      });
+    } catch (err) {
+      logger.error(`Failed to write audit entry "${auditAction}" for workspace ${workspaceId}`, err as Error);
+    }
+  }
+
+  if (webhookEvent) {
+    try {
+      await enqueueWebhookEvent(db, workspaceId, webhookEvent, { id: targetId, ...metadata });
+    } catch (err) {
+      logger.error(`Failed to queue webhook "${webhookEvent}" for workspace ${workspaceId}`, err as Error);
+    }
+  }
+}

--- a/apps/api/src/conversions/conversions.controller.ts
+++ b/apps/api/src/conversions/conversions.controller.ts
@@ -3,6 +3,7 @@ import { RecordConversionInput } from "@snapurl/contract";
 import { zodBody } from "../common/zod.pipe.js";
 import { Actor, Scope, type RequestActor } from "../auth/auth.guard.js";
 import { ConversionsService } from "./conversions.service.js";
+import { toActor } from "../common/activity.js";
 
 @Controller("conversions")
 export class ConversionsController {
@@ -20,6 +21,6 @@ export class ConversionsController {
   @Scope("conversions:write")
   @HttpCode(201)
   record(@Actor() actor: RequestActor, @Body(zodBody(RecordConversionInput)) input: RecordConversionInput) {
-    return this.conversions.record(actor.workspaceId, input);
+    return this.conversions.record(actor.workspaceId, toActor(actor), input);
   }
 }

--- a/apps/api/src/conversions/conversions.service.ts
+++ b/apps/api/src/conversions/conversions.service.ts
@@ -1,13 +1,16 @@
-import { BadRequestException, Inject, Injectable } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
 import { and, clickDaily, conversions, desc, eq, gte, links, lt, sql, workspaces, type Database } from "@snapurl/database";
 import type { ConversionsReport, RecordConversionInput } from "@snapurl/contract";
 import { DB } from "../database/database.module.js";
+import { recordActivity, type Actor } from "../common/activity.js";
 
 const RANGE_DAYS: Record<string, number> = { "24h": 1, "7d": 7, "30d": 30, "90d": 90, "12m": 365 };
 
 @Injectable()
 export class ConversionsService {
   constructor(@Inject(DB) private readonly db: Database) {}
+
+  private readonly logger = new Logger(ConversionsService.name);
 
   async report(workspaceId: string, range = "30d"): Promise<ConversionsReport> {
     const days = RANGE_DAYS[range] ?? 30;
@@ -91,7 +94,7 @@ export class ConversionsService {
     };
   }
 
-  async record(workspaceId: string, input: RecordConversionInput) {
+  async record(workspaceId: string, actor: Actor, input: RecordConversionInput) {
     let linkId = input.linkId ?? null;
     if (!linkId && input.slug) {
       const [link] = await this.db
@@ -126,6 +129,35 @@ export class ConversionsService {
       })
       .onConflictDoNothing()
       .returning();
+
+    /* Only on a real insert.
+
+       onConflictDoNothing is what makes the ingest idempotent, and a customer
+       retrying a timed-out delivery is the case it exists for. Emitting the
+       webhook regardless would undo that on the way out: the retry books no
+       second conversion but still tells every subscriber a second sale
+       happened.
+
+       No audit entry here, unlike the other four call sites. The audit log is
+       a human-readable list of administrative actions, and conversion ingest
+       is machine traffic that can run to thousands a day — writing it here
+       would bury the member and link entries the page exists to show. */
+    if (row) {
+      await recordActivity(this.db, this.logger, {
+        workspaceId,
+        actor,
+        webhookEvent: "conversion.recorded",
+        targetType: "conversion",
+        targetId: row.id,
+        metadata: {
+          kind: input.kind,
+          name: input.name,
+          linkId,
+          valueMinor: input.valueMinor,
+          currency: (input.currency ?? workspace?.currency ?? "INR").toUpperCase(),
+        },
+      });
+    }
 
     return { id: row?.id ?? null, recorded: Boolean(row) };
   }

--- a/apps/api/src/domains/domains.controller.ts
+++ b/apps/api/src/domains/domains.controller.ts
@@ -3,6 +3,7 @@ import { AddDomainInput } from "@snapurl/contract";
 import { zodBody } from "../common/zod.pipe.js";
 import { Actor, Roles, Scope, type RequestActor } from "../auth/auth.guard.js";
 import { DomainsService } from "./domains.service.js";
+import { toActor } from "../common/activity.js";
 
 @Controller("domains")
 export class DomainsController {
@@ -26,7 +27,7 @@ export class DomainsController {
   @Scope("domains:write")
   @HttpCode(200)
   verify(@Actor() actor: RequestActor, @Param("id") id: string) {
-    return this.domains.verify(actor.workspaceId, id);
+    return this.domains.verify(actor.workspaceId, id, toActor(actor));
   }
 
   @Delete(":id")

--- a/apps/api/src/domains/domains.service.ts
+++ b/apps/api/src/domains/domains.service.ts
@@ -1,13 +1,16 @@
-import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { randomBytes } from "node:crypto";
 import { resolveTxt } from "node:dns/promises";
 import { and, domains, eq, links, sql, type Database } from "@snapurl/database";
 import type { AddDomainInput, Domain } from "@snapurl/contract";
 import { DB } from "../database/database.module.js";
+import { recordActivity, type Actor } from "../common/activity.js";
 
 @Injectable()
 export class DomainsService {
   constructor(@Inject(DB) private readonly db: Database) {}
+
+  private readonly logger = new Logger(DomainsService.name);
 
   async list(workspaceId: string): Promise<Domain[]> {
     const rows = await this.db
@@ -68,7 +71,7 @@ export class DomainsService {
    * domain we have not proved control of is how a shared-hosting provider ends
    * up issuing certificates for other people's names.
    */
-  async verify(workspaceId: string, id: string): Promise<Domain> {
+  async verify(workspaceId: string, id: string, actor: Actor): Promise<Domain> {
     const [row] = await this.db
       .select()
       .from(domains)
@@ -104,6 +107,16 @@ export class DomainsService {
       .set({ status: "live", verifiedAt: new Date(), updatedAt: new Date() })
       .where(eq(domains.id, id))
       .returning();
+
+    await recordActivity(this.db, this.logger, {
+      workspaceId,
+      actor,
+      auditAction: "domain.verified",
+      webhookEvent: "domain.verified",
+      targetType: "domain",
+      targetId: id,
+      metadata: { domain: row.domain },
+    });
 
     return this.toDto(updated!, 0);
   }

--- a/apps/api/src/links/links.controller.ts
+++ b/apps/api/src/links/links.controller.ts
@@ -3,6 +3,7 @@ import { CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contr
 import { zodBody, zodQuery } from "../common/zod.pipe.js";
 import { Actor, Roles, Scope, type RequestActor } from "../auth/auth.guard.js";
 import { LinksService } from "./links.service.js";
+import { toActor } from "../common/activity.js";
 
 @Controller("links")
 export class LinksController {
@@ -24,7 +25,7 @@ export class LinksController {
   @Roles("editor")
   @Scope("links:write")
   create(@Actor() actor: RequestActor, @Body(zodBody(CreateLinkInput)) input: CreateLinkInput) {
-    return this.links.create(actor.workspaceId, actor.userId, input);
+    return this.links.create(actor.workspaceId, toActor(actor), input);
   }
 
   /* G1 — the endpoint the frontend needed and the contract didn't have. */
@@ -36,7 +37,7 @@ export class LinksController {
     @Param("id") id: string,
     @Body(zodBody(UpdateLinkInput)) input: UpdateLinkInput,
   ) {
-    return this.links.update(actor.workspaceId, id, input);
+    return this.links.update(actor.workspaceId, id, toActor(actor), input);
   }
 
   @Delete(":id")
@@ -44,6 +45,6 @@ export class LinksController {
   @Scope("links:write")
   @HttpCode(204)
   async remove(@Actor() actor: RequestActor, @Param("id") id: string) {
-    await this.links.remove(actor.workspaceId, id);
+    await this.links.remove(actor.workspaceId, id, toActor(actor));
   }
 }

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import * as argon2 from "argon2";
 import { and, asc, clickDaily, desc, domains, eq, gte, inArray, isNull, links, projectionOutbox, routingRules, sql, users, type Database, type Executor } from "@snapurl/database";
 import type { CreateLinkInput, Link, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
@@ -6,6 +6,7 @@ import { SLUG_RETRY_LIMIT, generateSlug, isSlugAvailableShape, validateRoutingCh
 import { DB } from "../database/database.module.js";
 import { SafeBrowsingService } from "../safe-browsing/safe-browsing.service.js";
 import { isUniqueViolation } from "../common/postgres-error.filter.js";
+import { recordActivity, type Actor } from "../common/activity.js";
 import {
   SPARKLINE_DAYS,
   buildSparkline,
@@ -24,6 +25,8 @@ export class LinksService {
     @Inject(DB) private readonly db: Database,
     private readonly safeBrowsing: SafeBrowsingService,
   ) {}
+
+  private readonly logger = new Logger(LinksService.name);
 
   async list(workspaceId: string, query: ListLinksQuery) {
     const filters = [eq(links.workspaceId, workspaceId)];
@@ -110,7 +113,7 @@ export class LinksService {
     return dto!;
   }
 
-  async create(workspaceId: string, userId: string | null, input: CreateLinkInput): Promise<Link> {
+  async create(workspaceId: string, actor: Actor, input: CreateLinkInput): Promise<Link> {
     const domain = await this.resolveDomain(workspaceId, input.domain);
 
     const problems = validateRoutingChain(input.rules);
@@ -157,7 +160,7 @@ export class LinksService {
               safeBrowsingCheckedAt: scan.checkedAt,
               utm: input.utm ?? null,
               social: input.social ?? null,
-              createdBy: userId,
+              createdBy: actor.userId,
             })
             .returning();
 
@@ -177,7 +180,20 @@ export class LinksService {
 
           await this.enqueueProjection(tx, row!.id, "upsert");
           return row!.id;
-        }).then((id) => this.get(workspaceId, id));
+        })
+          .then((id) => this.get(workspaceId, id))
+          .then(async (link) => {
+            await recordActivity(this.db, this.logger, {
+              workspaceId,
+              actor,
+              auditAction: "link.created",
+              webhookEvent: "link.created",
+              targetType: "link",
+              targetId: link.id,
+              metadata: { slug: link.slug, domain: link.domain, destination: link.destination },
+            });
+            return link;
+          });
       } catch (err) {
         if (isUniqueViolation(err)) {
           if (input.slug) {
@@ -194,7 +210,7 @@ export class LinksService {
 
   /* G1 — PATCH did not exist, yet editing a destination is the entire promise
      behind "print it once, change where it points forever". */
-  async update(workspaceId: string, id: string, input: UpdateLinkInput): Promise<Link> {
+  async update(workspaceId: string, id: string, actor: Actor, input: UpdateLinkInput): Promise<Link> {
     const existing = await this.get(workspaceId, id);
 
     if (input.rules) {
@@ -255,13 +271,31 @@ export class LinksService {
       await this.enqueueProjection(tx, id, "upsert");
     });
 
-    void existing;
-    return this.get(workspaceId, id);
+    const updated = await this.get(workspaceId, id);
+    await recordActivity(this.db, this.logger, {
+      workspaceId,
+      actor,
+      auditAction: "link.updated",
+      webhookEvent: "link.updated",
+      targetType: "link",
+      targetId: id,
+      metadata: {
+        slug: updated.slug,
+        domain: updated.domain,
+        // The old destination is the field anyone auditing an edit is looking
+        // for: "where did this QR code point before someone changed it?"
+        from: existing.destination,
+        to: updated.destination,
+      },
+    });
+    return updated;
   }
 
-  async remove(workspaceId: string, id: string): Promise<void> {
+  async remove(workspaceId: string, id: string, actor: Actor): Promise<void> {
+    // The slug is read before the delete because it is the only thing that
+    // makes the audit entry and the webhook payload mean anything afterwards.
     const [row] = await this.db
-      .select({ id: links.id })
+      .select({ id: links.id, slug: links.slug })
       .from(links)
       .where(and(eq(links.id, id), eq(links.workspaceId, workspaceId)))
       .limit(1);
@@ -270,6 +304,16 @@ export class LinksService {
     await this.db.transaction(async (tx) => {
       await this.enqueueProjection(tx, id, "delete");
       await tx.delete(links).where(eq(links.id, id));
+    });
+
+    await recordActivity(this.db, this.logger, {
+      workspaceId,
+      actor,
+      auditAction: "link.deleted",
+      webhookEvent: "link.deleted",
+      targetType: "link",
+      targetId: id,
+      metadata: { slug: row.slug },
     });
   }
 

--- a/apps/worker/src/jobs/webhooks.ts
+++ b/apps/worker/src/jobs/webhooks.ts
@@ -127,27 +127,10 @@ async function recordFailure(db: Database, row: PendingDelivery, error: string, 
   `);
 }
 
-/** Enqueue an event for every webhook subscribed to it. */
-export async function enqueueEvent(
-  db: Database,
-  workspaceId: string,
-  event: string,
-  payload: unknown,
-): Promise<number> {
-  const result = (await db.execute(sql`
-    with queued as (
-      insert into webhook_deliveries (webhook_id, event, payload)
-      select id, ${event}, ${JSON.stringify(payload)}::jsonb
-      from webhooks
-      where workspace_id = ${workspaceId}::uuid
-        and disabled_at is null
-        and ${event} = any(events)
-      returning 1
-    )
-    select count(*)::int as n from queued
-  `)) as unknown as [{ n: number }];
-  return result[0]?.n ?? 0;
-}
+/* enqueueEvent used to live here and had no caller: apps/api is where events
+   happen, and it cannot import from apps/worker. It is now
+   enqueueWebhookEvent in @snapurl/database, which both apps already depend on.
+   This file keeps delivery — signing, backoff and health. */
 
 /** Delivered rows are history nobody reads after a week. */
 export async function pruneDeliveries(db: Database): Promise<number> {

--- a/packages/database/src/events.ts
+++ b/packages/database/src/events.ts
@@ -1,0 +1,83 @@
+import { sql } from "drizzle-orm";
+import type { Executor } from "./client.js";
+import { auditLog } from "./schema/index.js";
+
+/* ============================================================
+   Workspace activity: the audit trail and the webhook queue.
+
+   These live here rather than in apps/worker because apps/api is where the
+   events actually happen, and apps/api does not depend on @snapurl/worker —
+   adding that dependency to reach one function would invert the direction of
+   the dependency graph and break --frozen-lockfile besides. Both apps already
+   depend on @snapurl/database, so this is the one place both can reach.
+
+   apps/worker still owns *delivery* (signing, backoff, health). It owns
+   draining the queue; this file owns filling it.
+   ============================================================ */
+
+/** The events a webhook can subscribe to. Mirrors WEBHOOK_EVENTS in the
+ *  contract — kept as a type here so packages/database need not depend on it. */
+export type WebhookEvent =
+  | "link.created"
+  | "link.updated"
+  | "link.deleted"
+  | "link.clicked"
+  | "conversion.recorded"
+  | "domain.verified";
+
+/**
+ * Queue one event for every webhook in the workspace subscribed to it.
+ *
+ * Returns how many deliveries were queued, which is zero for a workspace with
+ * no matching webhook — the overwhelmingly common case, and not an error.
+ *
+ * Call this *after* the transaction that made the change has committed. A
+ * delivery enqueued inside the transaction is still queued if that transaction
+ * later rolls back, and the receiver would be told about a link that does not
+ * exist.
+ */
+export async function enqueueWebhookEvent(
+  db: Executor,
+  workspaceId: string,
+  event: WebhookEvent,
+  payload: unknown,
+): Promise<number> {
+  const result = (await db.execute(sql`
+    with queued as (
+      insert into webhook_deliveries (webhook_id, event, payload)
+      select id, ${event}, ${JSON.stringify(payload)}::jsonb
+      from webhooks
+      where workspace_id = ${workspaceId}::uuid
+        and disabled_at is null
+        and ${event} = any(events)
+      returning 1
+    )
+    select count(*)::int as n from queued
+  `)) as unknown as [{ n: number }];
+  return result[0]?.n ?? 0;
+}
+
+export interface AuditEntryInput {
+  workspaceId: string;
+  actorId: string | null;
+  actorLabel: string;
+  /** Rendered into a sentence by describe() in members.service.ts. A key with
+   *  no case there shows raw, so add one when you add an action. */
+  action: string;
+  targetType?: string | null;
+  targetId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+/** Append one row to the workspace's audit trail. */
+export async function writeAuditEntry(db: Executor, entry: AuditEntryInput): Promise<void> {
+  await db.insert(auditLog).values({
+    workspaceId: entry.workspaceId,
+    actorId: entry.actorId,
+    actorLabel: entry.actorLabel,
+    action: entry.action,
+    targetType: entry.targetType ?? null,
+    targetId: entry.targetId ?? null,
+    metadata: entry.metadata ?? null,
+  });
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./client.js";
 export * from "./schema/index.js";
+export * from "./events.js";
 export { sql, eq, and, or, not, desc, asc, inArray, isNull, isNotNull, gte, lte, gt, lt, count, sum, like, ilike } from "drizzle-orm";

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -155,6 +155,27 @@ check "api key authenticates" '"total"' "$(curl -s "$API/links" -H "Authorizatio
 check "api key scope is enforced" 'scope' "$(curl -s "$API/analytics" -H "Authorization: Bearer $APIKEY")"
 
 echo
+echo "== audit trail =="
+# Both subsystems were fully built and never invoked: enqueueEvent had zero
+# call sites, and only the three member actions ever wrote an audit row. The
+# team page's claim that every action is logged was false.
+#
+# The stored key is "link.created"; describe() renders it into a sentence
+# before it leaves the API, so these assert what a reader actually sees.
+AUDIT=$(curl -s "$API/audit" -H "Authorization: Bearer $ACCESS")
+check "creating a link writes an audit entry" "Created ${RUN}-one" "$AUDIT"
+check "editing a link writes an audit entry" "Edited ${RUN}-one" "$AUDIT"
+check "the audit entry names the actor" "$EMAIL" "$AUDIT"
+
+# Deletion is the one that matters most after the fact — the row it describes
+# is gone, so the audit entry is the only remaining record of it.
+BODY=$(curl -s -X POST "$API/links" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' \
+  -d "{\"destination\":\"https://example.com/doomed\",\"domain\":\"localhost:3002\",\"slug\":\"${RUN}-doomed\",\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"deepLink\":false,\"hideReferrer\":false,\"publicPreview\":true}")
+DOOMED_ID=$(echo "$BODY" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).id || ""')
+curl -s -o /dev/null -X DELETE "$API/links/$DOOMED_ID" -H "Authorization: Bearer $ACCESS"
+check "deleting a link writes an audit entry" "Deleted ${RUN}-doomed" "$(curl -s "$API/audit" -H "Authorization: Bearer $ACCESS")"
+
+echo
 echo "== G6: two-factor =="
 BODY=$(curl -s -X POST "$API/auth/2fa/setup" -H "Authorization: Bearer $ACCESS")
 check "2FA setup returns an otpauth URI (G6)" 'otpauth://totp' "$BODY"


### PR DESCRIPTION
## What does this PR do?

Fixes #215

Two finished subsystems were never invoked. `enqueueEvent` had **zero call sites**, so `deliverWebhooks` has been waking every 30 seconds to drain a queue nothing could fill. `describe()` renders ten action types and only the three member ones were ever written — which made the team page's "every action is logged" a false claim rather than a partial one.

Both are now emitted from the five call sites the issue names.

| Call site | Audit | Webhook |
| --- | --- | --- |
| `LinksService.create` | `link.created` | `link.created` |
| `LinksService.update` | `link.updated` | `link.updated` |
| `LinksService.remove` | `link.deleted` | `link.deleted` |
| `DomainsService.verify` | `domain.verified` | `domain.verified` |
| `ConversionsService.record` | — see below | `conversion.recorded` |

### The relocation

`enqueueEvent` moves to `packages/database` as `enqueueWebhookEvent`, per the issue's constraint. `apps/api` is where the events happen and has no dependency on `apps/worker`; adding one to reach a single function would invert the dependency graph and break `--frozen-lockfile` besides. Both apps already depend on `@snapurl/database`.

The worker keeps **delivery** — signing, backoff, health — and now only drains the queue instead of also owning the code that fills it.

### Three deliberate design decisions

**1. Emission never throws.** The change it describes has already committed by the time `recordActivity` runs. A failed audit insert must not turn a successfully created link into a 500 — the user retries, hits a duplicate-slug conflict, and a working operation looks broken. Failures are logged at `error` level instead, because a silently empty audit trail is its own bug. This is the riskiest part of the design, so it is what the new unit tests pin down.

**2. Emission happens after the transaction, never inside it.** A delivery enqueued in a transaction that later rolls back would tell a receiver about a link that does not exist.

**3. Conversions get a webhook but no audit row.** This is a deliberate deviation from a literal reading of "both belong on the same five call sites", and I want it visible rather than buried:

> The audit log is a human-readable list of administrative actions. Conversion ingest is machine traffic — usually API-key callers, potentially thousands a day. Writing an audit row per conversion would bury the member and link entries the page exists to show. `describe()` also has no `conversion.recorded` case, so such rows would render as a raw key.

If you'd rather have them, it is a two-line change plus a `describe()` case — say so and I'll add it.

The conversion webhook also fires **only on a real insert**. `onConflictDoNothing` is what makes the ingest idempotent for a customer retrying a timed-out delivery; emitting regardless would undo that on the way out — no second sale booked, but every subscriber told one happened.

## Requirement/Documentation

- Issue #215 is the specification, including the `packages/database` relocation constraint.
- `docs/DECISIONS.md` Part 2 (SQS + Lambda for background work) and Part 4b are consistent with this; nothing is contradicted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Non-breaking: every changed service signature is internal, and all callers are updated in the same commit.

## How should this be tested?

**Unit — no database:**

```
pnpm test
```

8 new tests in `apps/api/src/common/activity.test.ts` cover the audit-only, webhook-only and both paths, and assert the never-throws guarantee: a failing audit insert still queues the webhook, a failing enqueue still returns, and both failing logs twice rather than stopping at the first.

**End-to-end — needs a running API and Postgres 18:**

```
pnpm db:up && pnpm db:migrate && pnpm dev:api
bash scripts/smoke.sh
```

Four new assertions, no existing one weakened or removed:

- `creating a link writes an audit entry`
- `editing a link writes an audit entry`
- `the audit entry names the actor`
- `deleting a link writes an audit entry` — creates a throwaway link and deletes it, because the deletion entry is the one that matters most after the fact: the row it describes is gone, so the audit entry is the only remaining record of it.

| Command | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | pass — no dependency added |
| `pnpm type-check` | pass — 7 packages |
| `pnpm build` | pass |
| `pnpm test` | pass — **91 tests** (was 83) |

`bash -n scripts/smoke.sh` is clean; the script itself needs a live API, which CI does not currently run.

## Checklist

- No assertion in `scripts/smoke.sh` or any `*.test.ts` was weakened, skipped or deleted — only added to.
- No new dependencies; `packages/database` was already a dependency of both apps.
- Verified `enqueueEvent` had no other callers before moving it, and that the worker's existing test covers only `signPayload`, so the move breaks nothing.
- Untouched by policy: `verify.yml`, `pnpm-workspace.yaml`, `tsconfig.base.json`, `docker-compose.yml`, `designs/`.

## Noticed but not fixed

1. **The smoke assertions check the rendered sentence, not the raw key.** The issue asks that `GET /audit` contain `link.created`; it never will, because `describe()` renders the stored key into "Created &lt;slug&gt;" before it leaves the API. The assertions check the rendered form, which is the same guarantee expressed against what the endpoint actually returns. Worth knowing if you expected the literal string.
2. **The webhook queue has no HTTP-observable surface**, so `scripts/smoke.sh` cannot assert a delivery was queued — `GET /webhooks` reports health, which only changes once the worker attempts delivery. The enqueue path is covered by unit tests against a stub executor instead. A real assertion needs the DB-backed integration harness that #216 introduces.
3. **`describe()` still has three unwritten cases**: `domain.added`, `apikey.created` and `apikey.revoked`. `DomainsService.add`, `DevelopersService.createKey` and `revokeKey` are real call sites that would fill them, but they are outside the five this issue names, so I left them. Worth a follow-up — the same one-line `recordActivity` call each.
4. **`link.clicked` is in `WEBHOOK_EVENTS` and is still never emitted.** It belongs on the redirect hot path in `apps/redirect`, which is deliberately not part of this change: adding a write there trades the latency the service exists to protect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_