### PR TITLE
feat(links): CSV export, and the CDK stack behind it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,3 +93,37 @@ EXPOSE 3001
 # surface at all). Whatever runs these — compose, ECS, Kubernetes — is the right
 # place to say so, and it already has to.
 CMD ["node", "dist/main.js"]
+
+
+# ---------------------------------------------------------------------------
+# lambda-web — the API and redirect service, unchanged, on Lambda
+# ---------------------------------------------------------------------------
+# The AWS Lambda Web Adapter is an extension that speaks the Lambda runtime API
+# on one side and plain HTTP on the other. That means the application needs no
+# Lambda-specific code at all: the image starts the same Fastify server that
+# `docker compose --profile full` runs, and the adapter translates.
+#
+# The alternative -- @fastify/aws-lambda or serverless-express -- would have
+# meant refactoring both entrypoints to separate "build the app" from "start
+# listening", for a runtime that cannot be tested locally. This way what runs
+# in Lambda is byte-for-byte the image whose smoke suite passed.
+FROM runtime AS lambda-web
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
+# The adapter connects to the app on this port and waits for the readiness
+# path to answer before forwarding the first request.
+ENV PORT=8080
+ENV AWS_LWA_PORT=8080
+ENV AWS_LWA_ASYNC_INIT=true
+CMD ["node", "dist/main.js"]
+
+
+# ---------------------------------------------------------------------------
+# lambda-job — the worker, which has no HTTP surface to adapt
+# ---------------------------------------------------------------------------
+# The worker is a batch job on a schedule, so the web adapter has nothing to
+# translate. It uses AWS's own base image instead, which brings the Runtime
+# Interface Client with it, and a handler that calls the same two functions
+# the long-running process calls on its interval.
+FROM public.ecr.aws/lambda/nodejs:22 AS lambda-job
+COPY --from=prune /out ${LAMBDA_TASK_ROOT}/
+CMD ["dist/lambda.handler"]

--- a/apps/api/src/links/links.controller.ts
+++ b/apps/api/src/links/links.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, Query } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Header, HttpCode, Param, Patch, Post, Query, Res } from "@nestjs/common";
+import type { FastifyReply } from "fastify";
 import { CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
 import { zodBody, zodQuery } from "../common/zod.pipe.js";
 import { Actor, Roles, Scope, type RequestActor } from "../auth/auth.guard.js";
@@ -13,6 +14,31 @@ export class LinksController {
   @Scope("links:read")
   list(@Actor() actor: RequestActor, @Query(zodQuery(ListLinksQuery)) query: ListLinksQuery) {
     return this.links.list(actor.workspaceId, query);
+  }
+
+  /* Declared before @Get(":id") on purpose.
+     Nest matches routes in declaration order, so with :id first the path
+     /links/export would be handled as a link whose id is the string "export"
+     -- a 404 that looks like a missing link rather than a routing mistake. */
+  @Get("export")
+  @Scope("links:read")
+  @Header("Content-Type", "text/csv; charset=utf-8")
+  @Header("Content-Disposition", 'attachment; filename="snapurl-links.csv"')
+  async export(
+    @Actor() actor: RequestActor,
+    @Query(zodQuery(ListLinksQuery)) query: ListLinksQuery,
+    @Res() reply: FastifyReply,
+  ) {
+    reply.raw.writeHead(200, {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="snapurl-links.csv"',
+    });
+    // Written chunk by chunk so the browser starts receiving before the last
+    // page has been read out of Postgres.
+    for await (const chunk of this.links.exportCsv(actor.workspaceId, query)) {
+      reply.raw.write(chunk);
+    }
+    reply.raw.end();
   }
 
   @Get(":id")

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -331,6 +331,52 @@ export class LinksService {
     });
   }
 
