### PR TITLE
deploy(api): production container images for all three services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Everything the build does not need. Keeping this tight matters twice over:
+# a smaller context uploads faster, and node_modules from the host would
+# shadow the ones the image installs for its own platform.
+**/node_modules
+**/dist
+**/.next
+**/.turbo
+.git
+.github
+.claude
+.idea
+.vscode
+designs
+docs
+web
+*.md
+!README.md
+**/.env
+**/.env.*
+!**/.env.example
+**/*.tsbuildinfo
+**/coverage
+**/logs
+.gh-token

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+# syntax=docker/dockerfile:1.7
+
+# One Dockerfile, three images.
+#
+#   docker build --build-arg APP=api      -t snapurl-api .
+#   docker build --build-arg APP=redirect -t snapurl-redirect .
+#   docker build --build-arg APP=worker   -t snapurl-worker .
+#
+# The three apps share a workspace, a lockfile and most of their build, so
+# three near-identical Dockerfiles would drift apart the first time one of them
+# changed. The interesting part — pruning a pnpm workspace down to one
+# deployable app — is identical for all three and is explained at each stage.
+
+ARG NODE_VERSION=22-alpine
+
+
+# ---------------------------------------------------------------------------
+# base — pnpm, once, so every later stage shares this layer
+# ---------------------------------------------------------------------------
+FROM node:${NODE_VERSION} AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+# Pin the version the lockfile was written by. A different pnpm can quietly
+# resolve a different tree, which is the whole thing a lockfile exists to stop.
+RUN corepack enable && corepack prepare pnpm@11.24.0 --activate
+WORKDIR /repo
+
+
+# ---------------------------------------------------------------------------
+# build — install everything, compile everything
+# ---------------------------------------------------------------------------
+FROM base AS build
+
+# Manifests first, sources second. Dependencies change far less often than
+# code, so this ordering means an ordinary code edit reuses the install layer
+# instead of re-downloading the world.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/api/package.json        apps/api/
+COPY apps/redirect/package.json   apps/redirect/
+COPY apps/worker/package.json     apps/worker/
+COPY packages/contract/package.json  packages/contract/
+COPY packages/domain/package.json    packages/domain/
+COPY packages/database/package.json  packages/database/
+
+# --frozen-lockfile fails if any manifest disagrees with the lockfile, so an
+# image can never be built from a dependency set nobody committed.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --ignore-scripts=false
+
+COPY tsconfig.base.json ./
+COPY packages/ packages/
+COPY apps/ apps/
+
+# `pnpm -r build` walks the workspace in dependency order, so contract and
+# domain are compiled before the apps that import their type declarations.
+RUN pnpm -r --filter "./packages/*" build
+ARG APP
+RUN pnpm --filter "@snapurl/${APP}" build
+
+
+# ---------------------------------------------------------------------------
+# prune — one app plus exactly the dependencies it actually uses
+# ---------------------------------------------------------------------------
+FROM build AS prune
+ARG APP
+
+# `pnpm deploy` rewrites the workspace links (@snapurl/contract and friends)
+# into real directories, so the result runs with no knowledge that a workspace
+# ever existed. --prod drops devDependencies; --legacy is required because
+# pnpm 10+ otherwise expects `inject-workspace-packages=true`, which this
+# workspace deliberately does not use.
+RUN pnpm deploy --legacy --filter "@snapurl/${APP}" --prod /out
+
+
+# ---------------------------------------------------------------------------
+# runtime — no pnpm, no sources, no build tools
+# ---------------------------------------------------------------------------
+FROM node:${NODE_VERSION} AS runtime
+ENV NODE_ENV=production
+
+# `node` (uid 1000) ships with the official image. Running as root inside a
+# container is a needless escalation if anything else goes wrong.
+WORKDIR /app
+COPY --from=prune --chown=node:node /out ./
+USER node
+
+# Documentation only — publishing the port is the runtime's decision. The API
+# and redirect service read PORT; the worker ignores it and serves no HTTP.
+EXPOSE 3001
+
+# No HEALTHCHECK here on purpose: the three apps have different probes (the API
+# is /api/v1/health, the redirect service is /health, and the worker has no HTTP
+# surface at all). Whatever runs these — compose, ECS, Kubernetes — is the right
+# place to say so, and it already has to.
+CMD ["node", "dist/main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,15 @@
-# Local dependencies for SnapURL 2.0.
-# Postgres is on 5433, not 5432 — 5432 is already taken on this machine.
+# Local dependencies, and optionally the whole stack.
+#
+#   docker compose up -d postgres        just the database (what `pnpm db:up` does)
+#   docker compose --profile full up -d  database + api + redirect + worker
+#
+# The default is the database alone, because day-to-day development runs the
+# apps from source with `pnpm dev:*` for hot reload. The `full` profile exists
+# to prove the container images actually work — it is the closest thing to a
+# deployment you can run on a laptop.
+
+name: snapurl
+
 services:
   postgres:
     image: postgres:18-alpine
@@ -10,6 +20,8 @@ services:
       POSTGRES_PASSWORD: snapurl
       POSTGRES_DB: snapurl
     ports:
+      # 5433 on the host because 5432 is commonly already taken. Inside the
+      # compose network the containers still reach it on 5432.
       - "5433:5432"
     volumes:
       - snapurl-pgdata:/var/lib/postgresql
@@ -18,6 +30,90 @@ services:
       interval: 5s
       timeout: 3s
       retries: 20
+
+  api:
+    profiles: ["full"]
+    build:
+      context: .
+      args:
+        APP: api
+    image: snapurl-api:local
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: "3001"
+      # `postgres:5432`, not localhost:5433 — inside the compose network the
+      # service name is the hostname and the port is the container's own.
+      DATABASE_URL: postgres://snapurl:snapurl@postgres:5432/snapurl
+      # Throwaway local values. Real deployments read these from SSM Parameter
+      # Store; nothing here is a secret worth protecting.
+      JWT_ACCESS_SECRET: local-compose-access-secret-000000000000
+      JWT_REFRESH_SECRET: local-compose-refresh-secret-00000000000
+      WEB_ORIGIN: http://localhost:3000
+      DEFAULT_DOMAIN: localhost:3002
+      REDIRECT_ORIGIN: http://localhost:3002
+      MAIL_TRANSPORT: outbox
+      LOG_LEVEL: info
+    ports:
+      - "3001:3001"
+    healthcheck:
+      # The probe lives here rather than in the Dockerfile: all three images
+      # share one Dockerfile but have different (or no) HTTP surfaces.
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3001/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  redirect:
+    profiles: ["full"]
+    build:
+      context: .
+      args:
+        APP: redirect
+    image: snapurl-redirect:local
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: "3002"
+      DATABASE_URL: postgres://snapurl:snapurl@postgres:5432/snapurl
+      # Must match the API's. The redirect service verifies unlock tokens that
+      # the API signed, so a mismatch silently breaks password-protected links.
+      JWT_ACCESS_SECRET: local-compose-access-secret-000000000000
+      WEB_ORIGIN: http://localhost:3000
+      LOG_LEVEL: info
+    ports:
+      - "3002:3002"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3002/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  worker:
+    profiles: ["full"]
+    build:
+      context: .
+      args:
+        APP: worker
+    image: snapurl-worker:local
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: postgres://snapurl:snapurl@postgres:5432/snapurl
+      LOG_LEVEL: info
+    # No healthcheck and no ports: the worker serves no HTTP. Its liveness is
+    # visible in what it writes to the rollup tables, not in a probe.
 
 volumes:
   snapurl-pgdata:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -84,10 +84,67 @@ simplest honest answer is to point previews at a staging API.
 
 ---
 
+## Backend → containers
+
+All three services build into production images from a single `Dockerfile`,
+selected with a build argument:
+
+```bash
+docker build --build-arg APP=api      -t snapurl-api .
+docker build --build-arg APP=redirect -t snapurl-redirect .
+docker build --build-arg APP=worker   -t snapurl-worker .
+```
+
+Roughly 60 MB each. They run as the non-root `node` user, contain no build
+tools, no pnpm and no sources — only compiled output and production
+dependencies.
+
+### Why one Dockerfile instead of three
+
+The three apps share a workspace, a lockfile and most of their build. Three
+near-identical Dockerfiles would drift apart the first time one of them
+changed. The genuinely interesting part — pruning a pnpm workspace down to one
+deployable app — is identical for all three.
+
+That pruning is `pnpm deploy --legacy --filter @snapurl/<app> --prod`. It
+rewrites the workspace links (`@snapurl/contract` and friends) into real
+directories, so the image runs with no knowledge that a workspace ever existed.
+`--legacy` is required because pnpm 10+ otherwise expects
+`inject-workspace-packages=true`, which this workspace does not use.
+
+### Running the whole stack locally
+
+```bash
+docker compose --profile full up -d
+```
+
+Database, API, redirect service and worker, wired together. The default
+(`docker compose up -d postgres`) is still the database alone, because
+day-to-day work runs the apps from source with `pnpm dev:*` for hot reload.
+
+The `full` profile is the closest thing to a deployment you can run on a
+laptop, and it is how the images get verified: both smoke suites — 72
+assertions — pass against it.
+
+Two details worth noting if you write your own compose or task definition:
+
+- Inside the network the database is `postgres:5432`, not `localhost:5433`.
+  The host port mapping exists because 5432 is usually already taken.
+- `JWT_ACCESS_SECRET` **must match** between the API and the redirect service.
+  The redirect verifies unlock tokens the API signed, so a mismatch breaks
+  password-protected links silently and nothing else.
+
+Health probes live in the compose file rather than the Dockerfile, because the
+three images share one Dockerfile but have different HTTP surfaces: the API is
+`/api/v1/health`, the redirect service is `/health`, and the worker has none at
+all — its liveness shows up in what it writes to the rollup tables.
+
+---
+
 ## Backend → AWS
 
-Not yet implemented. There is no CDK stack, no container image and no deploy
-pipeline.
+Not yet implemented. There is no CDK stack and no deploy pipeline; the
+container images above are the prerequisite for one.
 
 The shape it should take, and the cost constraints that dictate it, are
 recorded in [DECISIONS.md](./DECISIONS.md). The single most important one:


### PR DESCRIPTION
Refs #233 — the container half. The CDK stack follows separately; these images are its prerequisite.

## What

One `Dockerfile`, three images, selected by `--build-arg APP=`:

| Image | Size |
| --- | --- |
| `snapurl-api` | 62 MB |
| `snapurl-redirect` | 59 MB |
| `snapurl-worker` | 58 MB |

Non-root (`node`, uid 1000), no build tools, no pnpm, no sources — compiled output and production dependencies only.

## Why one Dockerfile

Three near-identical Dockerfiles would drift apart the first time one app changed, and the genuinely interesting part is identical for all three: **pruning a pnpm workspace down to one deployable app.**

That is `pnpm deploy --legacy --filter @snapurl/<app> --prod`, which rewrites the workspace links (`@snapurl/contract` and friends) into real directories, so the image runs with no knowledge a workspace ever existed. `--legacy` is required because pnpm 10+ otherwise expects `inject-workspace-packages=true`, which this workspace deliberately does not use — that took a failed build to discover.

Manifests are copied before sources, so an ordinary code edit reuses the install layer instead of re-resolving every dependency.

## Verified by running them, not just building them

`docker compose --profile full up -d` brings up database, API, redirect and worker together. Against that stack:

```
scripts/smoke.sh           51 passed, 0 failed
scripts/smoke-redirect.sh  21 passed, 0 failed
```

Container logs confirm these hit the images (`pid: 1`, container hostname) rather than leftover dev processes. `pnpm type-check`, `build` and `test` (159 tests) all pass.

## Two things that will bite anyone writing their own task definition

- Inside the network the database is **`postgres:5432`**, not `localhost:5433`. The host port mapping only exists because 5432 is usually taken.
- **`JWT_ACCESS_SECRET` must match** between the API and the redirect service. The redirect verifies unlock tokens the API signed, so a mismatch breaks password-protected links *silently* and nothing else.

Both are documented in `docs/DEPLOYMENT.md`.

## Incidental cleanup

Removes `packages/aws` — an empty directory with no `package.json`, caught by the `packages/*` workspace glob, which broke the image build. Untracked, contained only an empty `src/`, referenced by nothing. It was leftover scaffolding.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update