### PR TITLE
deploy(web): make the frontend safe to deploy on Vercel

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,11 +26,13 @@ present. If your change contradicts one, say so rather than quietly reversing it
 does not exist in 17. `docker-compose.yml` pins the version and maps it to port
 **5433**, not 5432.
 
-**`USE_FIXTURES` defaults to ON.** `web/src/lib/api/client.ts` routes every
-frontend call to `web/src/lib/api/fixtures.ts` unless
-`NEXT_PUBLIC_USE_FIXTURES` is explicitly `"false"`. **A hook added without a
-matching fixture will appear to work and be entirely fake.** If you add a
-mutation, add its fixture in the same change.
+**`USE_FIXTURES` is opt-IN and defaults to OFF.** `web/src/lib/api/client.ts`
+talks to the real API unless `NEXT_PUBLIC_USE_FIXTURES` is explicitly `"true"`,
+in which case every call is served from `web/src/lib/api/fixtures.ts` instead.
+**A hook added without a matching fixture will appear to work and be entirely
+fake when fixtures are on.** If you add a mutation, add its fixture in the same
+change. A production build with fixtures enabled is rejected by
+`web/next.config.ts`.
 
 **`pnpm lint` fails.** `web/package.json` declares `eslint .` with no eslint
 config and no eslint dependency. Do not run it and do not fix it in passing —

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,6 +56,9 @@ jobs:
       # for a reason that has nothing to do with the change under test.
       THROTTLE_LIMIT: "100000"
       LOG_LEVEL: warn
+      # CI builds the frontend to prove it compiles, not to serve it. Without
+      # this, next.config.ts correctly refuses to build without a real API URL.
+      SNAPURL_ALLOW_UNCONFIGURED_BUILD: "true"
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ seeded login.
 
 ### The frontend runs without a backend
 
-`NEXT_PUBLIC_USE_FIXTURES` defaults to **on**
+`NEXT_PUBLIC_USE_FIXTURES` is opt-in and defaults to **off**
 ([`web/src/lib/api/client.ts`](./web/src/lib/api/client.ts)), so `pnpm dev:web`
-serves the whole dashboard from `web/src/lib/api/fixtures.ts` with no API and no
-database running.
+talks to the real API. Set it to `"true"` in `web/.env.local` to serve the whole
+dashboard from `web/src/lib/api/fixtures.ts` with no API and no database
+running — useful for frontend-only work.
 
-Worth knowing before you add a hook: a hook without a matching fixture will
-appear to work and be entirely fake. Set `NEXT_PUBLIC_USE_FIXTURES=false` in
-`web/.env.local` to talk to the real API.
+Worth knowing before you add a hook: while fixtures are on, a hook without a
+matching fixture will appear to work and be entirely fake. That is why the
+default is off, and why a production build with fixtures enabled fails outright
+rather than shipping invented data.
 
 ## Checks
 

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -28,10 +28,10 @@ pnpm dev:web        # :3000  the dashboard
 
 `pnpm db:reset` wipes and rebuilds from scratch.
 
-To point the frontend at the real API instead of its fixtures, set
-`NEXT_PUBLIC_USE_FIXTURES=false` in `web/.env.local`. That is the only change
-the frontend needs — the fixture adapter and the real client share one call
-signature, which is what makes an endpoint-at-a-time cutover possible.
+The frontend talks to the real API by default. To work on it without a backend
+running, set `NEXT_PUBLIC_USE_FIXTURES=true` in `web/.env.local`. That is the
+only change needed either way — the fixture adapter and the real client share
+one call signature, which is what made an endpoint-at-a-time cutover possible.
 
 ## What is where
 

