### PR TITLE
fix: show the real workspace name, and make the rollup test hermetic

### DIFF
--- a/apps/worker/src/jobs/rollup.test.ts
+++ b/apps/worker/src/jobs/rollup.test.ts
@@ -108,8 +108,19 @@ describeDb("rollupClicks", () => {
     await addClick({ visitor: "visitor-a", hour: 3 });
     await addClick({ visitor: "visitor-b", hour: 4 });
 
+    /* Deliberately not `expect(result.events).toBe(4)`.
+     *
+     * rollupClicks is global — it drains every unprocessed event in the
+     * database, not just this test's. That assertion held only on a database
+     * nothing else had ever written to, so it passed in CI against a fresh
+     * service container and failed on any developer machine that had run the
+     * app or the smoke suite. A test that is green in CI and red locally
+     * teaches people to distrust the suite.
+     *
+     * It has to process at least ours, and the row assertions below are
+     * scoped to this link, which is what the test is actually about. */
     const result = await rollupClicks(db);
-    expect(result.events).toBe(4);
+    expect(result.events).toBeGreaterThanOrEqual(4);
 
     const row = await daily();
     expect(row.clicks).toBe(4);

--- a/web/src/app/(app)/team/page.tsx
+++ b/web/src/app/(app)/team/page.tsx
@@ -2,7 +2,7 @@
 
 import { PageHead } from "@/components/app-shell";
 import { Button, Card, CardBody, CardHeader, Chip, Field, Input, Segmented, Skeleton, Table, TableWrap, Td, Th } from "@/components/ui";
-import { useAudit, useChangeMemberRole, useInviteMember, useMembers, useRemoveMember } from "@/lib/api/hooks";
+import { useAudit, useChangeMemberRole, useInviteMember, useMembers, useRemoveMember, useWorkspace } from "@/lib/api/hooks";
 import { InviteMemberInput, type MemberRole } from "@snapurl/contract";
 import { useState } from "react";
 import { cn, full } from "@/lib/utils";
@@ -32,6 +32,7 @@ const ROLE_OPTIONS: { value: MemberRole; label: string }[] = [...INVITE_ROLES, {
 
 export default function TeamPage() {
   const { data: members, isLoading } = useMembers();
+  const { data: workspace } = useWorkspace();
   const { data: audit } = useAudit();
 
   const invite = useInviteMember();
@@ -89,7 +90,7 @@ export default function TeamPage() {
     <>
       <PageHead
         title="Team"
-        sub={`${members?.length ?? "—"} members in Acme Growth · every action is written to the audit log`}
+        sub={`${members?.length ?? "—"} members in ${workspace?.name ?? "this workspace"} · every action is written to the audit log`}
         actions={
           <>
             <Button>Audit log</Button>


### PR DESCRIPTION
Two bugs found while verifying the frontend builds the way Vercel will build it (real API URL, no `.env.local`, exact `vercel.json` build command).

## The team page told every workspace it was someone else's

`web/src/app/(app)/team/page.tsx` hardcoded **"Acme Growth"** — the seed workspace's name — in its subtitle. Every real workspace saw "N members in Acme Growth". Now reads `useWorkspace()`.

## The rollup test was green in CI and red on every real machine

`rollup.test.ts` asserted `expect(result.events).toBe(4)`. But `rollupClicks` is **global** — it drains every unprocessed event in the database, not just the four the test inserted.

That assertion only held on a database nothing else had ever written to. It passed in CI against a fresh Postgres service container, and failed on any developer machine that had run the app or the smoke suite. On mine: **17 events processed, 87 rows in `click_events`.**

A test that's green in CI and red locally is worse than no test — it teaches people the suite is unreliable, so they stop trusting the red ones that matter. It now asserts it processed *at least* its own events; the assertions below it were already scoped to the link, which is what the test is actually about.

## Verified

- The exact `vercel.json` build command, with a real API URL and `.env.language` removed: **succeeds**
- Real API URL is inlined into the client bundle; **zero occurrences of `localhost:3001`**
- `pnpm type-check`, `build`, `test` — **167 tests pass**, on a database with real data in it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)