### PR TITLE
feat(web): a routing rules editor, replacing four rules that were props

### DIFF
--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./routing": {
+      "types": "./dist/routing.d.ts",
+      "default": "./dist/routing.js"
     }
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@snapurl/contract':
         specifier: workspace:*
         version: link:../packages/contract
+      '@snapurl/domain':
+        specifier: workspace:*
+        version: link:../packages/domain
       '@tanstack/react-query':
         specifier: ^5.90.5
         version: 5.102.5(react@19.1.0)

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@snapurl/contract": "workspace:*",
+    "@snapurl/domain": "workspace:*",
     "@tanstack/react-query": "^5.90.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/web/src/components/links/create-link-drawer.tsx
+++ b/web/src/components/links/create-link-drawer.tsx
@@ -3,8 +3,9 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { Button, Chip, Field, Input, SectionLabel, Segmented, Toggle } from "@/components/ui";
+import { Button, Field, Input, SectionLabel, Segmented, Toggle } from "@/components/ui";
 import { QrPreview } from "@/components/qr/qr-preview";
+import { RoutingRulesEditor } from "@/components/links/routing-rules-editor";
 import { useCreateLink, useDomains } from "@/lib/api/hooks";
 import { CreateLinkInput, type CreateLinkFormValues, type RedirectType } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -208,18 +209,17 @@ export function CreateLinkDrawer({ open, onClose }: { open: boolean; onClose: ()
                 >
                   <div />
                 </Field>
-                <div className="flex flex-col gap-[9px]">
-                  <RuleRow when="If country is India" to="acme.in/spring" />
-                  <RuleRow when="If device is iOS" to="apps.apple.com/acme" />
-                  <RuleRow when="If device is Android" to="play.google.com/acme" />
-                  <RuleRow when="Everything else" to={destination || "your destination"} fallback badge="A/B 50-50" />
-                  <button
-                    type="button"
-                    className="px-3 py-2 border border-dashed border-line-2 rounded-[var(--radius-sm)] text-ink-3 text-[12px] hover:border-accent hover:text-accent"
-                  >
-                    ＋ Add rule
-                  </button>
-                </div>
+                <Controller
+                  control={control}
+                  name="rules"
+                  render={({ field }) => (
+                    <RoutingRulesEditor
+                      value={field.value ?? []}
+                      onChange={field.onChange}
+                      fallbackDestination={destination}
+                    />
+                  )}
+                />
 
                 <SectionLabel>Redirect behaviour</SectionLabel>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -439,32 +439,5 @@ export function CreateLinkDrawer({ open, onClose }: { open: boolean; onClose: ()
         </form>
       </aside>
     </>
-  );
-}
-
-function RuleRow({
-  when,
-  to,
-  fallback,
-  badge,
-}: {
-  when: string;
-  to: string;
-  fallback?: boolean;
-  badge?: string;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-[9px] px-3 py-2 rounded-[var(--radius-sm)] border justify-between",
-        fallback ? "border-dashed border-line-2 bg-transparent" : "border-line bg-surface",
-      )}
-    >
-      <span className="text-[12px] text-ink-2">{when}</span>
-      <div className="flex items-center gap-2">
-        {badge ? <Chip tone="accent">{badge}</Chip> : null}
-        <span className="font-mono text-[11.5px] text-teal truncate max-w-[200px]">{to}</span>
-      </div>
-    </div>
   );
 }