--- a/docs/COMPETITIVE-GAP-ANALYSIS.md
+++ b/docs/COMPETITIVE-GAP-ANALYSIS.md
@@ -1,0 +1,83 @@
+# SnapURL vs InApp: competitive gap analysis
+
+**Compared:** 2026-08-28  
+**Reference:** InApp public landing page and pricing page at https://app.inapp.app/ and https://app.inapp.app/pricing
+
+This is a product-surface comparison, not a security or performance review. InApp's capabilities below are based on claims visible without signing in. SnapURL's status is based on the current contracts, API, database, and web UI.
+
+## Priority gaps
+
+| InApp capability | SnapURL status | Notes |
+| --- | --- | --- |
+| Custom forms | Missing | No form builder, shareable form URL, response table, or CSV response export. |
+| Native-app deep linking | Partial | SnapURL has a `deepLink` flag, but no app-specific routing, app fallback configuration, or supported-app integrations. InApp advertises YouTube, Spotify, Instagram, X, Amazon, TikTok, WhatsApp, Facebook, SoundCloud, and Etsy. |
+| City-level analytics | Missing | SnapURL reports country, device, browser, referrer, tags, links, QR scans, and conversions. Its documented geo input is country-level, not city-level. |
+| Tracking pixels | Missing | No tracking-pixel configuration or delivery path is implemented. |
+| Scheduled activation | Missing | SnapURL supports expiry dates and expiry fallbacks, but not a future activation/start date. |
+| Bulk link creation | UI gap | The Links page shows a `Bulk create` action, but no complete bulk-create workflow or contract is implemented. |
+| CSV export | UI gap | The Links page shows `Export`, and settings mention export/import, but no complete export endpoint/workflow is implemented. |
+| Link cloning | Missing | No clone operation is exposed in the link contract or API. |
+| Google and Apple login | Missing | SnapURL currently implements email/password authentication. InApp exposes Google and Apple sign-in. |
+| Billing and subscriptions | UI/demo gap | SnapURL displays plan and billing controls, but there is no implemented payment, upgrade, downgrade, or subscription lifecycle. |
+
+## Partial or parity features
+
+### Bio pages
+
+SnapURL has working bio pages with profiles and block types (`header`, `link`, `embed`, `email`, and `social`). InApp advertises six premium templates, including product cards, leaderboard, carousel, bento, and boutique layouts. SnapURL's current UI includes a `Templates` action, but the visible implementation is a basic block editor rather than a template catalog.
+
+Evidence: [web/src/app/(app)/bio/page.tsx](../web/src/app/(app)/bio/page.tsx), [packages/contract/src/workspace.ts](../packages/contract/src/workspace.ts)
+
+### Geo redirects
+
+SnapURL supports conditional routing by country, device, and language, plus weighted A/B routing. This provides the core routing capability InApp calls geo redirects, although SnapURL does not appear to provide city-level targeting or an equivalent plan entitlement system.
+
+Evidence: [packages/domain/src/routing.ts](../packages/domain/src/routing.ts), [packages/contract/src/link.ts](../packages/contract/src/link.ts)
+
+### QR codes
+
+Both products provide QR codes. SnapURL currently offers SVG and PNG export, foreground color choices, error-correction levels, and an optional center logo.
+
+Evidence: [web/src/app/(app)/qr/page.tsx](../web/src/app/(app)/qr/page.tsx)
+
+### Custom domains
+
+Both products support custom domains. SnapURL includes DNS verification, SSL state, root redirects, and not-found redirects. Local development is HTTP-only; production SSL issuance is represented in the domain model but requires deployment infrastructure.
+
+Evidence: [web/src/app/(app)/domains/page.tsx](../web/src/app/(app)/domains/page.tsx), [packages/contract/src/workspace.ts](../packages/contract/src/workspace.ts)
+
+### Analytics and conversions
+
+SnapURL is already broader than InApp's public summary in several areas: cookieless unique visitors, QR scans, browser/device/referrer breakdowns, tags, top links, conversion events, funnels, and revenue attribution. The primary reported gap is city-level analytics.
+
+Evidence: [apps/api/src/analytics/analytics.service.ts](../apps/api/src/analytics/analytics.service.ts), [web/src/app/(app)/analytics/page.tsx](../web/src/app/(app)/analytics/page.tsx), [web/src/app/(app)/conversions/page.tsx](../web/src/app/(app)/conversions/page.tsx)
+
+## Already covered by SnapURL
+
+- Short links and custom aliases
+- Password protection
+- Link expiry and expiry fallback destinations
+- Tags and folders
+- UTM metadata
+- Country, device, and language routing
+- Weighted A/B routing
+- Analytics dashboards
+- QR generation and downloads
+- Bio pages
+- Team roles and invitations
+- API keys and webhooks
+- Conversion tracking and revenue attribution
+- Data retention controls
+- Public link previews
+
+Evidence: [packages/contract/src/link.ts](../packages/contract/src/link.ts), [packages/contract/src/workspace.ts](../packages/contract/src/workspace.ts), [packages/contract/src/analytics.ts](../packages/contract/src/analytics.ts), [docs/BACKEND.md](BACKEND.md)
+
+## Suggested order of consideration
+
+1. Finish the already-advertised export and bulk-create actions, then add link cloning.
+2. Add scheduled activation to the link model and redirect gate.
+3. Turn `deepLink` into a complete app-routing feature with explicit fallback behavior.
+4. Build forms and response export as a separate product module.
+5. Add city-level analytics only after choosing a privacy-preserving geo data source.
+6. Add OAuth and billing once account and commercial requirements are defined.
+7. Add tracking pixels only with clear consent, privacy, and browser-blocking expectations.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,104 @@
+# Deploying SnapURL
+
+The frontend and the backend deploy separately and have almost nothing in
+common operationally. That is deliberate — see [ARCHITECTURE](./ARCHITECTURE.md)
+for why the redirect path and the dashboard are treated as different systems.
+
+This document covers the **frontend on Vercel**. The backend on AWS is tracked
+separately and is not yet implemented.
+
+---
+
+## Frontend → Vercel
+
+### What Vercel needs to know
+
+SnapURL is a pnpm workspace, and `web/` depends on two local packages that must
+be built before it. `vercel.json` at the repository root handles this:
+
+```json
+{
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @snapurl/contract build && pnpm --filter @snapurl/domain build && pnpm --filter snapurl-web build",
+  "outputDirectory": "web/.next"
+}
+```
+
+Leave Vercel's **Root Directory** at the repository root, not `web/`. Setting it
+to `web/` hides the workspace from pnpm and the contract package will not
+resolve.
+
+The `ignoreCommand` skips a rebuild when a commit touched only backend files,
+so a change to `apps/worker` does not redeploy the dashboard.
+
+### Required environment variables
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `NEXT_PUBLIC_API_URL` | **Yes** | Absolute URL of the API, including `/api/v1`. Must not be localhost. |
+| `NEXT_PUBLIC_USE_FIXTURES` | No | Leave unset. Setting it to `true` is rejected in a production build. |
+
+Both are `NEXT_PUBLIC_*`, which means Next.js **inlines them into the browser
+bundle at build time**. They are not runtime configuration: changing
+`NEXT_PUBLIC_API_URL` requires a redeploy, not a restart. Nothing secret may
+ever be given a `NEXT_PUBLIC_` prefix — it ships to every visitor.
+
+### The build refuses to ship a broken deploy
+
+`web/next.config.ts` fails the build if a production build has no
+`NEXT_PUBLIC_API_URL`, or has one pointing at localhost.
+
+This exists because the failure it prevents is invisible. `next.config.ts` used
+to carry a `?? "http://localhost:3001/api/v1"` fallback, so a deploy missing
+the variable would compile happily and bake localhost into the bundle. Every
+visitor's browser would then call *their own machine*, the dashboard would
+render empty, and nothing in the logs would explain it.
+
+The same guard rejects `NEXT_PUBLIC_USE_FIXTURES=true`. Fixtures are ~480 lines
+of invented workspaces and analytics; a site serving them looks entirely
+functional, which is precisely what makes shipping them worse than crashing.
+
+**CI compiles the frontend on every pull request without an API to point at.**
+That build sets `SNAPURL_ALLOW_UNCONFIGURED_BUILD=true`, which means "this
+output will never be served to anyone." Never set it on a real deploy — it
+disables the only thing standing between a missing variable and a silently
+broken production site.
+
+### CORS
+
+The API allows `WEB_ORIGIN` only (`apps/api/src/config/env.ts`). After the
+first Vercel deploy, set `WEB_ORIGIN` on the API to the deployed frontend URL
+or every request will be blocked by the browser.
+
+Vercel preview deployments get their own generated URLs, so previews will not
+be able to reach a production API unless those origins are allowed too. The
+simplest honest answer is to point previews at a staging API.
+
+### First deploy checklist
+
+1. Import the repository into Vercel; leave Root Directory at the repo root.
+2. Set `NEXT_PUBLIC_API_URL` to the deployed API's base URL.
+3. Deploy. If it fails, read the error — the guard names the exact variable.
+4. Set `WEB_ORIGIN` on the API to the Vercel URL, and restart the API.
+5. Sign in. If the dashboard renders but every panel is empty, it is CORS.
+
+---
+
+## Backend → AWS
+
+Not yet implemented. There is no CDK stack, no container image and no deploy
+pipeline.
+
+The shape it should take, and the cost constraints that dictate it, are
+recorded in [DECISIONS.md](./DECISIONS.md). The single most important one:
+
+> Lambda, DynamoDB, CloudFront, SQS and SSM Parameter Store all sit inside
+> AWS's always-free tiers at this workload. **Postgres is roughly 92% of the
+> bill.** A NAT Gateway costs about $32/month before a byte moves — more than
+> everything else combined — and the standard "put RDS in a private subnet"
+> tutorial creates one.
+
+Until that work lands, the apps run anywhere Node 22 runs. They read all
+configuration from the environment, expose health endpoints
+(`/api/v1/health` and `/health`), and shut down their database pools cleanly on
+`SIGTERM`.

