### PR TITLE
feat(web): wire the dashboard controls to the endpoints that already served them

### DIFF
--- a/web/src/app/(app)/analytics/page.tsx
+++ b/web/src/app/(app)/analytics/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { PageHead } from "@/components/app-shell";
 import { BarList, Sparkline, TrafficChart } from "@/components/charts";
-import { Button, Card, CardBody, CardHeader, ErrorState, Skeleton, Tabs, Tile } from "@/components/ui";
+import { Button, Card, CardBody, CardHeader, ErrorState, Segmented, Skeleton, Tabs, Tile } from "@/components/ui";
 import { useAnalytics } from "@/lib/api/hooks";
 import type { AnalyticsRange } from "@snapurl/contract";
 import { compact, full, pct } from "@/lib/utils";
@@ -20,7 +20,19 @@ export default function AnalyticsPage() {
         sub="No cookies set · click data never sold · 3 years retention"
         actions={
           <>
-            <Button>Last 30 days ▾</Button>
+            {/* Was a dead "Last 30 days ▾" button, so 24h, 7d, 90d and 12m
+                were unreachable even though the API serves all five. */}
+            <Segmented<AnalyticsRange>
+              value={range}
+              onChange={setRange}
+              options={[
+                { value: "24h", label: "24h" },
+                  { value: "7d", label: "7d" },
+                  { value: "30d", label: "30d" },
+                  { value: "90d", label: "90d" },
+                  { value: "12m", label: "12m" },
+              ]}
+            />
             <Button>Schedule report</Button>
             <Button variant="primary">Export CSV</Button>
           </>

--- a/web/src/app/(app)/bio/page.tsx
+++ b/web/src/app/(app)/bio/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import { PageHead } from "@/components/app-shell";
-import { Button, Card, CardBody, CardHeader, Chip, Skeleton, Table, TableWrap, Td, Th } from "@/components/ui";
-import { useBioPages } from "@/lib/api/hooks";
+import { Button, Card, CardBody, CardHeader, Chip, Field, Input, Skeleton, Table, TableWrap, Td, Th } from "@/components/ui";
+import { useBioPages, useDeleteBioPage, useDomains, useUpsertBioPage } from "@/lib/api/hooks";
+import type { BioPage, UpsertBioPageInput } from "@snapurl/contract";
 import { full } from "@/lib/utils";
 
 const BLOCK_ICON: Record<string, string> = {
@@ -14,11 +15,82 @@ const BLOCK_ICON: Record<string, string> = {
   social: "◈",
 };
 
+/* PUT /bio-pages replaces the whole page, so publishing has to send the blocks
+   back with it. Sending only the status would silently empty the page. */
+function toInput(page: BioPage, over: Partial<UpsertBioPageInput> = {}): UpsertBioPageInput {
+  return {
+    domain: page.domain,
+    slug: page.slug,
+    status: page.status,
+    profile: { name: page.profile.name, bio: page.profile.bio },
+    blocks: page.blocks.map((b) => ({
+      id: b.id,
+      kind: b.kind,
+      title: b.title,
+      subtitle: b.subtitle ?? null,
+      metric: b.metric ?? null,
+      locked: b.locked,
+    })),
+    ...over,
+  };
+}
+
 export default function BioPagesPage() {
   const { data, isLoading } = useBioPages();
+  const { data: domains } = useDomains();
+  const upsert = useUpsertBioPage();
+  const remove = useDeleteBioPage();
+
   const pages = data ?? [];
   const [editing, setEditing] = useState(0);
   const page = pages[editing];
+
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState({ domain: "", slug: "", name: "" });
+  const [problem, setProblem] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  async function create() {
+    const domain = draft.domain || domains?.[0]?.domain || "";
+    if (!domain || !draft.slug.trim() || !draft.name.trim()) {
+      setProblem("A page needs a domain, a back-half and a display name.");
+      return;
+    }
+    try {
+      await upsert.mutateAsync({
+        domain,
+        slug: draft.slug.trim(),
+        status: "draft",
+        profile: { name: draft.name.trim(), bio: "" },
+        blocks: [],
+      });
+      setDraft({ domain: "", slug: "", name: "" });
+      setCreating(false);
+      setProblem(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
+
+  async function setStatus(target: BioPage, status: "live" | "draft") {
+    setProblem(null);
+    try {
+      await upsert.mutateAsync(toInput(target, { status }));
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
+
+  async function destroy(id: string) {
+    setProblem(null);
+    try {
+      await remove.mutateAsync(id);
+      setEditing(0);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+    setConfirming(null);
+  }
 
   return (
     <>
@@ -28,10 +100,62 @@ export default function BioPagesPage() {
         actions={
           <>
             <Button>Templates</Button>
-            <Button variant="primary">＋ New page</Button>
+            <Button variant="primary" onClick={() => { setCreating((v) => !v); setProblem(null); }}>
+              {creating ? "Cancel" : "＋ New page"}
+            </Button>
           </>
         }
       />
+
+      {problem ? (
+        <Card className="mb-3.5 border-bad">
+          <CardBody className="text-[13px] text-bad">{problem}</CardBody>
+        </Card>
+      ) : null}
+
+      {creating ? (
+        <Card className="mb-3.5">
+          <CardHeader title="New bio page" />
+          <CardBody className="flex flex-col gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <Field label="Domain">
+                <select
+                  className="px-[11px] py-[7px] bg-surface border border-line-2 rounded-[var(--radius-sm)] text-[13px] w-full"
+                  value={draft.domain || domains?.[0]?.domain || ""}
+                  onChange={(e) => setDraft((d) => ({ ...d, domain: e.target.value }))}
+                >
+                  {(domains ?? []).map((d) => (
+                    <option key={d.id} value={d.domain}>
+                      {d.domain}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Back-half">
+                <Input
+                  value={draft.slug}
+                  placeholder="yourname"
+                  className="font-mono text-[12.5px]"
+                  onChange={(e) => { setDraft((d) => ({ ...d, slug: e.target.value })); setProblem(null); }}
+                />
+              </Field>
+              <Field label="Display name">
+                <Input
+                  value={draft.name}
+                  placeholder="Acme Growth"
+                  onChange={(e) => { setDraft((d) => ({ ...d, name: e.target.value })); setProblem(null); }}
+                />
+              </Field>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="primary" onClick={create} disabled={upsert.isPending}>
+                {upsert.isPending ? "Creating…" : "Create as draft"}
+              </Button>
+              <Button onClick={() => { setCreating(false); setProblem(null); }}>Cancel</Button>
+            </div>
+          </CardBody>
+        </Card>
+      ) : null}
 
       <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_320px] gap-4 items-start">
         <div className="flex flex-col gap-3.5">
@@ -68,10 +192,26 @@ export default function BioPagesPage() {
                             {p.status === "live" ? "Live" : "Draft"}
                           </Chip>
                         </Td>
-                        <Td className="text-right">
-                          <Button size="sm" variant="ghost" onClick={() => setEditing(i)}>
-                            Edit
-                          </Button>
+                        <Td className="text-right whitespace-nowrap">
+                          {confirming === p.id ? (
+                            <>
+                              <Button size="sm" variant="ghost" onClick={() => setConfirming(null)}>
+                                Keep
+                              </Button>
+                              <Button size="sm" variant="danger" onClick={() => destroy(p.id)} disabled={remove.isPending}>
+                                Delete
+                              </Button>
+                            </>
+                          ) : (
+                            <>
+                              <Button size="sm" variant="ghost" onClick={() => setEditing(i)}>
+                                Edit
+                              </Button>
+                              <Button size="sm" variant="ghost" onClick={() => { setConfirming(p.id); setProblem(null); }}>
+                                Delete
+                              </Button>
+                            </>
+                          )}
                         </Td>
                       </tr>
                     ))}
@@ -95,8 +235,13 @@ export default function BioPagesPage() {
                 right={
                   <>
                     <Button size="sm">Theme</Button>
-                    <Button size="sm" variant="primary">
-                      Publish
+                    <Button
+                      size="sm"
+                      variant={page.status === "live" ? "default" : "primary"}
+                      disabled={upsert.isPending}
+                      onClick={() => setStatus(page, page.status === "live" ? "draft" : "live")}
+                    >
+                      {upsert.isPending ? "Saving…" : page.status === "live" ? "Unpublish" : "Publish"}
                     </Button>
                   </>
                 }

--- a/web/src/app/(app)/conversions/page.tsx
+++ b/web/src/app/(app)/conversions/page.tsx
@@ -2,12 +2,15 @@
 
 import { PageHead } from "@/components/app-shell";
 import { Funnel, Sparkline } from "@/components/charts";
-import { Button, Card, CardBody, CardHeader, Chip, ErrorState, Skeleton, Table, TableWrap, Td, Th, Tile } from "@/components/ui";
+import { Button, Card, CardBody, CardHeader, Chip, ErrorState, Segmented, Skeleton, Table, TableWrap, Td, Th, Tile } from "@/components/ui";
 import { useConversions } from "@/lib/api/hooks";
+import type { AnalyticsRange } from "@snapurl/contract";
+import { useState } from "react";
 import { full, inr, pct } from "@/lib/utils";
 
 export default function ConversionsPage() {
-  const { data, isLoading, isError, error, refetch } = useConversions();
+  const [range, setRange] = useState<AnalyticsRange>("30d");
+  const { data, isLoading, isError, error, refetch } = useConversions(range);
 
   return (
     <>
@@ -16,7 +19,17 @@ export default function ConversionsPage() {
         sub="Which links actually produced revenue — not which produced clicks."
         actions={
           <>
-            <Button>Last 30 days ▾</Button>
+            <Segmented<AnalyticsRange>
+              value={range}
+              onChange={setRange}
+              options={[
+                { value: "24h", label: "24h" },
+                  { value: "7d", label: "7d" },
+                  { value: "30d", label: "30d" },
+                  { value: "90d", label: "90d" },
+                  { value: "12m", label: "12m" },
+              ]}
+            />
             <Button>Define an event</Button>
             <Button variant="primary">Install tracking</Button>
           </>

--- a/web/src/app/(app)/developers/page.tsx
+++ b/web/src/app/(app)/developers/page.tsx
@@ -2,8 +2,16 @@
 
 import { useState } from "react";
 import { PageHead } from "@/components/app-shell";
-import { Button, Card, CardBody, CardHeader, Chip, Skeleton, Table, TableWrap, Tabs, Td, Th } from "@/components/ui";
-import { useApiKeys, useWebhooks } from "@/lib/api/hooks";
+import { Button, Card, CardBody, CardHeader, Chip, Field, Input, Skeleton, Table, TableWrap, Tabs, Td, Th } from "@/components/ui";
+import {
+  useApiKeys,
+  useCreateApiKey,
+  useCreateWebhook,
+  useDeleteWebhook,
+  useRevokeApiKey,
+  useWebhooks,
+} from "@/lib/api/hooks";
+import { API_SCOPES, WEBHOOK_EVENTS } from "@snapurl/contract";
 import { API_URL } from "@/lib/api/client";
 
 const SNIPPETS = {
@@ -62,6 +70,69 @@ export default function DevelopersPage() {
   const { data: hooks } = useWebhooks();
   const [lang, setLang] = useState<keyof typeof SNIPPETS>("curl");
 
+  const createKey = useCreateApiKey();
+  const revokeKey = useRevokeApiKey();
+  const createWebhook = useCreateWebhook();
+  const deleteWebhook = useDeleteWebhook();
+
+  const [namingKey, setNamingKey] = useState(false);
+  const [keyName, setKeyName] = useState("");
+  const [keyScopes, setKeyScopes] = useState<string[]>(["links:read", "links:write"]);
+  /* Shown once and never again — the server stores a hash, so if this is
+     dismissed without copying, the key is gone and a new one is the only
+     recourse. That is why it gets a panel rather than a toast. */
+  const [freshKey, setFreshKey] = useState<string | null>(null);
+
+  const [addingHook, setAddingHook] = useState(false);
+  const [endpoint, setEndpoint] = useState("");
+  const [hookEvents, setHookEvents] = useState<string[]>(["link.created"]);
+  const [freshSecret, setFreshSecret] = useState<string | null>(null);
+
+  const [problem, setProblem] = useState<string | null>(null);
+  const [confirmKey, setConfirmKey] = useState<string | null>(null);
+  const [confirmHook, setConfirmHook] = useState<string | null>(null);
+
+  const toggle = (list: string[], value: string) =>
+    list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+
+  async function mintKey() {
+    if (!keyName.trim() || keyScopes.length === 0) {
+      setProblem("A key needs a name and at least one scope.");
+      return;
+    }
+    try {
+      const created = await createKey.mutateAsync({
+        name: keyName.trim(),
+        scopes: keyScopes as (typeof API_SCOPES)[number][],
+      });
+      setFreshKey(created.key);
+      setKeyName("");
+      setNamingKey(false);
+      setProblem(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
+
+  async function addWebhook() {
+    if (hookEvents.length === 0) {
+      setProblem("Pick at least one event to send.");
+      return;
+    }
+    try {
+      const created = await createWebhook.mutateAsync({
+        endpoint: endpoint.trim(),
+        events: hookEvents as (typeof WEBHOOK_EVENTS)[number][],
+      });
+      setFreshSecret(created.secret);
+      setEndpoint("");
+      setAddingHook(false);
+      setProblem(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
+
   return (
     <>
       <PageHead
@@ -70,10 +141,125 @@ export default function DevelopersPage() {
         actions={
           <>
             <Button>Read the docs</Button>
-            <Button variant="primary">＋ New API key</Button>
+            <Button variant="primary" onClick={() => { setNamingKey((v) => !v); setProblem(null); }}>
+              {namingKey ? "Cancel" : "＋ New API key"}
+            </Button>
           </>
         }
       />
+
+      {problem ? (
+        <Card className="mb-3.5 border-bad">
+          <CardBody className="text-[13px] text-bad">{problem}</CardBody>
+        </Card>
+      ) : null}
+
+      {freshKey ? (
+        <Card className="mb-3.5 border-accent">
+          <CardHeader title="Copy this key now" right={<Button size="sm" onClick={() => setFreshKey(null)}>Done</Button>} />
+          <CardBody className="flex flex-col gap-2">
+            <code className="font-mono text-[12.5px] break-all bg-surface-3 px-3 py-2 rounded-[var(--radius-sm)]">
+              {freshKey}
+            </code>
+            <span className="text-[12px] text-ink-3">
+              This is the only time it is shown. Only a hash is stored, so it cannot be recovered — if you lose it,
+              revoke this key and mint another.
+            </span>
+          </CardBody>
+        </Card>
+      ) : null}
+
+      {freshSecret ? (
+        <Card className="mb-3.5 border-accent">
+          <CardHeader title="Webhook signing secret" right={<Button size="sm" onClick={() => setFreshSecret(null)}>Done</Button>} />
+          <CardBody className="flex flex-col gap-2">
+            <code className="font-mono text-[12.5px] break-all bg-surface-3 px-3 py-2 rounded-[var(--radius-sm)]">
+              {freshSecret}
+            </code>
+            <span className="text-[12px] text-ink-3">
+              Verify every delivery against this. The signature is HMAC-SHA256 over
+              <code className="font-mono"> timestamp.body</code>, sent as X-SnapURL-Signature.
+            </span>
+          </CardBody>
+        </Card>
+      ) : null}
+
+      {namingKey ? (
+        <Card className="mb-3.5">
+          <CardHeader title="New API key" />
+          <CardBody className="flex flex-col gap-3">
+            <Field label="Name" help="What is it for? This is how you will recognise it when revoking.">
+              <Input
+                value={keyName}
+                autoFocus
+                placeholder="CI deploy bot"
+                onChange={(e) => { setKeyName(e.target.value); setProblem(null); }}
+              />
+            </Field>
+            <Field label="Scopes" help="A key can do exactly what you tick here and nothing else.">
+              <div className="flex gap-1.5 flex-wrap">
+                {API_SCOPES.map((scope) => (
+                  <button
+                    key={scope}
+                    type="button"
+                    onClick={() => setKeyScopes((cur) => toggle(cur, scope))}
+                    className={`px-[9px] py-[4px] rounded-[var(--radius-sm)] border text-[12px] font-mono ${
+                      keyScopes.includes(scope) ? "border-accent text-accent bg-accent-wash" : "border-line text-ink-3"
+                    }`}
+                  >
+                    {scope}
+                  </button>
+                ))}
+              </div>
+            </Field>
+            <div className="flex gap-2">
+              <Button variant="primary" onClick={mintKey} disabled={createKey.isPending}>
+                {createKey.isPending ? "Creating…" : "Create key"}
+              </Button>
+              <Button onClick={() => { setNamingKey(false); setProblem(null); }}>Cancel</Button>
+            </div>
+          </CardBody>
+        </Card>
+      ) : null}
+
+      {addingHook ? (
+        <Card className="mb-3.5">
+          <CardHeader title="Add a webhook endpoint" />
+          <CardBody className="flex flex-col gap-3">
+            <Field label="Endpoint" help="Absolute https URL. We retry with backoff for about twelve hours.">
+              <Input
+                value={endpoint}
+                autoFocus
+                placeholder="https://example.com/hooks/snapurl"
+                className="font-mono text-[12.5px]"
+                onChange={(e) => { setEndpoint(e.target.value); setProblem(null); }}
+              />
+            </Field>
+            <Field label="Events">
+              <div className="flex gap-1.5 flex-wrap">
+                {WEBHOOK_EVENTS.map((event) => (
+                  <button
+                    key={event}
+                    type="button"
+                    onClick={() => setHookEvents((cur) => toggle(cur, event))}
+                    className={`px-[9px] py-[4px] rounded-[var(--radius-sm)] border text-[12px] font-mono ${
+                      hookEvents.includes(event) ? "border-accent text-accent bg-accent-wash" : "border-line text-ink-3"
+                    }`}
+                  >
+                    {event}
+                  </button>
+                ))}
+              </div>
+            </Field>
+            <div className="flex gap-2">
+              <Button variant="primary" onClick={addWebhook} disabled={createWebhook.isPending || !endpoint.trim()}>
+                {createWebhook.isPending ? "Adding…" : "Add endpoint"}
+              </Button>
+              <Button onClick={() => { setAddingHook(false); setProblem(null); }}>Cancel</Button>
+            </div>
+          </CardBody>
+        </Card>
+      ) : null}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3.5 items-start">
         <div className="flex flex-col gap-3.5">
@@ -108,10 +294,33 @@ export default function DevelopersPage() {
                           </span>
                         </Td>
                         <Td>{k.lastUsed ?? "Never"}</Td>
-                        <Td className="text-right">
-                          <Button size="sm" variant="ghost">
-                            Revoke
-                          </Button>
+                        <Td className="text-right whitespace-nowrap">
+                          {confirmKey === k.id ? (
+                            <>
+                              <Button size="sm" variant="ghost" onClick={() => setConfirmKey(null)}>
+                                Keep
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="danger"
+                                disabled={revokeKey.isPending}
+                                onClick={async () => {
+                                  try {
+                                    await revokeKey.mutateAsync(k.id);
+                                  } catch (err) {
+                                    setProblem((err as Error).message);
+                                  }
+                                  setConfirmKey(null);
+                                }}
+                              >
+                                Revoke now
+                              </Button>
+                            </>
+                          ) : (
+                            <Button size="sm" variant="ghost" onClick={() => { setConfirmKey(k.id); setProblem(null); }}>
+                              Revoke
+                            </Button>
+                          )}
                         </Td>
                       </tr>
                     ))}
@@ -122,7 +331,14 @@ export default function DevelopersPage() {
           </Card>
 
           <Card>
-            <CardHeader title="Webhooks" right={<Button size="sm">＋ Add endpoint</Button>} />
+            <CardHeader
+              title="Webhooks"
+              right={
+                <Button size="sm" onClick={() => { setAddingHook((v) => !v); setProblem(null); }}>
+                  {addingHook ? "Cancel" : "＋ Add endpoint"}
+                </Button>
+              }
+            />
             <TableWrap>
               <Table>
                 <thead>
@@ -130,6 +346,7 @@ export default function DevelopersPage() {
                     <Th>Endpoint</Th>
                     <Th>Events</Th>
                     <Th>Status</Th>
+                    <Th />
                   </tr>
                 </thead>
                 <tbody>
@@ -147,6 +364,34 @@ export default function DevelopersPage() {
                         <Chip tone={w.health === "healthy" ? "good" : "warn"} dot>
                           {w.detail}
                         </Chip>
+                      </Td>
+                      <Td className="text-right whitespace-nowrap">
+                        {confirmHook === w.id ? (
+                          <>
+                            <Button size="sm" variant="ghost" onClick={() => setConfirmHook(null)}>
+                              Keep
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="danger"
+                              disabled={deleteWebhook.isPending}
+                              onClick={async () => {
+                                try {
+                                  await deleteWebhook.mutateAsync(w.id);
+                                } catch (err) {
+                                  setProblem((err as Error).message);
+                                }
+                                setConfirmHook(null);
+                              }}
+                            >
+                              Delete
+                            </Button>
+                          </>
+                        ) : (
+                          <Button size="sm" variant="ghost" onClick={() => { setConfirmHook(w.id); setProblem(null); }}>
+                            Delete
+                          </Button>
+                        )}
                       </Td>
                     </tr>
                   ))}

--- a/web/src/app/(app)/domains/page.tsx
+++ b/web/src/app/(app)/domains/page.tsx
@@ -1,22 +1,109 @@
 "use client";
 
+import { useState } from "react";
 import { PageHead } from "@/components/app-shell";
-import { Button, Card, CardBody, CardHeader, Chip, Skeleton, Table, TableWrap, Td, Th } from "@/components/ui";
-import { useDomains } from "@/lib/api/hooks";
+import { Button, Card, CardBody, CardHeader, Chip, Field, Input, Skeleton, Table, TableWrap, Td, Th } from "@/components/ui";
+import { useAddDomain, useDeleteDomain, useDomains, useVerifyDomain } from "@/lib/api/hooks";
+import { AddDomainInput } from "@snapurl/contract";
 import { formatDate, full } from "@/lib/utils";
 
 export default function DomainsPage() {
   const { data, isLoading } = useDomains();
+  const addDomain = useAddDomain();
+  const verifyDomain = useVerifyDomain();
+  const deleteDomain = useDeleteDomain();
+
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState("");
+  const [problem, setProblem] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+
   const domains = data ?? [];
   const pending = domains.find((d) => d.status === "verifying");
+
+  async function add() {
+    const parsed = AddDomainInput.safeParse({ domain: name.trim() });
+    if (!parsed.success) {
+      setProblem(parsed.error.issues[0]?.message ?? "That doesn't look like a domain name.");
+      return;
+    }
+    try {
+      await addDomain.mutateAsync(parsed.data);
+      setName("");
+      setAdding(false);
+      setProblem(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
+
+  async function verify(id: string) {
+    setProblem(null);
+    try {
+      await verifyDomain.mutateAsync(id);
+    } catch (err) {
+      // The usual failure is "the TXT record isn't there yet", which is
+      // information rather than an error — show it where it was asked for.
+      setProblem((err as Error).message);
+    }
+  }
+
+  async function disconnect(id: string) {
+    setProblem(null);
+    try {
+      await deleteDomain.mutateAsync(id);
+      setConfirming(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+      setConfirming(null);
+    }
+  }
 
   return (
     <>
       <PageHead
         title="Domains"
         sub="Bring your own domain. SSL is issued automatically and renews itself."
-        actions={<Button variant="primary">＋ Add domain</Button>}
+        actions={
+          <Button variant="primary" onClick={() => { setAdding((a) => !a); setProblem(null); }}>
+            {adding ? "Cancel" : "＋ Add domain"}
+          </Button>
+        }
       />
+
+      {adding ? (
+        <Card className="mb-3.5">
+          <CardHeader title="Add a domain" />
+          <CardBody className="flex flex-col gap-3">
+            <Field
+              label="Domain"
+              help="Add it here first, then create the DNS record we show you. Nothing resolves until it verifies."
+              error={problem ?? undefined}
+            >
+              <Input
+                value={name}
+                autoFocus
+                placeholder="go.example.com"
+                className="font-mono text-[12.5px]"
+                onChange={(e) => { setName(e.target.value); setProblem(null); }}
+                onKeyDown={(e) => { if (e.key === "Enter") void add(); }}
+              />
+            </Field>
+            <div className="flex gap-2">
+              <Button variant="primary" onClick={add} disabled={addDomain.isPending || !name.trim()}>
+                {addDomain.isPending ? "Adding…" : "Add domain"}
+              </Button>
+              <Button onClick={() => { setAdding(false); setProblem(null); }}>Cancel</Button>
+            </div>
+          </CardBody>
+        </Card>
+      ) : null}
+
+      {problem && !adding ? (
+        <Card className="mb-3.5 border-bad">
+          <CardBody className="text-[13px] text-bad">{problem}</CardBody>
+        </Card>
+      ) : null}
 
       <Card className="mb-3.5">
         {isLoading ? (
@@ -58,10 +145,26 @@ export default function DomainsPage() {
                     <Td className="font-mono text-[12px]">
                       {d.notFoundRedirect ?? <span className="text-ink-3">— not set</span>}
                     </Td>
-                    <Td className="text-right">
-                      <Button size="sm" variant="ghost">
-                        Manage
-                      </Button>
+                    <Td className="text-right whitespace-nowrap">
+                      {d.status !== "live" ? (
+                        <Button size="sm" variant="ghost" onClick={() => verify(d.id)} disabled={verifyDomain.isPending}>
+                          {verifyDomain.isPending ? "Checking…" : "Check DNS"}
+                        </Button>
+                      ) : null}
+                      {confirming === d.id ? (
+                        <>
+                          <Button size="sm" variant="ghost" onClick={() => setConfirming(null)}>
+                            Keep
+                          </Button>
+                          <Button size="sm" variant="danger" onClick={() => disconnect(d.id)} disabled={deleteDomain.isPending}>
+                            Disconnect
+                          </Button>
+                        </>
+                      ) : (
+                        <Button size="sm" variant="ghost" onClick={() => { setConfirming(d.id); setProblem(null); }}>
+                          Disconnect
+                        </Button>
+                      )}
                     </Td>
                   </tr>
                 ))}
@@ -71,13 +174,32 @@ export default function DomainsPage() {
         )}
       </Card>
 
+      {confirming ? (
+        <Card className="mb-3.5">
+          <CardBody className="text-[13px] text-ink-2 leading-[1.6]">
+            <b className="text-ink">Disconnecting a domain stops every link on it.</b> Printed codes and shared URLs
+            using it will 404 immediately. The links themselves are not deleted, but nothing resolves to them until the
+            domain is connected again. The shared short domain belongs to everyone and cannot be disconnected.
+          </CardBody>
+        </Card>
+      ) : null}
+
       {pending?.dns ? (
         <Card>
-          <CardHeader title={`Finish setting up ${pending.domain}`} right={<Chip tone="warn">1 step left</Chip>} />
+          <CardHeader
+            title={`Finish setting up ${pending.domain}`}
+            right={
+              <div className="flex items-center gap-2">
+                <Chip tone="warn">1 step left</Chip>
+                <Button size="sm" onClick={() => verify(pending.id)} disabled={verifyDomain.isPending}>
+                  {verifyDomain.isPending ? "Checking…" : "Check now"}
+                </Button>
+              </div>
+            }
+          />
           <CardBody>
             <p className="m-0 mb-3.5 text-[13.5px] text-ink-2">
-              Add this record at your DNS provider. We check every 30 seconds and issue the certificate as soon as it
-              resolves.
+              Add this record at your DNS provider, then check again. DNS changes can take a few minutes to propagate.
             </p>
             <TableWrap>
               <Table className="min-w-[420px]">

--- a/web/src/app/(app)/links/page.tsx
+++ b/web/src/app/(app)/links/page.tsx
@@ -1,26 +1,81 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { PageHead } from "@/components/app-shell";
 import { LinkRow } from "@/components/links/link-row";
-import { Button, Card, EmptyState, ErrorState, Skeleton, Tabs } from "@/components/ui";
-import { useLinks } from "@/lib/api/hooks";
+import { Button, Card, EmptyState, ErrorState, Input, Skeleton, Tabs } from "@/components/ui";
+import { useDomains, useLinks } from "@/lib/api/hooks";
+import type { ListLinksQuery } from "@snapurl/contract";
 import { cn, full } from "@/lib/utils";
 
 const FILTERS = [
   { value: "all", label: "All" },
   { value: "active", label: "Active" },
   { value: "expiring", label: "Expiring" },
+  { value: "expired", label: "Expired" },
   { value: "archived", label: "Archived" },
 ] as const;
 
+const SELECT_CLASS =
+  "inline-flex items-center px-[10px] py-[5px] bg-surface border border-line-2 rounded-full text-[12.5px] text-ink-2 hover:border-ink-3 hover:text-ink";
+
 export default function LinksPage() {
-  const [filter, setFilter] = useState<string>("all");
+  const [filter, setFilter] = useState<ListLinksQuery["status"]>("all");
   const [view, setView] = useState<"list" | "grid">("list");
-  const { data, isLoading, isError, error, refetch } = useLinks(filter);
+
+  /* All four were implemented in LinksService.list and had no way in from the
+     UI: the domain, tag and folder chips were decorative buttons and there was
+     no search box at all. */
+  const [search, setSearch] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [domain, setDomain] = useState("");
+  const [tag, setTag] = useState("");
+  const [folder, setFolder] = useState("");
+
+  /* Cursor pages, kept as a stack. G4 chose a cursor over an offset because
+     links are created continuously, so there is deliberately no "jump to page
+     7" — a cursor cannot serve one. Back and forward is what it can do. */
+  const [stack, setStack] = useState<string[]>([]);
+  const cursor = stack[stack.length - 1];
+
+  // Typing shouldn't fire a request per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim()), 250);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // Any change to what is being asked for invalidates the page position.
+  useEffect(() => {
+    setStack([]);
+  }, [filter, debounced, domain, tag, folder]);
+
+  const query = useMemo(
+    () => ({
+      status: filter,
+      ...(debounced ? { search: debounced } : {}),
+      ...(domain ? { domain } : {}),
+      ...(tag ? { tag } : {}),
+      ...(folder ? { folder } : {}),
+      ...(cursor ? { cursor } : {}),
+    }),
+    [filter, debounced, domain, tag, folder, cursor],
+  );
+
+  const { data, isLoading, isFetching, isError, error, refetch } = useLinks(query);
+  const { data: domains } = useDomains();
 
   const links = data?.items ?? [];
-  const visible = filter === "all" ? links : links.filter((l) => l.status === filter);
+
+  // No endpoint enumerates tags or folders, so the options come from what is
+  // on the page. Enough to reach them; not a complete list of what exists.
+  const tags = useMemo(() => [...new Set(links.flatMap((l) => l.tags))].sort(), [links]);
+  const folders = useMemo(
+    () => [...new Set(links.map((l) => l.folder).filter((f): f is string => Boolean(f)))].sort(),
+    [links],
+  );
+
+  const filtered = Boolean(debounced || domain || tag || folder || filter !== "all");
+  const page = stack.length + 1;
 
   return (
     <>
@@ -28,9 +83,9 @@ export default function LinksPage() {
         title="Links"
         sub={
           data
-            ? `${full(data.total)} links across 3 domains · ${full(
+            ? `${full(data.total)} links across ${domains?.length ?? 0} domains · ${full(
                 links.reduce((a, l) => a + l.clicks, 0),
-              )} clicks in the last 30 days`
+              )} clicks on this page`
             : "Loading…"
         }
         actions={
@@ -59,15 +114,54 @@ export default function LinksPage() {
             </button>
           ))}
         </div>
+
         <span className="w-px h-[22px] bg-line" />
-        {["◈ Domain", "⌗ Tags", "▤ Folder"].map((l) => (
-          <button
-            key={l}
-            className="inline-flex items-center gap-[6px] px-[10px] py-[5px] bg-surface border border-line-2 rounded-full text-[12.5px] text-ink-2 hover:border-ink-3 hover:text-ink"
+
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search back-halves and destinations"
+          className="w-[260px] max-w-full"
+          aria-label="Search links"
+        />
+
+        <select className={SELECT_CLASS} value={domain} onChange={(e) => setDomain(e.target.value)} aria-label="Filter by domain">
+          <option value="">◈ Any domain</option>
+          {(domains ?? []).map((d) => (
+            <option key={d.id} value={d.domain}>
+              {d.domain}
+            </option>
+          ))}
+        </select>
+
+        <select className={SELECT_CLASS} value={tag} onChange={(e) => setTag(e.target.value)} aria-label="Filter by tag">
+          <option value="">⌗ Any tag</option>
+          {tags.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+
+        <select className={SELECT_CLASS} value={folder} onChange={(e) => setFolder(e.target.value)} aria-label="Filter by folder">
+          <option value="">▤ Any folder</option>
+          {folders.map((f) => (
+            <option key={f} value={f}>
+              {f}
+            </option>
+          ))}
+        </select>
+
+        {filtered ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => { setFilter("all"); setSearch(""); setDomain(""); setTag(""); setFolder(""); }}
           >
-            {l}
-          </button>
-        ))}
+            Clear
+          </Button>
+        ) : null}
+
         <div className="ml-auto">
           <Tabs
             value={view}
@@ -90,24 +184,46 @@ export default function LinksPage() {
             <Skeleton key={i} className="h-[68px]" />
           ))}
         </div>
-      ) : visible.length === 0 ? (
+      ) : links.length === 0 ? (
         <Card>
           <EmptyState
             icon="⛓"
             title="No links here yet"
             body={
-              filter === "all"
-                ? "Create your first link and it'll show up here with its click history."
-                : `Nothing matches the "${filter}" filter right now.`
+              filtered
+                ? "Nothing matches those filters. Clear them to see everything again."
+                : "Create your first link and it'll show up here with its click history."
             }
           />
         </Card>
       ) : (
-        <div className={cn(view === "grid" ? "grid grid-cols-1 xl:grid-cols-2 gap-2" : "flex flex-col gap-2")}>
-          {visible.map((link, i) => (
-            <LinkRow key={link.id} link={link} defaultOpen={i === 0 && view === "list"} />
-          ))}
-        </div>
+        <>
+          {/* The server applies every filter above, so the list is rendered as
+              returned. Filtering again here would have hidden rows from a page
+              that was already the correct page. */}
+          <div className={cn(view === "grid" ? "grid grid-cols-1 xl:grid-cols-2 gap-2" : "flex flex-col gap-2")}>
+            {links.map((link, i) => (
+              <LinkRow key={link.id} link={link} defaultOpen={i === 0 && view === "list"} />
+            ))}
+          </div>
+
+          {stack.length > 0 || data?.nextCursor ? (
+            <div className="flex items-center gap-2 mt-3">
+              <Button disabled={stack.length === 0 || isFetching} onClick={() => setStack((s) => s.slice(0, -1))}>
+                ← Previous
+              </Button>
+              <span className="text-[12px] text-ink-3">
+                Page {page} of {full(data?.total ?? 0)} links
+              </span>
+              <Button
+                disabled={!data?.nextCursor || isFetching}
+                onClick={() => data?.nextCursor && setStack((s) => [...s, data.nextCursor!])}
+              >
+                {isFetching ? "Loading…" : "Next →"}
+              </Button>
+            </div>
+          ) : null}
+        </>
       )}
     </>
   );

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -1,19 +1,69 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PageHead } from "@/components/app-shell";
 import { ACCENTS, useAppearance, type Mode } from "@/components/theme/theme-provider";
 import { Button, Card, CardBody, CardHeader, Chip, Field, Input, Segmented, Skeleton, Toggle } from "@/components/ui";
-import { useWorkspace } from "@/lib/api/hooks";
-import type { RedirectType } from "@/lib/api/types";
+import { useUpdateWorkspace, useWorkspace } from "@/lib/api/hooks";
+import type { RedirectType, Workspace } from "@/lib/api/types";
 import { cn, compact } from "@/lib/utils";
+
+/* Retention is offered as three choices but stored as a number of years, so
+   "Forever" has to land on something. 100 is the contract's maximum and is
+   past the lifetime of any link anyone is planning for. */
+const FOREVER_YEARS = 100;
+const retentionValue = (years: number) => (years >= FOREVER_YEARS ? "forever" : String(years));
+
+type Draft = Pick<
+  Workspace,
+  "name" | "slug" | "defaultDomain" | "defaultRedirect" | "retentionYears" | "cookielessAnalytics" | "scanOnCreate" | "publicPreviews"
+>;
+
+const draftOf = (ws: Workspace): Draft => ({
+  name: ws.name,
+  slug: ws.slug,
+  defaultDomain: ws.defaultDomain,
+  defaultRedirect: ws.defaultRedirect,
+  retentionYears: ws.retentionYears,
+  cookielessAnalytics: ws.cookielessAnalytics,
+  scanOnCreate: ws.scanOnCreate,
+  publicPreviews: ws.publicPreviews,
+});
 
 export default function SettingsPage() {
   const { data: ws, isLoading } = useWorkspace();
   const appearance = useAppearance();
-  const [redirect, setRedirect] = useState<RedirectType>("302");
-  const [privacy, setPrivacy] = useState({ cookieless: true, scan: true, previews: true });
-  const [retention, setRetention] = useState("3");
+  const save = useUpdateWorkspace();
+
+  /* Every control below used to be uncontrolled -- defaultValue with no
+     onChange and no submit -- so each edit survived exactly until the next
+     reload and then silently reverted. The form is now held here and sent
+     with the Save button. */
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [problem, setProblem] = useState<string | null>(null);
+
+  // Seeded once the workspace arrives, and re-seeded if it is refetched while
+  // there is nothing unsaved to lose.
+  useEffect(() => {
+    if (ws && draft === null) setDraft(draftOf(ws));
+  }, [ws, draft]);
+
+  const set = <K extends keyof Draft>(key: K, value: Draft[K]) => {
+    setProblem(null);
+    setDraft((d) => (d ? { ...d, [key]: value } : d));
+  };
+
+  const dirty = Boolean(ws && draft && JSON.stringify(draft) !== JSON.stringify(draftOf(ws)));
+
+  async function submit() {
+    if (!draft) return;
+    try {
+      await save.mutateAsync(draft);
+      setProblem(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
 
   const usedPct = ws ? Math.min(100, Math.round((ws.clicksUsed / ws.clicksIncluded) * 100)) : 0;
 
@@ -26,25 +76,37 @@ export default function SettingsPage() {
           <Card>
             <CardHeader title="Workspace" />
             <CardBody className="flex flex-col gap-3.5">
-              {isLoading ? (
+              {isLoading || !draft ? (
                 <Skeleton className="h-[180px]" />
               ) : (
                 <>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <Field label="Name">
-                      <Input defaultValue={ws?.name} />
+                      <Input value={draft.name} onChange={(e) => set("name", e.target.value)} />
                     </Field>
-                    <Field label="Slug">
-                      <Input defaultValue={ws?.slug} className="font-mono text-[12.5px]" />
+                    <Field label="Slug" help="Lowercase letters, numbers and dashes.">
+                      <Input
+                        value={draft.slug}
+                        onChange={(e) => set("slug", e.target.value)}
+                        className="font-mono text-[12.5px]"
+                      />
                     </Field>
                   </div>
                   <Field label="Default domain">
-                    <Input defaultValue={ws?.defaultDomain} className="font-mono text-[12.5px]" />
+                    <Input
+                      value={draft.defaultDomain}
+                      onChange={(e) => set("defaultDomain", e.target.value)}
+                      className="font-mono text-[12.5px]"
+                    />
                   </Field>
-                  <Field label="Default redirect type" help="Applies to new links. Any link can override it.">
+                  <Field
+                    label="Default redirect type"
+                    help="Applies to new links. Any link can override it."
+                    error={problem ?? undefined}
+                  >
                     <Segmented<RedirectType>
-                      value={redirect}
-                      onChange={setRedirect}
+                      value={draft.defaultRedirect}
+                      onChange={(v) => set("defaultRedirect", v)}
                       options={[
                         { value: "301", label: "301" },
                         { value: "302", label: "302" },
@@ -52,6 +114,16 @@ export default function SettingsPage() {
                       ]}
                     />
                   </Field>
+                  <div className="flex items-center gap-2">
+                    <Button variant="primary" onClick={submit} disabled={!dirty || save.isPending}>
+                      {save.isPending ? "Saving…" : "Save changes"}
+                    </Button>
+                    {dirty ? (
+                      <Button onClick={() => setDraft(ws ? draftOf(ws) : null)}>Discard</Button>
+                    ) : (
+                      <span className="text-[12px] text-ink-3">{save.isSuccess ? "Saved." : "No unsaved changes."}</span>
+                    )}
+                  </div>
                 </>
               )}
             </CardBody>
@@ -141,27 +213,27 @@ export default function SettingsPage() {
             <CardHeader title="Privacy & data" />
             <CardBody className="flex flex-col gap-3">
               <Toggle
-                checked={privacy.cookieless}
-                onChange={(v) => setPrivacy((p) => ({ ...p, cookieless: v }))}
+                checked={draft?.cookielessAnalytics ?? true}
+                onChange={(v) => set("cookielessAnalytics", v)}
                 title="Cookieless analytics"
                 description="Visitors are counted server-side with a daily-rotating hash. Nothing is stored on their device."
               />
               <Toggle
-                checked={privacy.scan}
-                onChange={(v) => setPrivacy((p) => ({ ...p, scan: v }))}
+                checked={draft?.scanOnCreate ?? true}
+                onChange={(v) => set("scanOnCreate", v)}
                 title="Scan destinations on create"
-                description="Checks every new link against Google Safe Browsing."
+                description="Checks every new link against Google Safe Browsing. Needs GOOGLE_SAFE_BROWSING_API_KEY to be set."
               />
               <Toggle
-                checked={privacy.previews}
-                onChange={(v) => setPrivacy((p) => ({ ...p, previews: v }))}
+                checked={draft?.publicPreviews ?? true}
+                onChange={(v) => set("publicPreviews", v)}
                 title="Allow public link previews"
                 description="Anyone can add + to a link to see where it goes first."
               />
-              <Field label="Click data retention">
+              <Field label="Click data retention" help="Rollups are kept regardless; this is how long the raw click rows live.">
                 <Segmented
-                  value={retention}
-                  onChange={setRetention}
+                  value={retentionValue(draft?.retentionYears ?? 3)}
+                  onChange={(v) => set("retentionYears", v === "forever" ? FOREVER_YEARS : Number(v))}
                   options={[
                     { value: "1", label: "1 year" },
                     { value: "3", label: "3 years" },

--- a/web/src/app/(app)/team/page.tsx
+++ b/web/src/app/(app)/team/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { PageHead } from "@/components/app-shell";
-import { Button, Card, CardBody, CardHeader, Chip, Skeleton, Table, TableWrap, Td, Th, Toggle } from "@/components/ui";
-import { useAudit, useMembers } from "@/lib/api/hooks";
+import { Button, Card, CardBody, CardHeader, Chip, Field, Input, Segmented, Skeleton, Table, TableWrap, Td, Th, Toggle } from "@/components/ui";
+import { useAudit, useChangeMemberRole, useInviteMember, useMembers, useRemoveMember } from "@/lib/api/hooks";
+import { InviteMemberInput, type MemberRole } from "@snapurl/contract";
 import { useState } from "react";
 import { cn, full } from "@/lib/utils";
 
@@ -19,10 +20,71 @@ const PERMISSIONS: { label: string; roles: [boolean, boolean, boolean, boolean] 
 
 const AVATAR_TONES = ["bg-accent", "bg-teal", "bg-violet", "bg-amber", "bg-good"];
 
+/* Owner is excluded: transferring ownership is a role change on an existing
+   member, not something you can hand out with an invitation. */
+const INVITE_ROLES: { value: Exclude<MemberRole, "owner">; label: string }[] = [
+  { value: "viewer", label: "Viewer" },
+  { value: "editor", label: "Editor" },
+  { value: "admin", label: "Admin" },
+];
+
+const ROLE_OPTIONS: { value: MemberRole; label: string }[] = [...INVITE_ROLES, { value: "owner", label: "Owner" }];
+
 export default function TeamPage() {
   const { data: members, isLoading } = useMembers();
   const { data: audit } = useAudit();
   const [requireSso, setRequireSso] = useState(true);
+
+  const invite = useInviteMember();
+  const changeRole = useChangeMemberRole();
+  const removeMember = useRemoveMember();
+
+  const [inviting, setInviting] = useState(false);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Exclude<MemberRole, "owner">>("editor");
+  const [problem, setProblem] = useState<string | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  async function sendInvite() {
+    const parsed = InviteMemberInput.safeParse({ email: email.trim(), role });
+    if (!parsed.success) {
+      setProblem(parsed.error.issues[0]?.message ?? "That doesn't look like an email address.");
+      return;
+    }
+    try {
+      await invite.mutateAsync(parsed.data);
+      setEmail("");
+      setInviting(false);
+      setProblem(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
+
+  async function setMemberRole(id: string, next: MemberRole) {
+    setProblem(null);
+    try {
+      await changeRole.mutateAsync({ id, role: next });
+      setEditing(null);
+    } catch (err) {
+      // "This is the only owner" arrives here, and is the whole reason the
+      // API refuses rather than letting a workspace become unadministrable.
+      setProblem((err as Error).message);
+      setEditing(null);
+    }
+  }
+
+  async function remove(id: string) {
+    setProblem(null);
+    try {
+      await removeMember.mutateAsync(id);
+      setConfirming(null);
+    } catch (err) {
+      setProblem((err as Error).message);
+      setConfirming(null);
+    }
+  }
 
   return (
     <>
@@ -32,10 +94,46 @@ export default function TeamPage() {
         actions={
           <>
             <Button>Audit log</Button>
-            <Button variant="primary">＋ Invite</Button>
+            <Button variant="primary" onClick={() => { setInviting((v) => !v); setProblem(null); }}>
+              {inviting ? "Cancel" : "＋ Invite"}
+            </Button>
           </>
         }
       />
+
+      {inviting ? (
+        <Card className="mb-3.5">
+          <CardHeader title="Invite a teammate" />
+          <CardBody className="flex flex-col gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-3 items-end">
+              <Field label="Email" error={problem ?? undefined}>
+                <Input
+                  value={email}
+                  autoFocus
+                  placeholder="teammate@example.com"
+                  onChange={(e) => { setEmail(e.target.value); setProblem(null); }}
+                  onKeyDown={(e) => { if (e.key === "Enter") void sendInvite(); }}
+                />
+              </Field>
+              <Field label="Role">
+                <Segmented value={role} onChange={setRole} options={INVITE_ROLES} />
+              </Field>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="primary" onClick={sendInvite} disabled={invite.isPending || !email.trim()}>
+                {invite.isPending ? "Sending…" : "Send invitation"}
+              </Button>
+              <Button onClick={() => { setInviting(false); setProblem(null); }}>Cancel</Button>
+            </div>
+          </CardBody>
+        </Card>
+      ) : null}
+
+      {problem && !inviting ? (
+        <Card className="mb-3.5 border-bad">
+          <CardBody className="text-[13px] text-bad">{problem}</CardBody>
+        </Card>
+      ) : null}
 
       <Card className="mb-3.5">
         <CardHeader title="Members" />
@@ -88,10 +186,37 @@ export default function TeamPage() {
                     <Td>
                       {m.status === "invited" ? "—" : <Chip tone={m.twoFactor ? "good" : "warn"}>{m.twoFactor ? "On" : "Off"}</Chip>}
                     </Td>
-                    <Td className="text-right">
-                      <Button size="sm" variant="ghost">
-                        {m.status === "invited" ? "Resend" : "⋯"}
-                      </Button>
+                    <Td className="text-right whitespace-nowrap">
+                      {editing === m.id ? (
+                        <div className="inline-flex items-center gap-2">
+                          <Segmented
+                            value={m.role}
+                            onChange={(next) => setMemberRole(m.id, next)}
+                            options={ROLE_OPTIONS}
+                          />
+                          <Button size="sm" variant="ghost" onClick={() => setEditing(null)}>
+                            Done
+                          </Button>
+                        </div>
+                      ) : confirming === m.id ? (
+                        <>
+                          <Button size="sm" variant="ghost" onClick={() => setConfirming(null)}>
+                            Keep
+                          </Button>
+                          <Button size="sm" variant="danger" onClick={() => remove(m.id)} disabled={removeMember.isPending}>
+                            Remove
+                          </Button>
+                        </>
+                      ) : (
+                        <>
+                          <Button size="sm" variant="ghost" onClick={() => { setEditing(m.id); setProblem(null); }}>
+                            Change role
+                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => { setConfirming(m.id); setProblem(null); }}>
+                            Remove
+                          </Button>
+                        </>
+                      )}
                     </Td>
                   </tr>
                 ))}

--- a/web/src/app/p/[slug]/page.tsx
+++ b/web/src/app/p/[slug]/page.tsx
@@ -1,15 +1,45 @@
 "use client";
 
-import { useParams } from "next/navigation";
-import { Button, Chip, ErrorState, Skeleton } from "@/components/ui";
-import { useLinkPreview } from "@/lib/api/hooks";
+import { useParams, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { Button, Chip, ErrorState, Field, Input, Skeleton } from "@/components/ui";
+import { useLinkPreview, useUnlockLink } from "@/lib/api/hooks";
 import { formatDate, relativeDate } from "@/lib/utils";
+
+/** shortUrl is "domain/slug" with no scheme; localhost is the dev redirect. */
+function withUnlockKey(shortUrl: string, token: string): string {
+  const scheme = /^(localhost|127\.0\.0\.1)/.test(shortUrl) ? "http" : "https";
+  const url = new URL(/^https?:\/\//.test(shortUrl) ? shortUrl : `${scheme}://${shortUrl}`);
+  url.searchParams.set("k", token);
+  return url.toString();
+}
 
 /* The public trust page. Anyone can reach it by adding "+" to a short link;
    the redirect service rewrites that to /p/<slug>. No auth, no cookies. */
 export default function LinkPreviewPage() {
   const { slug } = useParams<{ slug: string }>();
+  /* G3 — the redirect service bounces a password-protected link here as
+     ?unlock=1 and waits for the visitor to come back with ?k=<token>. The
+     page ignored the parameter entirely, so those links were unreachable:
+     the redirect sent people to a page that offered no way to continue. */
+  const unlockRequested = useSearchParams().get("unlock") === "1";
   const { data, isLoading, isError, error, refetch } = useLinkPreview(slug);
+  const unlock = useUnlockLink(slug);
+
+  const [password, setPassword] = useState("");
+  const [problem, setProblem] = useState<string | null>(null);
+
+  async function submitPassword() {
+    if (!password) return;
+    try {
+      const { unlockToken } = await unlock.mutateAsync({ password });
+      // The token is bound to this link and expires in five minutes, so it is
+      // handed straight back to the redirect rather than kept anywhere.
+      window.location.href = withUnlockKey(data!.shortUrl, unlockToken);
+    } catch (err) {
+      setProblem((err as Error).message);
+    }
+  }
 
   return (
     <div className="max-w-[560px] mx-auto px-6 pt-[60px] pb-20">
@@ -93,6 +123,33 @@ export default function LinkPreviewPage() {
                 </div>
               ))}
             </div>
+
+            {unlockRequested ? (
+              <div className="px-6 pt-[18px] pb-[6px]">
+                <Field
+                  label="This link is password protected"
+                  help="Ask whoever shared it for the password. We check it on the server and never store it in your browser."
+                  error={problem ?? undefined}
+                >
+                  <Input
+                    type="password"
+                    value={password}
+                    autoFocus
+                    placeholder="Password"
+                    onChange={(e) => { setPassword(e.target.value); setProblem(null); }}
+                    onKeyDown={(e) => { if (e.key === "Enter") void submitPassword(); }}
+                  />
+                </Field>
+                <Button
+                  variant="primary"
+                  className="justify-center w-full mt-3"
+                  onClick={submitPassword}
+                  disabled={unlock.isPending || !password}
+                >
+                  {unlock.isPending ? "Checking…" : "Unlock and continue"}
+                </Button>
+              </div>
+            ) : null}
 
             <div className="px-6 pt-[18px] pb-[22px] flex flex-col gap-[9px]">
               <a


### PR DESCRIPTION
## What does this PR do?

Fixes #213

> ### ⚠️ Stacked on #222
> Base is `claude/snapurl-issue-210`, not `main` — every control here calls a hook that #222 adds. **Merge #222 first**; GitHub retargets this automatically. The diff shown is this issue's work alone: 9 files, +997 / −90.

Roughly thirty-five controls had no handler while the endpoint behind each one was already implemented. This connects them.

| Area | What now works |
| --- | --- |
| **Settings** | Name, slug, default domain, redirect type, retention, all three privacy toggles — held in state, saved as a partial `PATCH` |
| **Domains** | Add, check DNS (verify), disconnect |
| **Members** | Invite with role, change role, remove |
| **API keys** | Create with scope picker, revoke |
| **Webhooks** | Create with event picker, delete |
| **Bio pages** | Create, publish/unpublish, delete |
| **Range selectors** | Analytics and conversions, all five `AnalyticsRange` windows |
| **Links** | Search, tag, folder and domain filters; real cursor paging |
| **`/p/[slug]`** | The unlock form for password-protected links |

### Settings was the worst of it

Every field used `defaultValue` with no `onChange`, and there was **no save button anywhere on the page**. A change appeared to take effect and reverted on the next reload with nothing to indicate it had not been kept — the failure mode where a user believes retention is set to 1 year and it is still 3.

The form is now held in state and sent as a partial `PATCH`, with Save disabled until something actually differs from what the server returned, and a Discard next to it.

### Two decisions worth your eye

**"Forever" retention → 100 years.** Retention is offered as three choices but stored as `retentionYears` (int, max 100 in the contract). "Forever" has to land on a number; 100 is the maximum and is past the lifetime of any link anyone is planning for. If you'd rather the option didn't exist, that is a smaller change than inventing a nullable column.

**The links page no longer filters client-side.** It used to re-filter the returned rows by status. The server already returns the right page, so filtering again could only *hide rows from a page that was already correct* — visibly wrong the moment paging exists. Search is debounced at 250 ms, and any query change resets the page position, which is the only correct thing to do with a cursor.

There is deliberately **no "jump to page 7"**: G4 chose a cursor over an offset precisely because it cannot serve one. Back and forward is what a cursor can do honestly.

### Secrets get a panel, not a toast

API keys and webhook signing secrets are returned exactly once — only a hash is stored. A dismissed toast would mean reissuing, so both get a persistent panel that says so.

### `/p/[slug]` unlock

`apps/redirect/src/main.ts:94` has been bouncing password-protected links to `/p/<slug>?unlock=1` all along, and the page ignored the parameter — so those links were unreachable: the redirect sent people to a page offering no way to continue. The form posts the password, and the returned token goes straight back to the redirect as `?k=` rather than being stored anywhere; it lives five minutes and is bound to one link id.

## Requirement/Documentation

- Issue #213 is the specification, including its exclusions: the routing-rules editor (#214 — a design problem, not a wiring one) and SSO/billing (no backend exists).
- `docs/DECISIONS.md` G3 (unlock token), G4 (cursor over offset) and Part 4 (the frontend follow-up table) all describe what this implements. Nothing is contradicted.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

`USE_FIXTURES` defaults on, so `pnpm dev:web` exercises everything — #222's fixture stores are mutable, so creates, edits and deletes persist across renders.

1. **Settings** — change the name, toggle a privacy switch, pick 1-year retention. Save enables only when something differs. Save, reload, confirm it stuck.
2. **Domains** — add `go.example.com`, see it appear as *Verifying DNS* with its TXT record, hit *Check DNS*, watch it go live. Disconnect, and read the warning.
3. **Team** — invite an address as Viewer; change a role; remove someone.
4. **Developers** — create a key, confirm the full key panel appears once; revoke it. Same for a webhook and its signing secret.
5. **Bio pages** — create a draft, publish it, delete it.
6. **Links** — type in the search box, pick a tag/folder/domain, page forward and back. Filters should survive paging and reset the page position when changed.
7. **`/p/<slug>?unlock=1`** — the password form appears; a wrong password shows the API's own message.

| Command | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | pass |
| `pnpm type-check` | pass — 7 packages |
| `pnpm build` | pass |
| `pnpm test` | pass — 83 tests |

## Checklist

- Every input validated against the contract schema that the API enforces (`AddDomainInput`, `InviteMemberInput`, `UpsertBioPageInput`), rather than a second copy that can drift.
- Server errors surfaced where the action was taken — "This is the only owner", "the TXT record isn't there yet", "that domain isn't yours" are all information the user needs, not console noise.
- Checked `bg-accent-wash` and the `danger` button variant exist before using them; my first draft used a `bg-wash-accent` token that does not.
- `PUT /bio-pages` replaces the whole page, so publishing sends the blocks back with it — sending only the status would have silently emptied the page.
- No new dependencies, no new UI primitive.
- Untouched by policy: `verify.yml`, `pnpm-workspace.yaml`, `tsconfig.base.json`, `docker-compose.yml`, `designs/`.

## Noticed but not fixed

1. **Conflicts with #224 in two files.** #217 removes the SSO card from `team/page.tsx` and a line from `p/[slug]/page.tsx`; this PR edits both files elsewhere. The hunks look disjoint, but if git disagrees, **take #224's deletions and this PR's additions** — they are independent changes.
2. **Tag and folder options come from the current page of links**, because no endpoint enumerates them. Enough to reach the filters; not a complete list of what exists in the workspace. A `GET /links/facets` would fix it properly.
3. **The `Domain` contract has no `isSystem` field**, so the UI cannot grey out Disconnect on the shared short domain. It offers the button and surfaces the API's 403 ("that domain isn't yours"). Adding the field would let the UI be honest up front.
4. **Still dead on pages I touched**: Export, Bulk create, Schedule report, Export CSV, Define an event, Install tracking, Templates, Theme, Manage billing, Report this link, and the link detail page's Copy link / Share report. None has an endpoint — they are product gaps, not wiring gaps, which is why the issue scoped them out.
5. **The members table still shows "Invited 2 days ago"** as a literal string for pending invites. `Member` carries no `invitedAt`, so there is nothing real to render; it wants a contract field rather than a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_