--- a/web/src/components/links/routing-rules-editor.tsx
+++ b/web/src/components/links/routing-rules-editor.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { Button, Chip, Input } from "@/components/ui";
+import type { DeviceType, RoutingRule } from "@snapurl/contract";
+import { validateRoutingChain } from "@snapurl/domain/routing";
+import { cn } from "@/lib/utils";
+
+/* ============================================================
+   The routing chain editor.
+
+   The drawer used to render four hardcoded rows from a presentational-only
+   component — country IN, iOS, Android, and a 50/50 split — with an add button
+   that had no handler. None of it was ever submitted: `rules` went to the API
+   as an empty array every time, so the headline feature on the landing page
+   ("Route by anything") produced links that routed by nothing.
+
+   Everything behind it was already built: validateRoutingChain and
+   evaluateRouting in packages/domain, persisted by LinksService.create and
+   executed by apps/redirect. This is the missing input surface.
+   ============================================================ */
+
+/** The four conditions a rule can carry. "Everything else" is the catch-all. */
+type ConditionKind = "any" | "country" | "device" | "language";
+
+const CONDITIONS: { value: ConditionKind; label: string }[] = [
+  { value: "any", label: "Everything else" },
+  { value: "country", label: "Country is" },
+  { value: "device", label: "Device is" },
+  { value: "language", label: "Language is" },
+];
+
+const DEVICES: DeviceType[] = ["ios", "android", "desktop", "mobile"];
+
+const SELECT_CLASS =
+  "px-[9px] py-[6px] bg-surface border border-line-2 rounded-[var(--radius-sm)] text-[12.5px] text-ink-2";
+
+function kindOf(rule: RoutingRule): ConditionKind {
+  if (rule.when.country) return "country";
+  if (rule.when.device) return "device";
+  if (rule.when.language) return "language";
+  return "any";
+}
+
+const isCatchAll = (rule: RoutingRule) => kindOf(rule) === "any";
+
+/** Rules are identified by id in the contract and by nothing else here. */
+function newId() {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? `rule_${crypto.randomUUID().slice(0, 8)}`
+    : `rule_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function RoutingRulesEditor({
+  value,
+  onChange,
+  fallbackDestination,
+}: {
+  value: RoutingRule[];
+  onChange: (rules: RoutingRule[]) => void;
+  /** Where a visitor lands when nothing matches — the link's own destination. */
+  fallbackDestination: string;
+}) {
+  const rules = value ?? [];
+
+  /* The same function the API validates with on save, so the feedback here is
+     the feedback there. Duplicating the rules in the browser is exactly the
+     drift this project already removed once. */
+  const problems = validateRoutingChain(rules);
+
+  const replace = (index: number, next: RoutingRule) =>
+    onChange(rules.map((rule, i) => (i === index ? next : rule)));
+
+  const setKind = (index: number, kind: ConditionKind) => {
+    const rule = rules[index]!;
+    // Only one condition at a time: a rule matching country AND device is
+    // expressible in the contract but not something this UI should invent.
+    const when = { country: null, device: null, language: null } as RoutingRule["when"];
+    if (kind === "country") when.country = "IN";
+    if (kind === "device") when.device = "ios";
+    if (kind === "language") when.language = "en";
+    // Weight only means anything on a catch-all, so drop it when conditions appear.
+    replace(index, { ...rule, when, weight: kind === "any" ? rule.weight : null });
+  };
+
+  const move = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= rules.length) return;
+    const next = [...rules];
+    [next[index], next[target]] = [next[target]!, next[index]!];
+    onChange(next);
+  };
+
+  const add = (weighted = false) =>
+    onChange([
+      ...rules,
+      {
+        id: newId(),
+        when: { country: null, device: null, language: null },
+        then: "",
+        weight: weighted ? 50 : null,
+      },
+    ]);
+
+  /** Two weighted catch-alls at 50/50 is the shape an A/B test actually needs. */
+  const startSplit = () =>
+    onChange([
+      ...rules,
+      { id: newId(), when: { country: null, device: null, language: null }, then: "", weight: 50 },
+      { id: newId(), when: { country: null, device: null, language: null }, then: "", weight: 50 },
+    ]);
+
+  const weightedCount = rules.filter((r) => isCatchAll(r) && (r.weight ?? 0) > 0).length;
+
+  return (
+    <div className="flex flex-col gap-[9px]">
+      {rules.length === 0 ? (
+        <div className="px-3 py-3 border border-dashed border-line-2 rounded-[var(--radius-sm)] text-[12px] text-ink-3 leading-[1.55]">
+          No rules yet — every visitor goes to{" "}
+          <span className="font-mono text-teal">{fallbackDestination || "your destination"}</span>. Add a rule to send
+          some of them somewhere else.
+        </div>
+      ) : null}
+
+      {rules.map((rule, i) => {
+        const kind = kindOf(rule);
+        return (
+          <div
+            key={rule.id}
+            className={cn(
+              "flex flex-col gap-2 px-3 py-[10px] rounded-[var(--radius-sm)] border",
+              isCatchAll(rule) ? "border-dashed border-line-2" : "border-line bg-surface",
+            )}
+          >
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-mono text-[10px] text-ink-3 w-[16px] shrink-0">{i + 1}</span>
+
+              <select
+                className={SELECT_CLASS}
+                value={kind}
+                onChange={(e) => setKind(i, e.target.value as ConditionKind)}
+                aria-label={`Rule ${i + 1} condition`}
+              >
+                {CONDITIONS.map((c) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+
+              {kind === "country" ? (
+                <Input
+                  value={rule.when.country ?? ""}
+                  onChange={(e) =>
+                    replace(i, { ...rule, when: { ...rule.when, country: e.target.value.toUpperCase().slice(0, 2) } })
+                  }
+                  placeholder="IN"
+                  aria-label={`Rule ${i + 1} country`}
+                  className="w-[70px] font-mono text-[12.5px] uppercase"
+                />
+              ) : null}
+
+              {kind === "device" ? (
+                <select
+                  className={SELECT_CLASS}
+                  value={rule.when.device ?? "ios"}
+                  onChange={(e) => replace(i, { ...rule, when: { ...rule.when, device: e.target.value as DeviceType } })}
+                  aria-label={`Rule ${i + 1} device`}
+                >
+                  {DEVICES.map((d) => (
+                    <option key={d} value={d}>
+                      {d}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+
+              {kind === "language" ? (
+                <Input
+                  value={rule.when.language ?? ""}
+                  onChange={(e) =>
+                    replace(i, { ...rule, when: { ...rule.when, language: e.target.value.toLowerCase().slice(0, 5) } })
+                  }
+                  placeholder="en"
+                  aria-label={`Rule ${i + 1} language`}
+                  className="w-[70px] font-mono text-[12.5px]"
+                />
+              ) : null}
+
+              {isCatchAll(rule) && (rule.weight ?? 0) > 0 ? (
+                <span className="inline-flex items-center gap-1">
+                  <Input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={rule.weight ?? 0}
+                    onChange={(e) => replace(i, { ...rule, weight: Number(e.target.value) })}
+                    aria-label={`Rule ${i + 1} weight`}
+                    className="w-[64px] font-mono text-[12.5px] tnum"
+                  />
+                  <span className="text-[12px] text-ink-3">%</span>
+                </span>
+              ) : null}
+
+              <div className="ml-auto flex items-center gap-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Move rule ${i + 1} up`}
+                  disabled={i === 0}
+                  onClick={() => move(i, -1)}
+                >
+                  ↑
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Move rule ${i + 1} down`}
+                  disabled={i === rules.length - 1}
+                  onClick={() => move(i, 1)}
+                >
+                  ↓
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Remove rule ${i + 1}`}
+                  onClick={() => onChange(rules.filter((_, j) => j !== i))}
+                >
+                  ✕
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <span className="text-[12px] text-ink-3 shrink-0">go to</span>
+              <Input
+                value={rule.then}
+                onChange={(e) => replace(i, { ...rule, then: e.target.value })}
+                placeholder="https://example.com/somewhere-else"
+                aria-label={`Rule ${i + 1} destination`}
+                className="font-mono text-[12px]"
+              />
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="flex gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={() => add()}
+          className="px-3 py-2 border border-dashed border-line-2 rounded-[var(--radius-sm)] text-ink-3 text-[12px] hover:border-accent hover:text-accent"
+        >
+          ＋ Add rule
+        </button>
+        {weightedCount === 0 ? (
+          <button
+            type="button"
+            onClick={startSplit}
+            className="px-3 py-2 border border-dashed border-line-2 rounded-[var(--radius-sm)] text-ink-3 text-[12px] hover:border-accent hover:text-accent"
+          >
+            ＋ Add 50/50 split test
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => add(true)}
+            className="px-3 py-2 border border-dashed border-line-2 rounded-[var(--radius-sm)] text-ink-3 text-[12px] hover:border-accent hover:text-accent"
+          >
+            ＋ Add split arm
+          </button>
+        )}
+        {weightedCount > 1 ? <Chip tone="accent">A/B across {weightedCount} arms</Chip> : null}
+      </div>
+
+      {problems.length > 0 ? (
+        /* Shown as you type rather than on submit. The API rejects the same
+           chain with the same sentences, so this is a preview of that refusal,
+           not a second opinion about it. */
+        <div className="px-[11px] py-[9px] bg-wash-warn rounded-[var(--radius-sm)] flex flex-col gap-1">
+          {problems.map((problem) => (
+            <span key={problem} className="text-[12px] text-amber leading-[1.5]">
+              {problem}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {rules.length > 0 && problems.length === 0 ? (
+        <span className="text-[11.5px] text-ink-3 leading-[1.5]">
+          Checked top to bottom at the edge. Anything matching nothing falls through to{" "}
+          <span className="font-mono text-teal">{fallbackDestination || "your destination"}</span>.
+        </span>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #214

> ### ⚠️ Stacked on #222
> Base is `claude/snapurl-issue-210`. Merge #222 first; GitHub retargets automatically. Diff shown is this issue's work alone.

The Routing tab rendered four hardcoded rows — country IN, iOS, Android, a 50/50 split — from a component that took **strings** and had no state. The add button had no handler, and `rules` submitted as an empty array every time.

So the landing page's headline feature, *"Route by anything"*, produced links that routed by nothing — while showing the author a convincing picture of the rules they were about to get. That is the part worth fixing beyond the missing feature: it did not look broken.

Everything underneath was already built and tested — `validateRoutingChain` and `evaluateRouting` in `packages/domain`, persisted by `LinksService.create`, executed by `apps/redirect`. Only the input surface was missing.

## The design decisions

This is the UX problem #214 separated from the mechanical wiring, so here is what I chose and why:

**One condition per rule.** `RoutingRule.when` permits country *and* device *and* language together, but a row offering all three invites chains nobody can reason about. First-match-wins ordering is the better tool for compound intent, and it is the semantic the evaluator actually implements. Switching the condition type resets the others rather than leaving a hidden constraint.

**Weights only on catch-all rules.** That is the only place `evaluateRouting` reads them. Switching a rule from "Everything else" to a condition **clears its weight**, rather than leaving a number that silently stopped mattering.

**"Add 50/50 split test" adds two arms at once.** One weighted rule is not a split, and `validateRoutingChain` rejects it — so offering a single "add weighted rule" button would walk every user into an error state on their first click.

**Validation is live, and it is the API's own.** `validateRoutingChain` is imported and run as you type, so the sentences shown are the sentences the API would refuse with — "Split weights add up to 90%, not 100%", "2 rules after 'everything else' can never match." Reimplementing those rules in the browser is exactly the drift #210 just finished removing from `types.ts`.

**Ordering is explicit.** Up/down buttons rather than drag-and-drop: the chain is first-match-wins, so position is semantics, not decoration — and it needs to work by keyboard.

## The one dependency question

Reaching `validateRoutingChain` from the browser required **a `./routing` subpath export on `@snapurl/domain`**, plus that workspace package as a `web` dependency.

I want to flag this against "do not add dependencies": it is **not a third-party package** — it is a first-party workspace package already built and type-checked in CI, added exactly as #210 added `@snapurl/contract`. The lockfile diff is 3 lines:

```
+      '@snapurl/domain':
+        specifier: workspace:*
+        version: link:../packages/domain
```

The subpath matters: the package **root** also exports `slug.ts` and `visitor.ts`, which import `node:crypto`. Importing `@snapurl/domain` wholesale from a client component would drag that into the browser bundle. `@snapurl/domain/routing` is pure — no clock, no randomness, no I/O.

If you would rather not have `web` depend on `domain` at all, the fallback is dropping live validation and letting the API's 400 surface on submit; the drawer already renders `create.error`. Say the word and I will swap it.

## Requirement/Documentation

- Issue #214 is the specification, including its instruction that the fake rows should be deleted rather than left implying a feature that does not work.
- `packages/domain/src/routing.ts` documents the semantics this UI exposes — first match wins, `mobile` as a family, weights keyed on the visitor hash so a returning visitor stays in the same bucket.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

`USE_FIXTURES` defaults on, so `pnpm dev:web` → Links → **＋ New link** → **Routing**.

1. **Empty state** names the fallback destination rather than showing invented rules.
2. **Add rule** → pick *Country is* → `IN` → a destination. Add another for *Device is iOS*. Reorder with ↑/↓.
3. **Add 50/50 split test** → two arms at 50 each. Change one to 40 and the warning appears live: *"Split weights add up to 90%, not 100%."* Fix it and the warning clears.
4. Add a rule **below** an unweighted "Everything else" → *"1 rule after 'everything else' can never match. Move them above it."*
5. Two rules with identical conditions → *"Two rules have identical conditions — the second can never match."*
6. Create the link and confirm `rules` is actually submitted — previously always `[]`.

| Command | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | pass |
| `pnpm type-check` | pass — 7 packages |
| `pnpm build` | pass |
| `pnpm test` | pass — 83 tests |

## Checklist

- The fake `RuleRow` component is deleted, not left orphaned; `Chip` became an unused import with it and was removed too.
- Every control has an `aria-label` and the ordering works by keyboard — position is semantics here.
- Validation imported from `@snapurl/domain/routing`, never reimplemented.
- No third-party dependency added.
- Untouched by policy: `verify.yml`, `pnpm-workspace.yaml`, `tsconfig.base.json`, `docker-compose.yml`, `designs/`.

## Noticed but not fixed

1. **The link detail page renders rules read-only and cannot edit them.** `UpdateLinkInput` accepts `rules`, so the editor could be reused there — but that page is #212's, and putting the editor in two PRs at once would collide. Natural follow-up.
2. **`RoutingRule.when` still permits combined conditions** through the API even though this UI offers one at a time. A chain built via the API with `{country, device}` renders here as country-only and would lose the device condition if re-saved. Constraining the contract, or supporting compound conditions in the UI, is a product decision.
3. **No preview of where a given visitor would land.** `evaluateRouting` is pure and takes a `VisitorContext`, so a "test this chain as an iOS visitor from India" panel is very reachable, and would answer the question the editor raises.
4. **Weights accept any number 0–100** with no help toward summing to 100 beyond the warning. A "distribute evenly" button would be kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_