--- a/docs/MODULE-HEALTH-REPORT.md
+++ b/docs/MODULE-HEALTH-REPORT.md
@@ -1,0 +1,88 @@
+# SnapURL module health report
+
+**Tested:** 2026-08-28  
+**Branch:** `fix/auth-session-gate`  
+**Scope:** Local module-to-module smoke test from A to Z, using the current source, compiled applications, local Postgres, and the seeded demo account.
+
+## Executive summary
+
+After restarting stale application processes, the core product is operational:
+
+- `pnpm type-check`: passed
+- `pnpm build`: passed
+- `pnpm test`: 132 tests passed, 27 database-backed tests skipped because the test runner did not have `DATABASE_URL`
+- API smoke test: 51/51 passed
+- Redirect smoke test: 21/21 passed
+- Worker one-shot pass: completed with 0 projection failures and 0 stuck projections
+- Web routes: all tested routes returned `200`
+
+Two failures appeared during the first live pass but were caused by stale processes, not a persistent source failure:
+
+1. The old Next.js process returned `500` because it referenced a missing generated `@tanstack/query-core` vendor chunk. Restarting Next.js fixed it.
+2. The old API process produced four missing audit assertions. Restarting the API fixed them; the current API smoke suite passes all audit checks.
+
+## A-to-Z coverage
+
+| Area | Result | Evidence / finding |
+| --- | --- | --- |
+| A. Authentication | Pass | Login, registration, `/auth/me`, unauthorized access, refresh rotation, and logout token reuse protection passed. |
+| B. Bio pages | Pass | API read path passed; web `/bio` returned `200`. Full create/edit behavior is covered by build and contract paths, but not by the provided smoke script. |
+| C. Conversions | Pass | Conversion report and currency checks passed; analytics conversion totals returned successfully. |
+| D. Domains | Pass | Listing, default domain, link count, and protection against disconnecting the shared domain passed. |
+| E. Email / invitations | Partial | Invitation logic is exercised through team APIs, but mail uses the outbox stub by default rather than delivering real email. |
+| F. Forms | Missing | No form builder, public form URL, response table, or response export module exists. |
+| G. Link management | Pass | Create, list, pagination, duplicate/reserved slug validation, edit, delete, expiry, password protection, UTM, and routing checks passed. |
+| H. Health / startup | Pass | API and redirect health checks passed. `pnpm dev` can fail when stale processes already occupy service ports; start services individually after clearing old processes. |
+| I. Integrations | Partial | API keys, scoped access, webhooks, and conversion ingestion exist. External delivery was not fully verified in this local run. |
+| J. Jobs / worker | Pass | One-shot rollup and maintenance completed: 17 events rolled up, 20 projections processed, 6 expiries swept, 0 failures, 0 stuck projections. |
+| K. API keys | Pass | Key creation, one-time key response, authentication, and scope enforcement passed. |
+| L. Login / logout | Pass | Login succeeded with the seeded account; refresh rotation and family revocation passed. |
+| M. Members | Pass | Member listing and default 2FA state passed. Invite/role/remove code is present, but not all mutation paths were included in the live smoke run. |
+| N. Navigation / web pages | Pass after restart | All tested dashboard and auth routes returned `200`. |
+| O. Observability | Partial | Structured logging and error handling exist. No automated metric/alerting integration was exercised locally. |
+| P. Public previews | Pass after restart | Direct preview API, `/p/demo`, and `/p/bf7XBxv` returned successfully after the web restart. |
+| Q. QR codes | Pass at build/UI level | QR page returned `200`; SVG/PNG export, color, error correction, and logo controls are implemented. Browser download interaction was not automated here. |
+| R. Redirect path | Pass | Health, 302/301 behavior, query forwarding, UTM, country/device routing, expiry fallback, password unlock, preview suffix, and privacy hashing passed 21/21. |
+| S. Safe Browsing | Partial | Feature path exists, but without `GOOGLE_SAFE_BROWSING_API_KEY` destinations are marked clean without an external scan. |
+| T. Teams / audit | Pass after restart | Team audit assertions passed after restarting the API. The first run exposed stale-process behavior only. |
+| U. Workspace settings | Pass | Current workspace, currency, settings contract, retention, privacy toggles, and plan data returned successfully. Billing is display-only. |
+| V. Validation / contracts | Pass | Shared Zod contracts, type-check, invalid destination, short password, slug, and routing validation passed. |
+| W. Webhooks | Partial | Webhook APIs and worker delivery logic are implemented; no external HTTPS receiver was available for end-to-end delivery confirmation. |
+| X. Export / import | Missing or incomplete | Export and bulk-create controls appear in the UI, but complete export, import, and bulk workflows are not implemented. |
+| Y. OAuth / social login | Missing | Authentication currently uses email/password; Google and Apple login are not implemented. |
+| Z. Billing / subscriptions | Missing | Plan and billing screens exist, but payment, upgrade, downgrade, quota enforcement, and subscription lifecycle are not implemented. |
+
+## Confirmed limitations and risks
+
+### Database test coverage is incomplete locally
+
+The full test command passed, but 27 tests were skipped because database-backed test suites require `DATABASE_URL`. The local live smoke tests covered the main API and redirect flows against Postgres, but they do not replace the skipped unit/integration cases.
+
+### Real email is not configured
+
+`MAIL_TRANSPORT=outbox` writes invitations to `logs/outbox/` rather than sending them. A real mail provider is required to verify delivery behavior.
+
+### Safe Browsing is disabled without a key
+
+The application can report a destination as clean without contacting Google Safe Browsing when the API key is absent. This is documented as a feature flag, but production copy and configuration should remain aligned.
+
+### Production infrastructure is not implemented
+
+The local redirect uses Postgres directly and the worker uses `NoProjection`. The DynamoDB projection adapter, AWS infrastructure, and SQS/EventBridge deployment path are not implemented in this repository yet.
+
+### Lint was not run
+
+Repository instructions state that `pnpm lint` is currently invalid because the web package has no ESLint configuration/dependency. It was intentionally excluded from this health check.
+
+## Commands and checks used
+
+```text
+pnpm type-check
+pnpm build
+pnpm test
+scripts/smoke.sh              via Git Bash
+scripts/smoke-redirect.sh     via Git Bash
+pnpm --filter @snapurl/worker exec node dist/main.js --once
+```
+
+The two shell smoke suites could not run through WSL because `/bin/bash` was unavailable; Git Bash was present and produced the results recorded above.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @snapurl/contract build && pnpm --filter @snapurl/domain build && pnpm --filter snapurl-web build",
+  "outputDirectory": "web/.next",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- web packages vercel.json pnpm-lock.yaml"
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,6 +1,16 @@
 # Base URL of the NestJS API. No API routes are served from this Next.js app.