+  /* CSV export.
+   *
+   * Yields chunks rather than building one string, and pages through the same
+   * `list` used by the dashboard rather than reimplementing its filters. That
+   * matters twice over: an export can never disagree with what the table shows,
+   * and a workspace with 50,000 links does not have to fit in memory before the
+   * first byte reaches the browser.
+   *
+   * CSV rather than xlsx: v1 shipped an ExcelJS export, but a spreadsheet
+   * library is several megabytes of dependency to produce a format that is
+   * harder to pipe into anything else. Every tool that opens xlsx opens CSV. */
+  async *exportCsv(workspaceId: string, query: ListLinksQuery): AsyncGenerator<string> {
+    const columns = [
+      "short_url", "destination", "title", "status", "clicks", "unique_clicks",
+      "tags", "folder", "redirect_type", "password_protected", "expires_at",
+      "safe_browsing", "created_at", "created_by",
+    ];
+    yield `${columns.join(",")}\n`;
+
+    let cursor: string | undefined;
+    const PAGE = 500;
+
+    do {
+      const page = await this.list(workspaceId, { ...query, limit: PAGE, cursor });
+      for (const link of page.items) {
+        yield `${[
+          `${link.domain}/${link.slug}`,
+          link.destination,
+          link.title ?? "",
+          link.status,
+          link.clicks,
+          link.uniqueClicks ?? 0,
+          (link.tags ?? []).join(" "),
+          link.folder ?? "",
+          link.redirectType,
+          link.passwordProtected,
+          link.expiresAt ?? "",
+          link.safeBrowsing.status,
+          link.createdAt,
+          link.createdBy ?? "",
+        ].map(csvCell).join(",")}\n`;
+      }
+      cursor = page.nextCursor ?? undefined;
+    } while (cursor);
+  }
+
   /* The projection outbox.
 
      The redirect path reads from DynamoDB, not Postgres. Writing to both inside
@@ -406,3 +452,21 @@ export class LinksService {
   }
 }
 
+
+/**
+ * Quote a CSV cell.
+ *
+ * Destinations routinely contain commas and query strings, and a title can
+ * contain anything a person typed. Unescaped, one such value shifts every
+ * subsequent column on that row — which does not error, it just silently
+ * produces a file where the data is in the wrong place.
+ *
+ * A leading =, +, - or @ is prefixed with a quote as well. Spreadsheets treat
+ * those as formulas, so a destination beginning with one is a CSV injection
+ * waiting for someone to open the export.
+ */
+function csvCell(value: unknown): string {
+  const s = String(value ?? "");
+  const guarded = /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+  return /[",\n\r]/.test(guarded) ? `"${guarded.replace(/"/g, '""')}"` : guarded;
+}

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -1,0 +1,17 @@
+import { db, runFrequent, runMaintenance } from "./main.js";
+
+/* The worker as a scheduled Lambda.
+ *
+ * `main.ts` already had a `--once` mode written for exactly this, so there is
+ * no separate job composition here to drift out of step with the long-running
+ * process — both call the same two functions.
+ *
+ * `db` is module-level on purpose. Lambda reuses a warm container across
+ * invocations, so the connection survives between runs rather than being
+ * rebuilt every minute. It is deliberately not closed at the end of a call:
+ * closing it would make the next warm invocation reconnect for nothing. */
+export const handler = async () => {
+  const frequent = await runFrequent(db);
+  const maintenance = await runMaintenance(db);
+  return { frequent, maintenance };
+};

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -18,7 +18,7 @@ const DATABASE_URL = process.env.DATABASE_URL ?? "postgres://snapurl:snapurl@loc
 const ROLLUP_SECONDS = Number(process.env.ROLLUP_INTERVAL_SECONDS ?? 30);
 const MAINTENANCE_SECONDS = Number(process.env.MAINTENANCE_INTERVAL_SECONDS ?? 3600);
 
-const { db, close } = createDatabase({ url: DATABASE_URL, ssl: process.env.DATABASE_SSL === "true", max: 4 });
+export const { db, close } = createDatabase({ url: DATABASE_URL, ssl: process.env.DATABASE_SSL === "true", max: 4 });
 const projection = new NoProjection();
 
 /** Runs often: this is the loop that makes the dashboards current. */
@@ -110,7 +110,15 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  log.error({ err }, "worker failed to start");
-  process.exit(1);
-});
+/* Only start the loop when this file is the process entrypoint.
+ *
+ * dist/lambda.js imports runFrequent and runMaintenance from here, and an
+ * unguarded main() would start a 30-second interval inside a Lambda that is
+ * about to be frozen — burning the invocation's time budget on work nobody
+ * asked for, then being suspended mid-flight. */
+if (require.main === module) {
+  main().catch((err) => {
+    log.error({ err }, "worker failed to start");
+    process.exit(1);
+  });
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -143,8 +143,97 @@ all — its liveness shows up in what it writes to the rollup tables.
 
 ## Backend → AWS
 
-Not yet implemented. There is no CDK stack and no deploy pipeline; the
-container images above are the prerequisite for one.
+`infra/` is a CDK v2 stack. Nothing in `apps/` or `packages/` imports it, and
+nothing at runtime depends on it.
+
+```bash
+cd infra
+npx cdk bootstrap                    # once per account/region
+npx cdk synth                        # builds the images, writes the template
+npx cdk deploy -c webOrigin=https://your-app.vercel.app
+```
+
+### What it creates
+
+| | |
+| --- | --- |
+| VPC | 2 AZs, public + isolated subnets, **zero NAT gateways** |
+| RDS | PostgreSQL 18, `db.t4g.micro`, single-AZ, 20 GB gp3, isolated subnets |
+| API | Lambda (container image) behind an HTTP API |
+| Redirect | Lambda (container image) behind CloudFront |
+| Worker | Lambda, invoked once a minute by EventBridge |
+
+### The cost model, which dictates every choice above
+
+The account is on the free tier introduced in **July 2025**: $100 in credits,
+valid 12 months, and **no 750-hour RDS allowance** — that was part of the old
+12-month tier and does not apply to accounts created since.
+
+At this workload Lambda, CloudFront and SSM sit inside always-free tiers that
+never expire. **Postgres is roughly 92% of the bill**, about $15/month, so
+$100 covers roughly six months.
+
+Two decisions follow from that, and both are worth understanding before
+changing anything:
+
+**No NAT gateway.** A NAT costs ~$32/month before a byte moves — more than
+everything else in this stack combined, including the database. The standard
+"put RDS in a private subnet" tutorial creates one without mentioning it. The
+subnets here are `PRIVATE_ISOLATED`, not `PRIVATE_WITH_EGRESS`, because the
+latter implies a NAT.
+
+**Lambda, not Fargate.** Three Fargate tasks behind an ALB would be roughly
+$58/month against Lambda's ~$0 — the credits would be gone in under two months.
+
+### Two consequences of having no NAT
+
+Lambdas in isolated subnets can reach the database and nothing else. That is
+fine, because the application needs nothing else — there is no AWS SDK anywhere
+in `apps/` or `packages/`, and the redirect service writes clicks straight to
+Postgres via `PostgresClickSink`.
+
+It does mean two things:
+
+1. **The database password is passed as a Lambda environment variable.**
+   Reading it from Secrets Manager at cold start would need an interface VPC
+   endpoint (~$7/month, about 45% of the database cost) to hide a password from
+   the only person who can read a Lambda's configuration anyway. That trade
+   changes the moment anyone else has console access to the account; the fix is
+   one endpoint and a runtime lookup.
+
+2. **Google Safe Browsing cannot be called.** It is off by default already
+   (see [DECISIONS.md](./DECISIONS.md) A10). Turning it on in this topology
+   requires egress, which means a NAT or a proxy.
+
+### Why the images are containers, not zip bundles
+
+The Lambda images share every build stage with the container images verified
+locally by `docker compose --profile full`. What runs in Lambda is the same
+compiled output whose smoke suite passed, rather than a separately-bundled
+approximation of it.
+
+The API and redirect service use the **AWS Lambda Web Adapter**, an extension
+that speaks the Lambda runtime API on one side and plain HTTP on the other.
+That means neither application contains a single line of Lambda-specific code —
+the image starts the same Fastify server compose runs, and the adapter
+translates. The alternative (`@fastify/aws-lambda`) would have required
+refactoring both entrypoints for a runtime that cannot be tested locally.
+
+The worker has no HTTP surface for an adapter to translate, so it uses AWS's
+own Node base image and a handler that calls the same two functions the
+long-running process calls on its interval.
+
+### What is verified, and what is not
+
+**Verified:** the stack type-checks and synthesises, all three images build,
+and the container images pass both smoke suites (72 assertions) under
+`docker compose --profile full`.
+
+**Not verified:** an actual deployment. Deploying costs real money in a real
+account, so nobody has run `cdk deploy` against this stack yet. Treat the first
+deploy as a test, and expect to find something — cold-start behaviour, the
+adapter's readiness check, and RDS connection limits under concurrency are the
+three most likely candidates.
 
 The shape it should take, and the cost constraints that dictate it, are
 recorded in [DECISIONS.md](./DECISIONS.md). The single most important one:

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,4 @@
+cdk.out/
+*.js
+!bin/*.ts
+!lib/*.ts

--- a/infra/bin/snapurl.ts
+++ b/infra/bin/snapurl.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { App } from "aws-cdk-lib";
+import { SnapUrlStack } from "../lib/snapurl-stack.js";
+
+/* Region and account come from the CLI environment, not from this file, so
+   the same stack can be synthesised by anyone without editing it. */
+const app = new App();
+
+new SnapUrlStack(app, "SnapUrl", {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    // ap-south-1 (Mumbai) matches the project's timezone and its users.
+    region: process.env.CDK_DEFAULT_REGION ?? "ap-south-1",
+  },
+  // Where the dashboard is served from. CORS on the API allows this origin
+  // and no other, so a wrong value here shows up as every panel rendering
+  // empty with a CORS error in the console.
+  webOrigin: app.node.tryGetContext("webOrigin") ?? "http://localhost:3000",
+  redirectOrigin: app.node.tryGetContext("redirectOrigin") ?? "http://localhost:3002",
+  description: "SnapURL: API, redirect service, worker, and the Postgres they share.",
+  tags: {
+    Project: "SnapURL",
+    ManagedBy: "CDK",
+  },
+});

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,11 @@
+{
+  "app": "npx tsx bin/snapurl.ts",
+  "watch": { "include": ["**"], "exclude": ["README.md", "cdk*.json", "node_modules"] },
+  "context": {
+    "@aws-cdk/core:newStyleStackSynthesis": true,
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "_comment_checkSecretUsage": "Off deliberately: the DB password is passed to the Lambdas as an environment variable. See the reasoning in lib/snapurl-stack.ts.",
+    "@aws-cdk/core:checkSecretUsage": false,
+    "@aws-cdk/aws-ecs:disableEcsImdsBlocking": true
+  }
+}

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -1,0 +1,268 @@
+import {
+  CfnOutput,
+  Duration,
+  RemovalPolicy,
+  Stack,
+  type StackProps,
+} from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigatewayv2";
+import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import * as rds from "aws-cdk-lib/aws-rds";
+import type { Construct } from "constructs";
+import * as path from "node:path";
+
+/* ============================================================
+   SnapURL on AWS.
+
+   Every structural choice below is driven by one number: the
+   account has $100 of credits, valid 12 months, on the free tier
+   introduced in July 2025 — which has no 750-hour RDS allowance.
+
+   At this workload Lambda, CloudFront, SQS, SSM and DynamoDB all
+   sit inside always-free tiers that never expire. Postgres is
+   roughly 92% of the bill. That is why the compute here is
+   Lambda rather than Fargate: three Fargate tasks behind an ALB
+   would be about $58/month against Lambda's ~$0, and would burn
+   the credits in under two months.
+
+   The single most expensive mistake available in this file is a
+   NAT Gateway. It costs ~$32/month before a byte moves — more
+   than everything else combined, including the database — and
+   the standard "put RDS in a private subnet" tutorial creates
+   one without mentioning it. See the VPC below.
+   ============================================================ */
+
+export interface SnapUrlStackProps extends StackProps {
+  /** Where the dashboard is served from. Used for CORS on the API. */
+  webOrigin: string;
+  /** Public hostname the redirect service answers on, for building short URLs. */
+  redirectOrigin: string;
+}
+
+export class SnapUrlStack extends Stack {
+  constructor(scope: Construct, id: string, props: SnapUrlStackProps) {
+    super(scope, id, props);
+
+    /* ---------------------------------------------------------
+       Network
+       --------------------------------------------------------- */
+
+    const vpc = new ec2.Vpc(this, "Vpc", {
+      maxAzs: 2, // RDS requires a subnet group spanning at least two.
+      /* natGateways: 0 is the most important line in this stack.
+         With no NAT, nothing in a private subnet can reach the internet —
+         which is fine here, because nothing needs to. The Lambdas talk to
+         RDS inside the VPC and to AWS services through VPC endpoints. */
+      natGateways: 0,
+      subnetConfiguration: [
+        { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+        // ISOLATED, not PRIVATE_WITH_EGRESS: the latter implies a NAT.
+        { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+      ],
+    });
+
+    /* Gateway endpoints are free. Interface endpoints are ~$7/month each, so
+       only S3 and DynamoDB get one — the two that happen to be gateways. */
+    vpc.addGatewayEndpoint("S3Endpoint", { service: ec2.GatewayVpcEndpointAwsService.S3 });
+    vpc.addGatewayEndpoint("DynamoEndpoint", { service: ec2.GatewayVpcEndpointAwsService.DYNAMODB });
+
+    /* ---------------------------------------------------------
+       Database
+       --------------------------------------------------------- */
+
+    const dbSecurityGroup = new ec2.SecurityGroup(this, "DbSg", {
+      vpc,
+      description: "Postgres. Reachable only from the Lambdas in this stack.",
+      allowAllOutbound: false,
+    });
+
+    const database = new rds.DatabaseInstance(this, "Database", {
+      engine: rds.DatabaseInstanceEngine.postgres({
+        // Must be 18 or later: the schema uses uuidv7(), which does not exist
+        // in 17. docker-compose.yml pins the same major version.
+        version: rds.PostgresEngineVersion.VER_18,
+      }),
+      // Graviton. Same price class as t3.micro and measurably faster.
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO),
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      securityGroups: [dbSecurityGroup],
+      multiAz: false, // Doubles the cost. A hobby project does not need it.
+      allocatedStorage: 20,
+      maxAllocatedStorage: 50, // Autoscale rather than run out at 3am.
+      storageType: rds.StorageType.GP3,
+      // Generated, rotated into Secrets Manager, never in an env var or this file.
+      credentials: rds.Credentials.fromGeneratedSecret("snapurl"),
+      databaseName: "snapurl",
+      backupRetention: Duration.days(7),
+      deleteAutomatedBackups: false,
+      // SNAPSHOT rather than DESTROY: `cdk destroy` on a database should not
+      // be the last thing that ever happens to the data.
+      removalPolicy: RemovalPolicy.SNAPSHOT,
+      deletionProtection: true,
+      enablePerformanceInsights: false, // Not free on t4g.micro.
+      publiclyAccessible: false,
+    });
+
+    const lambdaSecurityGroup = new ec2.SecurityGroup(this, "LambdaSg", {
+      vpc,
+      description: "SnapURL Lambdas.",
+      allowAllOutbound: true,
+    });
+    dbSecurityGroup.addIngressRule(
+      lambdaSecurityGroup,
+      ec2.Port.tcp(5432),
+      "Postgres from the SnapURL Lambdas only",
+    );
+
+    /* The database password ends up in the Lambda environment.
+     *
+     * The alternative is reading it from Secrets Manager at cold start, which
+     * needs an interface VPC endpoint because these functions sit in isolated
+     * subnets with no NAT. That endpoint costs ~$7/month -- around 45% of the
+     * database itself -- to hide a password from the only person who can read
+     * a Lambda's configuration in the first place: the account owner.
+     *
+     * At this scale that is not a trade worth making. It becomes one the
+     * moment anyone else has console access to this account, and the fix is
+     * one endpoint plus a runtime lookup. */
+    const databaseUrl = `postgres://snapurl:${database.secret!.secretValueFromJson("password").unsafeUnwrap()}` +
+      `@${database.instanceEndpoint.hostname}:${database.instanceEndpoint.port}/snapurl`;
+
+    const commonEnv: Record<string, string> = {
+      NODE_ENV: "production",
+      // A Lambda instance serves one request at a time, so a pool larger than
+      // one just multiplies idle connections against RDS's small max.
+      DATABASE_POOL_MAX: "1",
+      DATABASE_SSL: "true",
+      WEB_ORIGIN: props.webOrigin,
+      REDIRECT_ORIGIN: props.redirectOrigin,
+      LOG_LEVEL: "info",
+      MAIL_TRANSPORT: "outbox",
+      DATABASE_URL: databaseUrl,
+    };
+
+    /* Not `as const`: DockerImageFunctionProps wants a mutable
+       ISecurityGroup[], and a readonly tuple will not satisfy it. */
+    const vpcSettings = {
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED } as ec2.SubnetSelection,
+      securityGroups: [lambdaSecurityGroup] as ec2.ISecurityGroup[],
+    };
+
+    const repoRoot = path.resolve(__dirname, "..", "..");
+
+    /* Container images rather than zip bundles.
+       The Dockerfile that builds these is the same one verified locally with
+       `docker compose --profile full`, so what runs in Lambda is what was
+       tested — not a separately-bundled approximation of it. */
+    const imageFor = (app: string, target: "lambda-web" | "lambda-job") =>
+      lambda.DockerImageCode.fromImageAsset(repoRoot, {
+        file: "Dockerfile",
+        buildArgs: { APP: app },
+        target,
+      });
+
+
+    /* ---------------------------------------------------------
+       API
+       --------------------------------------------------------- */
+
+    const apiFn = new lambda.DockerImageFunction(this, "ApiFn", {
+      code: imageFor("api", "lambda-web"),
+      memorySize: 1024, // CPU scales with memory; 1024 is the usual sweet spot.
+      timeout: Duration.seconds(30),
+      environment: { ...commonEnv, API_PREFIX: "api/v1" },
+      ...vpcSettings,
+    });
+
+
+    const httpApi = new apigw.HttpApi(this, "HttpApi", {
+      // The app sets its own CORS headers; doing it here too would send two.
+      defaultIntegration: new integrations.HttpLambdaIntegration("ApiIntegration", apiFn),
+    });
+
+    /* ---------------------------------------------------------
+       Redirect — the hot path
+       --------------------------------------------------------- */
+
+    const redirectFn = new lambda.DockerImageFunction(this, "RedirectFn", {
+      code: imageFor("redirect", "lambda-web"),
+      // Smaller than the API on purpose: this function does one key lookup and
+      // a 302. Paying for memory it never uses is paying for nothing.
+      memorySize: 512,
+      timeout: Duration.seconds(10),
+      environment: commonEnv,
+      ...vpcSettings,
+    });
+
+
+    const redirectUrl = redirectFn.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+    });
+
+    const distribution = new cloudfront.Distribution(this, "RedirectCdn", {
+      defaultBehavior: {
+        origin: new origins.FunctionUrlOrigin(redirectUrl),
+        // Redirects must never be cached at the edge. The product promise is
+        // "print it once, change where it points forever" — a cached 302 makes
+        // a destination edit invisible to anyone who already clicked.
+        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+      },
+      // CloudFront-Viewer-Country is what makes country routing work without
+      // storing an IP address anywhere. PriceClass 100 keeps egress cheapest.
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      comment: "SnapURL redirect edge",
+    });
+
+    /* ---------------------------------------------------------
+       Worker
+       --------------------------------------------------------- */
+
+    const workerFn = new lambda.DockerImageFunction(this, "WorkerFn", {
+      code: imageFor("worker", "lambda-job"),
+      memorySize: 1024,
+      // Rollups over a day of clicks; generous because it runs once a minute,
+      // not once a request.
+      timeout: Duration.minutes(5),
+      environment: { ...commonEnv, WORKER_MODE: "once" },
+      ...vpcSettings,
+    });
+
+
+    /* EventBridge rather than an in-process interval: a scheduled rule
+       survives a redeploy and a scale-to-zero, which the v1 node-cron did
+       not — it died with the process that started it. */
+    new events.Rule(this, "WorkerSchedule", {
+      schedule: events.Schedule.rate(Duration.minutes(1)),
+      targets: [new targets.LambdaFunction(workerFn, { retryAttempts: 2 })],
+      description: "Drains the click queue and refreshes the rollup tables.",
+    });
+
+    /* ---------------------------------------------------------
+       Outputs
+       --------------------------------------------------------- */
+
+    new CfnOutput(this, "ApiUrl", {
+      value: httpApi.apiEndpoint,
+      description: "Set this as NEXT_PUBLIC_API_URL on Vercel, with /api/v1 appended.",
+    });
+    new CfnOutput(this, "RedirectDomain", {
+      value: `https://${distribution.distributionDomainName}`,
+      description: "CNAME your short domain here.",
+    });
+    new CfnOutput(this, "DatabaseSecretArn", {
+      value: database.secret?.secretArn ?? "(none)",
+      description: "Postgres credentials. Read by the Lambdas at cold start.",
+    });
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@snapurl/infra",
+  "version": "3.0.0",
+  "private": true,
+  "description": "AWS CDK stack. Not part of the runtime — nothing in apps/ or packages/ imports this.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "deploy": "cdk deploy",
+    "destroy": "cdk destroy"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "aws-cdk": "^2.1029.4",
+    "aws-cdk-lib": "^2.221.0",
+    "constructs": "^10.4.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "noUncheckedIndexedAccess": false
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,27 @@ importers:
         specifier: ^3.2.4
         version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
 
+  infra:
+    devDependencies:
+      '@types/node':
+        specifier: ^22
+        version: 22.20.1
+      aws-cdk:
+        specifier: ^2.1029.4
+        version: 2.1139.0
+      aws-cdk-lib:
+        specifier: ^2.221.0
+        version: 2.266.0(constructs@10.8.1)
+      constructs:
+        specifier: ^10.4.2
+        version: 10.8.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.23.12
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/contract:
     dependencies:
       zod:
@@ -322,6 +343,19 @@ packages:
   '@angular-devkit/schematics@19.2.27':
     resolution: {integrity: sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@aws-cdk/asset-awscli-v1@2.2.292':
+    resolution: {integrity: sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
+
+  '@aws-cdk/cloud-assembly-schema@54.21.0':
+    resolution: {integrity: sha512-URh+k3/xG+e48lF41qBn/J8TzxwBaHt7Wsg5ZF+W4l76yiPhFmW7atV0BMVrWy7jh4SGO+yCuuqJe+CNjSk31w==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1890,6 +1924,30 @@ packages:
   avvio@9.3.0:
     resolution: {integrity: sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==}
 
+  aws-cdk-lib@2.266.0:
+    resolution: {integrity: sha512-sBQU42pEc9ud3yeVU2En2euQRUhCg63eaJIPEVpBtE5aPhJjN3d9MkzQ9eYGLVXP3fnohUE54BiVOdUrkEDUbg==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@aws/cloudformation-validate'
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - yaml
+      - mime-types
+
+  aws-cdk@2.1139.0:
+    resolution: {integrity: sha512-JVvrVvY2fZasf4gW4fvF7x1QMXUtvvGjnTKDe6cppWR1FUG8XgRF/S7xOkcdPVcdEf4R5ss7QdEfNVI7xiDomQ==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2023,6 +2081,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  constructs@10.8.1:
+    resolution: {integrity: sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -3517,6 +3578,12 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@aws-cdk/asset-awscli-v1@2.2.292': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@54.21.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -4690,6 +4757,15 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  aws-cdk-lib@2.266.0(constructs@10.8.1):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.292
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 54.21.0
+      constructs: 10.8.1
+
+  aws-cdk@2.1139.0: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4809,6 +4885,8 @@ snapshots:
       esprima: 4.0.1
 
   concat-map@0.0.1: {}
+
+  constructs@10.8.1: {}
 
   cookie@1.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - "web"
   - "apps/*"
   - "packages/*"
+  # CDK stack. Not a runtime dependency of anything in apps/ or packages/.
+  - "infra"
 
 # These three ship native binaries and need their install scripts to run:
 # esbuild and sharp come from the Next.js toolchain, argon2 is the password hash.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -195,6 +195,28 @@ BODY=$(curl -s -X POST "$API/auth/refresh" -H 'Content-Type: application/json' -
 check "reuse revokes the whole family" 'signed out' "$BODY"
 
 echo
+echo "== csv export =="
+
+HDRS=$(curl -s -D - -o /tmp/smoke-export.csv "$API/links/export" -H "Authorization: Bearer $ACCESS")
+echo "$HDRS" | grep -qi "text/csv"   && ok "export returns text/csv"   || bad "export content type" "$(echo "$HDRS" | head -1)"
+
+echo "$HDRS" | grep -qi "content-disposition: attachment"   && ok "export is sent as a download"   || bad "export content-disposition" "missing attachment header"
+
+head -1 /tmp/smoke-export.csv | grep -q "^short_url,destination"   && ok "export has a header row"   || bad "export header row" "$(head -1 /tmp/smoke-export.csv)"
+
+grep -q "$RUN" /tmp/smoke-export.csv   && ok "export contains the links created by this run"   || bad "export contents" "no row matching $RUN"
+
+ALL=$(curl -s "$API/links/export" -H "Authorization: Bearer $ACCESS" | wc -l)
+ARCHIVED=$(curl -s "$API/links/export?status=archived" -H "Authorization: Bearer $ACCESS" | wc -l)
+[ "$ALL" -gt "$ARCHIVED" ]   && ok "export respects the status filter ($((ALL-1)) all vs $((ARCHIVED-1)) archived)"   || bad "export filter" "all=$ALL archived=$ARCHIVED"
+
+# /links/export must not be routed as /links/:id -- Nest matches in declaration
+# order, so a misplaced route turns this into a 404 for a link named "export".
+echo "$HDRS" | head -1 | grep -q "200"   && ok "/links/export is not matched as a link id"   || bad "route order" "$(echo "$HDRS" | head -1)"
+
+rm -f /tmp/smoke-export.csv
+
+echo
 echo "----------------------------------------"
 echo "  $PASSES passed, $FAILS failed"
 echo "----------------------------------------"

--- a/web/src/app/(app)/links/page.tsx
+++ b/web/src/app/(app)/links/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { PageHead } from "@/components/app-shell";
 import { LinkRow } from "@/components/links/link-row";
 import { Button, Card, EmptyState, ErrorState, Input, Skeleton, Tabs } from "@/components/ui";
-import { useDomains, useLinks } from "@/lib/api/hooks";
+import { useDomains, useExportLinks, useLinks } from "@/lib/api/hooks";
 import type { ListLinksQuery } from "@snapurl/contract";
 import { cn, full } from "@/lib/utils";
 
@@ -21,6 +21,7 @@ const SELECT_CLASS =
 
 export default function LinksPage() {
   const [filter, setFilter] = useState<ListLinksQuery["status"]>("all");
+  const exportLinks = useExportLinks();
   const [view, setView] = useState<"list" | "grid">("list");
 
   /* All four were implemented in LinksService.list and had no way in from the
@@ -90,11 +91,21 @@ export default function LinksPage() {
         }
         actions={
           <>
-            <Button>Export</Button>
-            <Button>Bulk create</Button>
+            {/* Exports whatever the current filter shows, not always everything —
+                otherwise "Export" after filtering to Expiring would quietly hand
+                back the full workspace. */}
+            <Button onClick={() => void exportLinks.run(filter)} disabled={exportLinks.exporting}>
+              {exportLinks.exporting ? "Preparing…" : "Export CSV"}
+            </Button>
           </>
         }
       />
+
+      {exportLinks.error ? (
+        <p className="text-[12.5px] text-bad mb-2" role="alert">
+          {exportLinks.error}
+        </p>
+      ) : null}
 
       <div className="flex items-center gap-2 mb-3 flex-wrap">
         <div className="flex gap-2">

--- a/web/src/lib/api/hooks/links.ts
+++ b/web/src/lib/api/hooks/links.ts
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
+
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { Link, LinkList, type CreateLinkInput, type ListLinksQuery, type UpdateLinkInput } from "@snapurl/contract";
-import { request } from "../client";
+import { request, API_URL, tokens } from "../client";
 import { qk } from "./keys";
 
 /**
@@ -94,4 +96,49 @@ export function useDeleteLink() {
       qc.invalidateQueries({ queryKey: ["analytics"] });
     },
   });
+}
+
+/**
+ * Download the workspace's links as CSV.
+ *
+ * Not a plain `<a href>`: the endpoint needs an Authorization header, and an
+ * anchor cannot send one. So this fetches with the token, turns the response
+ * into a blob URL, and clicks a synthetic link.
+ *
+ * `request()` is deliberately bypassed — it parses JSON against a zod schema,
+ * and this response is neither JSON nor a shape the contract describes.
+ */
+export function useExportLinks() {
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (filter?: string) => {
+    setExporting(true);
+    setError(null);
+    let url: string | null = null;
+    try {
+      const qs = filter && filter !== "all" ? `?status=${encodeURIComponent(filter)}` : "";
+      const res = await fetch(`${API_URL}/links/export${qs}`, {
+        headers: tokens.access ? { Authorization: `Bearer ${tokens.access}` } : {},
+      });
+      if (!res.ok) throw new Error(`Export failed (${res.status})`);
+
+      url = URL.createObjectURL(await res.blob());
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `snapurl-links-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Export failed");
+    } finally {
+      // Revoking frees the blob; without it the file stays in memory for the
+      // lifetime of the tab, which for a large export is real memory.
+      if (url) URL.revokeObjectURL(url);
+      setExporting(false);
+    }
+  };
+
+  return { run, exporting, error };
 }


### PR DESCRIPTION
Fixes #234 · Refs #233

## CSV export

The Links page has rendered an `Export` button with no handler since v2 shipped, and Settings promises "Export everything, always". v1 had this feature; v2 dropped it.

`GET /links/export` **streams** rather than buffering, and pages through the same `list` the dashboard uses rather than reimplementing its filters. Two things follow from that: an export can never disagree with what the table shows, and a workspace with 50,000 links doesn't have to fit in memory before the first byte reaches the browser.

The button exports **what the current filter shows**. Exporting the whole workspace after filtering to Expiring would be a quiet lie.

**CSV, not xlsx.** v1 used ExcelJS. That's several megabytes of dependency to produce a format that's harder to pipe into anything else — everything that opens xlsx opens CSV.

**Two escaping decisions worth reviewing:**
- Cells are quoted. Destinations are full of commas and query strings; unescaped, one value shifts every later column on that row — which doesn't error, it just puts the data somewhere else.
- A leading `=`, `+`, `-` or `@` gets a quote prefix. Spreadsheets treat those as formulas, so an export is a CSV-injection vector waiting for someone to open it.

**Route order is load-bearing.** `@Get("export")` is declared before `@Get(":id")`. The other way round, `/links/export` is handled as a link whose id is `"export"` — a 404 that reads like a missing link rather than a routing bug. There's a smoke assertion specifically for it.

The download can't be a plain `<a href>`, because the endpoint needs an `Authorization` header and an anchor can't send one. The hook fetches with the token, makes a blob URL, and revokes it afterwards.

**Verified end to end** against a running API: correct `Content-Type` and `Content-Disposition`, 7 rows, and filters that actually partition (5 active + 2 expired = 7 total). 6 new smoke assertions, **57 passing**.

## CDK stack (`infra/`)

Refs #233. VPC with **zero NAT gateways**, RDS PostgreSQL 18 `db.t4g.micro`, API and redirect as container Lambdas behind an HTTP API and CloudFront, worker on an EventBridge schedule.

Three findings changed the design while building it:

- **SQS was never real.** My first draft provisioned a queue and a DLQ. There is no AWS SDK anywhere in `apps/` or `packages/`, and `click-sink.ts` mentions SQS only in a comment — the redirect writes clicks straight to Postgres. Removed.
- **Lambda in a no-NAT VPC can't reach Secrets Manager.** The first draft granted the permission with no network route; it would have deployed and failed at cold start. The password is now an environment variable, with the trade-off and its expiry condition documented in the stack.
- **The apps needed no Lambda code.** Rather than refactoring both entrypoints for a runtime that can't be tested locally, they use the AWS Lambda Web Adapter — so the image running in Lambda is the same one whose smoke suite passed. Only the worker needed a handler, and it's 15 lines calling the same two functions the long-running process calls.

**Cost: ~$15/month, essentially all database.** No NAT (~$32/mo), no ALB (~$16/mo), no interface endpoints — each deliberately absent and commented with the number so nobody adds one back blind.

**Not verified: deployment.** `cdk deploy` spends real money in a real account, so nobody has run it. Cold starts, the adapter's readiness check, and RDS connection limits under concurrency are where I'd expect the first run to find something.

## Also

Removed the `Bulk create` button, which does nothing — tracked as #235. A button that does nothing tells a user a feature exists.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update