### PR TITLE
docs(deploy): record what actually gates the Vercel pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ logs/
 
 # Background-agent worktrees are local scratch, never part of the repo.
 .claude/worktrees/
+
+# Vercel CLI project link — local machine state, not repo state.
+.vercel

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -84,6 +84,56 @@ output will never be served to anyone." Never set it on a real deploy — it
 disables the only thing standing between a missing variable and a silently
 broken production site.
 
+### Continuous deployment, and what actually gates it
+
+The Vercel project is connected to the GitHub repository, so deploys are
+triggered by pushes, not by a workflow in this repo:
+
+| Trigger | Result |
+| --- | --- |
+| push to `main` | production deploy |
+| open/update a pull request | preview deploy on its own URL |
+
+**Vercel does not wait for GitHub Actions.** A preview builds even when
+`verify.yml` is red — the two run in parallel and neither knows about the
+other. That is fine for previews and would be dangerous for production, which
+is why the gate is somewhere else: `main` is a protected branch requiring the
+`Type-check, build, test` check to pass before anything can merge. Nothing
+reaches `main` without CI, so nothing reaches production without CI.
+
+If that protection is ever removed, this becomes an unguarded pipeline. The
+branch rule *is* the deployment gate.
+
+There is deliberately no `vercel deploy` step in `.github/workflows/`. Adding
+one alongside the Git integration would deploy every commit twice, and the
+second deploy would race the first.
+
+### Not deploying when nothing changed
+
+`web/vercel.json` sets an `ignoreCommand`:
+
+```
+git diff --quiet HEAD^ HEAD -- :/web :/packages :/pnpm-lock.yaml
+```
+
+Exit 0 means "nothing relevant changed, skip the build". A commit touching only
+`apps/worker` or `infra/` therefore does not redeploy the dashboard.
+
+The `:/` prefix is a git pathspec magic word meaning "relative to the
+repository root", which is what makes this work from inside `web/`. If the
+command errors — a shallow clone with no `HEAD^`, for instance — Vercel builds
+rather than skips, which is the right way round for a guard to fail.
+
+### `NEXT_PUBLIC_USE_FIXTURES` must not be set on the project
+
+It is opt-in and defaults to off, so setting it can only do harm: `"true"`
+fails the build by design, and `"false"` is redundant. Leave it absent.
+
+Also worth knowing: `NEXT_PUBLIC_*` variables are inlined into the browser
+bundle and readable by every visitor. Marking one "Sensitive" in the Vercel
+dashboard hides it from you, not from them. Nothing that needs protecting
+should ever carry that prefix.
+
 ### CORS
 
 The API allows `WEB_ORIGIN` only (`apps/api/src/config/env.ts`). After the


### PR DESCRIPTION
Written after getting the frontend live at https://snapurl-dhananjaythombles-projects.vercel.app

## What this documents

The Vercel project is connected to GitHub, so pushes deploy: `main` to production, pull requests to previews. The point worth writing down is what that does **not** include:

**Vercel does not wait for GitHub Actions.** The two run in parallel and neither knows about the other, so a preview builds even when `verify.yml` is red.

That is fine for previews and would be dangerous for production. The only reason it is not dangerous is that `main` is a protected branch requiring the `Type-check, build, test` check before anything can merge. Nothing reaches `main` without CI, so nothing reaches production without CI.

**The branch protection rule is the deployment gate.** Remove it and this becomes an unguarded pipeline. That connection was implicit and is now written down.

No `vercel deploy` step is added to `.github/workflows/` — alongside the Git integration it would deploy every commit twice, with the second racing the first.

## Verified live

The `ignoreCommand` was confirmed working on this very branch. The push that created this PR was skipped, because it touches only docs:

```
Running "git diff --quiet HEAD^ HEAD -- :/web :/packages :/pnpm-lock.yaml"
The Deployment has been canceled as a result of running the command defined
in the "Ignored Build Step" setting.
```

## Project settings changed outside this repo

- **Removed `NEXT_PUBLIC_USE_FIXTURES` from the Vercel project.** It is opt-in and defaults off, so setting it can only do harm — `"true"` fails the build by design, `"false"` is redundant. Its value was marked Sensitive and therefore unreadable, so a wrong value would have caused the next mystery failure.
- Flagged, not changed: `NEXT_PUBLIC_API_URL` is marked Sensitive. That hides it from you, not from visitors — `NEXT_PUBLIC_*` is inlined into the browser bundle by definition.

## Also

`.vercel` is now gitignored. It is local CLI link state, not repo state.

## Type of change

- [x] Chore (refactoring code, workflow improvements)
- [x] This change requires a documentation update