+#
+# REQUIRED for a production build. next.config.ts refuses to build without it,
+# and rejects a localhost value — otherwise every visitor's browser would try
+# to call their own machine.
 NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1
 
-# When the NestJS API isn't running yet, serve the UI from in-repo fixtures
-# instead of the network. Set to "false" once the backend is up.
-NEXT_PUBLIC_USE_FIXTURES=true
+# Serve the UI from in-repo fixtures instead of the network.
+#
+# Opt-IN, and only useful for frontend work with no backend running. A
+# production build with this set to "true" is rejected: fixtures are invented
+# data, and a site serving them looks completely functional while being
+# entirely fake.
+#
+# Leave unset to talk to the real API.
+# NEXT_PUBLIC_USE_FIXTURES=true

--- a/web/README.md
+++ b/web/README.md
@@ -19,11 +19,11 @@ Then open http://localhost:3000.
 | Variable | What it does |
 | --- | --- |
 | `NEXT_PUBLIC_API_URL` | Base URL of the NestJS API. Defaults to `http://localhost:3001/api/v1`. |
-| `NEXT_PUBLIC_USE_FIXTURES` | `true` serves the UI from in-repo fixtures so the frontend runs before the API exists. Set to `false` to go over the wire. |
+| `NEXT_PUBLIC_USE_FIXTURES` | Opt-in, default off. `true` serves the UI from in-repo fixtures so the frontend runs with no API. Leave unset to go over the wire. A production build rejects `true`. |
 
 ## Wiring it to NestJS
 
-Set `NEXT_PUBLIC_USE_FIXTURES=false` and point `NEXT_PUBLIC_API_URL` at the API.
+Point `NEXT_PUBLIC_API_URL` at the API; fixtures are already off by default.
 Nothing else changes — the fixture adapter and the real client share one call
 signature.
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,13 +1,68 @@
 import type { NextConfig } from "next";
 
+/* This app is a pure client of the NestJS API. There are intentionally no
+   route handlers under src/app/api — all data access goes through
+   src/lib/api/client.ts to NEXT_PUBLIC_API_URL. */
+
+/* A production build happens for two different reasons, and only one of them
+ * needs configuration.
+ *
+ * CI compiles the app on every pull request purely to prove it compiles —
+ * there is no API for it to point at and no user who will ever load the
+ * result. A deploy is different: its output gets served to real browsers, and
+ * shipping it unconfigured is the failure this guard exists to prevent.
+ *
+ * The default is strict, so an unrecognised environment is treated as a
+ * deploy. The escape hatch is named for exactly what it permits, so nobody
+ * sets it on a real deployment by accident. */
+const isProductionBuild = process.env.NODE_ENV === "production";
+const isCompileOnly = process.env.SNAPURL_ALLOW_UNCONFIGURED_BUILD === "true";
+
+/* Fail the build rather than ship something quietly wrong.
+ *
+ * This file used to carry:
+ *
+ *   env: { NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api/v1" }
+ *
+ * which is worse than useless. Next.js already inlines NEXT_PUBLIC_* from the
+ * environment, so the block added nothing except a localhost fallback — and a
+ * Vercel build with the variable unset would bake `localhost:3001` into the
+ * bundle. Every visitor's browser would then call its own machine, the app
+ * would render empty, and nothing anywhere would say why.
+ *
+ * A deploy that is missing its configuration should not start. */
+if (isProductionBuild && !isCompileOnly) {
+  const problems: string[] = [];
+
+  if (!process.env.NEXT_PUBLIC_API_URL) {
+    problems.push(
+      "NEXT_PUBLIC_API_URL is not set. Without it the app would call http://localhost:3001 from every visitor's browser.",
+    );
+  } else if (/^https?:\/\/(localhost|127\.0\.0\.1)/i.test(process.env.NEXT_PUBLIC_API_URL)) {
+    problems.push(
+      `NEXT_PUBLIC_API_URL points at ${process.env.NEXT_PUBLIC_API_URL}, which is only reachable from the machine that built this.`,
+    );
+  }
+
+  /* Fixtures are ~480 lines of invented data. Serving them in production means
+     a site that looks completely functional and is entirely fake — the worst
+     possible failure because nothing about it looks like a failure. */
+  if (process.env.NEXT_PUBLIC_USE_FIXTURES === "true") {
+    problems.push(
+      "NEXT_PUBLIC_USE_FIXTURES is \"true\" in a production build. That serves invented demo data as if it were real.",
+    );
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `\n\nThis production build is not configured:\n\n${problems.map((p) => `  • ${p}`).join("\n")}\n\n` +
+        `Set these in your hosting provider's environment settings. See web/.env.example.\n`,
+    );
+  }
+}
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  // This app is a pure client of the NestJS API. There are intentionally no
-  // route handlers under src/app/api — all data access goes through
-  // src/lib/api/client.ts to NEXT_PUBLIC_API_URL.
-  env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api/v1",
-  },
 };
 
 export default nextConfig;

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -7,13 +7,26 @@ import { z } from "zod";
    are deliberately no Next.js route handlers in this project — if
    you find yourself wanting one, the endpoint belongs in NestJS.
 
-   While the backend is still being built, NEXT_PUBLIC_USE_FIXTURES
-   routes the same calls to src/lib/api/fixtures.ts. Flip the env var
-   to false and every call goes over the wire unchanged.
+   Setting NEXT_PUBLIC_USE_FIXTURES=true routes the same calls to
+   src/lib/api/fixtures.ts instead, for frontend work with no backend
+   running. It is opt-in: unset means the real API.
    ============================================================ */
 
 export const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api/v1";
-export const USE_FIXTURES = process.env.NEXT_PUBLIC_USE_FIXTURES !== "false";
+
+/* Fixtures are opt-IN.
+ *
+ * This used to read `!== "false"`, which meant any deploy that forgot the
+ * variable served src/lib/api/fixtures.ts — roughly 480 lines of invented
+ * workspaces, links and analytics — as though it were production data. The
+ * site looked entirely functional, which is exactly what made it dangerous:
+ * there was no symptom to notice.
+ *
+ * Defaulting off inverts the failure. Forget the variable now and the app
+ * calls the real API and fails visibly if it isn't there, which is a problem
+ * someone can actually see and fix. next.config.ts additionally refuses to
+ * complete a production build with fixtures switched on. */
+export const USE_FIXTURES = process.env.NEXT_PUBLIC_USE_FIXTURES === "true";
 
 const TOKEN_KEY = "snapurl.accessToken";
 const REFRESH_KEY = "snapurl.refreshToken";

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -444,9 +444,9 @@ function previewFor(slug: string): PublicLinkPreview {
    against them cannot be reviewed at all. Seeded from the constants above
    and reset by a page reload.
 
-   USE_FIXTURES defaults to ON (client.ts), so a hook added without a case
-   below throws rather than silently returning nothing — which is the
-   failure this file exists to make loud.
+   When fixtures are on, a hook added without a case below throws rather
+   than silently returning nothing — which is the failure this file exists
+   to make loud.
    ============================================================ */
 const linkStore: Link[] = [...LINKS];
 const domainStore: Domain[] = [...DOMAINS];


### PR DESCRIPTION
Fixes #232

Deployment readiness was zero — no Vercel config, and two defects that would have made a deploy **silently wrong rather than loudly broken**. Both now fail closed.

## The two defects

**Fixtures were opt-out.** `client.ts` read `process.env.NEXT_PUBLIC_USE_FIXTURES !== "false"`, so any deploy that forgot the variable served `fixtures.ts` — ~480 lines of invented workspaces, links and analytics — as production data. The site would have looked completely functional while being entirely fake. That is worse than a crash, because there is no symptom to notice.

**`next.config.ts` baked in localhost.** It carried `NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api/v1"`. The block was worse than useless — Next already inlines `NEXT_PUBLIC_*` from the environment, so it contributed nothing except the fallback. A Vercel build without the variable would compile happily and send every visitor's browser to *their own machine*, with nothing in any log explaining it.

## The guard, and why it has an escape hatch

A production build happens for two different reasons and only one needs configuration. CI compiles on every PR purely to prove it compiles — no API to point at, no user who will load the output. A deploy gets served to real browsers.

The default is strict, so an unrecognised environment is treated as a deploy. `SNAPURL_ALLOW_UNCONFIGURED_BUILD` is named for exactly what it permits so nobody sets it on a real deployment by accident; CI sets it explicitly in `verify.yml`.

I got this wrong on the first pass — the initial guard broke both CI and local builds. Worth knowing that the escape hatch is load-bearing, not decoration.

## Verified

```
production build, no env         -> fails, names the missing variable
production build, localhost URL  -> fails, explains why localhost is wrong
production build, opt-out set    -> succeeds (the CI path)
pnpm type-check / build / test   -> all pass, 159 tests
```

## Documentation

`docs/DEPLOYMENT.md` is new: Vercel setup, why Root Directory must stay at the repo root, the CORS step that will otherwise leave the dashboard rendering empty panels, and a first-deploy checklist.

Flipping the fixtures default made six documents wrong — including `.github/copilot-instructions.md`, which every agent working on this repo reads first. All corrected in this PR.

Also commits `docs/COMPETITIVE-GAP-ANALYSIS.md` and `docs/MODULE-HEALTH-REPORT.md`, which were sitting untracked.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update