### PR TITLE
feat(links): duplicate a link, without duplicating what would be a lie

### DIFF
--- a/apps/api/src/links/links.controller.ts
+++ b/apps/api/src/links/links.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, Get, Header, HttpCode, Param, Patch, Post, Query, Res } from "@nestjs/common";
 import type { FastifyReply } from "fastify";
-import { CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
+import { CloneLinkInput, CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
 import { zodBody, zodQuery } from "../common/zod.pipe.js";
 import { Actor, Roles, Scope, type RequestActor } from "../auth/auth.guard.js";
 import { LinksService } from "./links.service.js";
@@ -52,6 +52,19 @@ export class LinksController {
   @Scope("links:write")
   create(@Actor() actor: RequestActor, @Body(zodBody(CreateLinkInput)) input: CreateLinkInput) {
     return this.links.create(actor.workspaceId, toActor(actor), input);
+  }
+
+  /* A creation, not a mutation of :id — the source link is untouched, so this
+     is POST to a subresource rather than PATCH. Returns the new link. */
+  @Post(":id/clone")
+  @Roles("editor")
+  @Scope("links:write")
+  clone(
+    @Actor() actor: RequestActor,
+    @Param("id") id: string,
+    @Body(zodBody(CloneLinkInput)) input: CloneLinkInput,
+  ) {
+    return this.links.clone(actor.workspaceId, id, toActor(actor), input);
   }
 
   /* G1 — the endpoint the frontend needed and the contract didn't have. */

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import * as argon2 from "argon2";
 import { and, asc, clickDaily, desc, domains, eq, gte, inArray, isNull, links, projectionOutbox, routingRules, sql, users, type Database, type Executor } from "@snapurl/database";
-import type { CreateLinkInput, Link, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
+import type { CloneLinkInput, CreateLinkInput, Link, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
 import { SLUG_RETRY_LIMIT, generateSlug, isSlugAvailableShape, validateRoutingChain, validateSchedule } from "@snapurl/domain";
 import { DB } from "../database/database.module.js";
 import { SafeBrowsingService } from "../safe-browsing/safe-browsing.service.js";
@@ -143,6 +143,107 @@ export class LinksService {
   }
 
   async create(workspaceId: string, actor: Actor, input: CreateLinkInput): Promise<Link> {
+    const passwordHash = input.password ? await argon2.hash(input.password, ARGON_OPTIONS) : null;
+    return this.insert(workspaceId, actor, input, passwordHash);
+  }
+
+  /**
+   * Duplicate a link under a new back-half.
+   *
+   * Builds a CreateLinkInput out of the source and hands it to the same
+   * `insert` that `create` uses, so slug generation, collision retry, routing
+   * validation, the projection outbox and the activity record are shared
+   * rather than reimplemented — a second copy of that sequence would drift the
+   * first time one of them changed.
+   *
+   * The password is the one thing that cannot go through CreateLinkInput,
+   * which carries a plaintext the caller has and we do not. It is resolved to
+   * a hash here and passed alongside.
+   */
+  async clone(workspaceId: string, id: string, actor: Actor, input: CloneLinkInput): Promise<Link> {
+    const source = await this.get(workspaceId, id);
+
+    /* The DTO exposes `passwordProtected`, never the hash, so read it
+       separately rather than widening what every caller of `get` receives. */
+    const [row] = await this.db
+      .select({ passwordHash: links.passwordHash })
+      .from(links)
+      .where(and(eq(links.id, id), eq(links.workspaceId, workspaceId)))
+      .limit(1);
+
+    /* Fails closed. Omitting `password` inherits whatever the source had:
+       cloning a private link must not quietly produce an open one. `null`
+       removes protection deliberately, a string replaces it. */
+    const passwordHash =
+      input.password === undefined
+        ? (row?.passwordHash ?? null)
+        : input.password === null
+          ? null
+          : await argon2.hash(input.password, ARGON_OPTIONS);
+
+    /* The DTO stores absent optional fields as null; CreateLinkInput expects
+       them absent. Mapped explicitly rather than cast, so a field added to one
+       shape and not the other is a compile error instead of a silent drop. */
+    const utm = source.utm
+      ? {
+          source: source.utm.source ?? undefined,
+          medium: source.utm.medium ?? undefined,
+          campaign: source.utm.campaign ?? undefined,
+          content: source.utm.content ?? undefined,
+        }
+      : undefined;
+    const social = source.social
+      ? {
+          title: source.social.title ?? undefined,
+          description: source.social.description ?? undefined,
+          image: source.social.image ?? undefined,
+        }
+      : undefined;
+
+    return this.insert(
+      workspaceId,
+      actor,
+      {
+        destination: source.destination,
+        domain: input.domain ?? source.domain,
+        // Empty string means "generate one", same as on create.
+        slug: input.slug || undefined,
+        tags: source.tags ?? [],
+        folder: source.folder ?? undefined,
+        comment: source.comment ?? undefined,
+        redirectType: source.redirectType,
+        rules: source.rules ?? [],
+        expiresAt: source.expiresAt ?? null,
+        expiresTo: source.expiresTo ?? null,
+        activatesAt: source.activatesAt ?? null,
+        scheduledTo: source.scheduledTo ?? null,
+        clickLimit: source.clickLimit ?? null,
+        forwardQuery: source.forwardQuery,
+        deepLink: source.deepLink,
+        hideReferrer: source.hideReferrer,
+        publicPreview: source.publicPreview,
+        utm,
+        social,
+      },
+      passwordHash,
+      id,
+    );
+  }
+
+  /**
+   * The shared write path behind `create` and `clone`.
+   *
+   * `input.password` is deliberately ignored here — the caller has already
+   * resolved it to `passwordHash`, because a clone carries a hash forward and
+   * has no plaintext to offer.
+   */
+  private async insert(
+    workspaceId: string,
+    actor: Actor,
+    input: CreateLinkInput,
+    passwordHash: string | null,
+    clonedFrom?: string,
+  ): Promise<Link> {
     const domain = await this.resolveDomain(workspaceId, input.domain);
 
     const problems = [
@@ -156,7 +257,6 @@ export class LinksService {
       if (!shape.ok) throw new BadRequestException(shape.reason);
     }
 
-    const passwordHash = input.password ? await argon2.hash(input.password, ARGON_OPTIONS) : null;
     const scan = await this.safeBrowsing.check(input.destination);
 
     /* Random slugs, retried on collision.
@@ -224,7 +324,16 @@ export class LinksService {
               webhookEvent: "link.created",
               targetType: "link",
               targetId: link.id,
-              metadata: { slug: link.slug, domain: link.domain, destination: link.destination },
+              /* Still link.created, not a new link.cloned event: a clone *is* a
+                 new link, and anything subscribed to link.created needs to hear
+                 about it. Where it came from is metadata, not a second event
+                 type every existing subscriber would have to learn. */
+              metadata: {
+                slug: link.slug,
+                domain: link.domain,
+                destination: link.destination,
+                ...(clonedFrom ? { clonedFrom } : {}),
+              },
             });
             return link;
           });

--- a/packages/contract/src/link.ts
+++ b/packages/contract/src/link.ts
@@ -164,6 +164,32 @@ export const UpdateLinkInput = CreateLinkInput.omit({ domain: true, slug: true }
   });
 export type UpdateLinkInput = z.infer<typeof UpdateLinkInput>;
 
+/**
+ * Duplicate an existing link under a new back-half.
+ *
+ * Everything that decides where a visitor lands is copied — destination,
+ * routing chain, UTM, redirect type, the whole expiry and activation window.
+ * What is deliberately not copied is anything that would be a lie on a new
+ * link: click counts start at zero, and the clone is never archived even if
+ * its source was.
+ *
+ * `password` follows the same tri-state as UpdateLinkInput, and the default
+ * matters: **omitted inherits the original's protection**. Dropping it would
+ * mean duplicating a private beta link and quietly publishing an open one.
+ * Pass `null` to deliberately remove it.
+ */
+export const CloneLinkInput = z.object({
+  slug: z
+    .string()
+    .regex(/^[a-zA-Z0-9._-]*$/, "Use letters, numbers, dots, dashes or underscores")
+    .optional()
+    .or(z.literal("")),
+  /** Defaults to the source link's domain. */
+  domain: z.string().min(1).optional(),
+  password: z.string().nullable().optional(),
+});
+export type CloneLinkInput = z.infer<typeof CloneLinkInput>;
+
 /* G4 — cursor pagination.
 
    `total` on its own implied a page that the request had no way to ask for.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -195,6 +195,38 @@ BODY=$(curl -s -X POST "$API/auth/refresh" -H 'Content-Type: application/json' -
 check "reuse revokes the whole family" 'signed out' "$BODY"
 
 echo
+echo "== clone =="
+# A link worth copying: routing chain, UTM and a click limit, so the clone has
+# something to get wrong.
+BODY=$(curl -s -X POST "$API/links" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' \
+  -d "{\"destination\":\"https://example.com/original\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-src\",\"tags\":[\"promo\"],\"redirectType\":\"307\",\"clickLimit\":250,\"forwardQuery\":false,\"deepLink\":false,\"hideReferrer\":true,\"publicPreview\":true,\"utm\":{\"source\":\"newsletter\"},\"rules\":[{\"id\":\"r-in\",\"when\":{\"country\":\"IN\"},\"then\":\"https://example.in/store\"}]}")
+SRC_ID=$(echo "$BODY" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).id || ""')
+
+BODY=$(curl -s -X POST "$API/links/$SRC_ID/clone" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' -d '{}')
+check "clone copies the destination"   '"destination":"https://example.com/original"' "$BODY"
+check "clone copies the redirect type" '"redirectType":"307"'                          "$BODY"
+check "clone copies the routing chain" 'example.in/store'                              "$BODY"
+check "clone copies UTM"               '"source":"newsletter"'                         "$BODY"
+check "clone copies the click limit"   '"clickLimit":250'                              "$BODY"
+check "clone starts with no clicks"    '"clicks":0'                                    "$BODY"
+CLONE_ID=$(echo "$BODY" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).id || ""')
+CLONE_SLUG=$(echo "$BODY" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).slug || ""')
+if [ -n "$CLONE_ID" ] && [ "$CLONE_ID" != "$SRC_ID" ]; then ok "clone is a new link, not the source"; else bad "clone id" "src=$SRC_ID clone=$CLONE_ID"; fi
+if [ -n "$CLONE_SLUG" ] && [ "$CLONE_SLUG" != "$RUN-src" ]; then ok "clone gets a generated back-half"; else bad "clone slug" "got '$CLONE_SLUG'"; fi
+
+# The security-critical default: cloning a protected link must not publish an
+# open one. $RUN-locked was created with a password in the G3 section above.
+LOCKED_ID=$(curl -s "$API/links?search=$RUN-locked" -H "Authorization: Bearer $ACCESS" | node -pe 'const d=JSON.parse(require("fs").readFileSync(0,"utf8")); (d.items[0]&&d.items[0].id)||""')
+BODY=$(curl -s -X POST "$API/links/$LOCKED_ID/clone" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' -d '{}')
+check "cloning a protected link stays protected" '"passwordProtected":true' "$BODY"
+
+BODY=$(curl -s -X POST "$API/links/$LOCKED_ID/clone" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' -d '{"password":null}')
+check "password:null drops protection deliberately" '"passwordProtected":false' "$BODY"
+
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/links/$SRC_ID/clone" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' -d "{\"slug\":\"$RUN-src\"}")
+status "cloning onto a taken back-half is refused" "409" "$CODE" ""
+
+echo
 echo "== scheduled activation =="
 BODY=$(curl -s -X POST "$API/links" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' \
   -d "{\"destination\":\"https://example.com/launch\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-sched\",\"activatesAt\":\"2099-01-01T00:00:00.000Z\",\"scheduledTo\":\"https://example.com/teaser\",\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"deepLink\":false,\"hideReferrer\":false,\"publicPreview\":true}")

--- a/web/src/components/links/link-row.tsx
+++ b/web/src/components/links/link-row.tsx
@@ -4,6 +4,7 @@ import NextLink from "next/link";
 import { useState } from "react";
 import { Sparkline } from "@/components/charts";
 import { Chip } from "@/components/ui";
+import { useCloneLink } from "@/lib/api/hooks";
 import type { Link, LinkStatus } from "@/lib/api/types";
 import { cn, compact, copy, faviconFor, formatDate, relativeDate } from "@/lib/utils";
 
@@ -21,6 +22,7 @@ const STATUS: Record<LinkStatus, { tone: "good" | "warn" | "bad" | "default"; la
 export function LinkRow({ link, defaultOpen = false }: { link: Link; defaultOpen?: boolean }) {
   const [open, setOpen] = useState(defaultOpen);
   const [copied, setCopied] = useState(false);
+  const cloneLink = useCloneLink();
   const status = STATUS[link.status];
   const url = `${link.domain}/${link.slug}`;
 
@@ -66,6 +68,16 @@ export function LinkRow({ link, defaultOpen = false }: { link: Link; defaultOpen
               className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-ink-3 text-[12px] px-[6px] py-[2px] rounded-[4px] hover:bg-surface-3 hover:text-ink transition-opacity"
             >
               {copied ? "✓ copied" : "⧉ copy"}
+            </button>
+            {/* No slug is sent, so the server generates one — a duplicate that
+                reused the back-half would collide with the link it came from. */}
+            <button
+              onClick={() => cloneLink.mutate({ id: link.id })}
+              disabled={cloneLink.isPending}
+              title="Create a copy of this link with a new back-half"
+              className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-ink-3 text-[12px] px-[6px] py-[2px] rounded-[4px] hover:bg-surface-3 hover:text-ink transition-opacity disabled:opacity-50"
+            >
+              {cloneLink.isPending ? "duplicating…" : "⧉⧉ duplicate"}
             </button>
             <Chip tone={status.tone} dot>
               {status.label(link)}

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -567,6 +567,29 @@ export async function fixtureRequest<T>(
     };
     linkStore.unshift(link);
     data = link;
+  } else if (m(/^\/links\/([^/]+)\/clone$/) && method === "POST") {
+    const source = findLink(m(/^\/links\/([^/]+)\/clone$/)![1]);
+    if (!source) throw new Error(`No fixture link ${path}`);
+    const body = opts.body as { slug?: string; domain?: string; password?: string | null };
+    /* Mirrors the server: everything that decides where a visitor lands is
+       carried over, and everything that would be a lie on a new link is not —
+       counters start at zero and a clone is never archived. */
+    const link: Link = {
+      ...source,
+      id: uid("lnk"),
+      slug: body.slug || Math.random().toString(36).slice(2, 9),
+      domain: body.domain ?? source.domain,
+      status: source.status === "archived" ? "active" : source.status,
+      clicks: 0,
+      uniqueClicks: 0,
+      sparkline: Array(15).fill(0),
+      // Omitting `password` inherits the source's protection.
+      passwordProtected: body.password === undefined ? source.passwordProtected : body.password !== null,
+      createdAt: new Date().toISOString(),
+      createdBy: SESSION.user.name,
+    };
+    linkStore.unshift(link);
+    data = link;
   } else if (m(/^\/links\/([^/]+)$/) && method === "PATCH") {
     const link = findLink(m(/^\/links\/([^/]+)$/)![1]);
     if (!link) throw new Error(`No fixture link ${path}`);

--- a/web/src/lib/api/hooks/links.ts
+++ b/web/src/lib/api/hooks/links.ts
@@ -4,7 +4,14 @@ import { useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
-import { Link, LinkList, type CreateLinkInput, type ListLinksQuery, type UpdateLinkInput } from "@snapurl/contract";
+import {
+  Link,
+  LinkList,
+  type CloneLinkInput,
+  type CreateLinkInput,
+  type ListLinksQuery,
+  type UpdateLinkInput,
+} from "@snapurl/contract";
 import { request, API_URL, tokens } from "../client";
 import { qk } from "./keys";
 
@@ -80,6 +87,27 @@ export function useUpdateLink() {
       request(`/links/${id}`, Link, { method: "PATCH", body: input }),
     onSuccess: (link) => {
       qc.setQueryData(qk.link(link.id), link);
+      qc.invalidateQueries({ queryKey: ["links"] });
+      qc.invalidateQueries({ queryKey: ["analytics"] });
+    },
+  });
+}
+
+/**
+ * Duplicate a link under a new back-half.
+ *
+ * Sending an empty body is the ordinary case: the server generates a slug and
+ * carries everything else over, including the password. Passing `password:
+ * null` is the only way to drop protection, which is deliberate — a clone that
+ * silently lost its password would be a link the workspace believes is private
+ * and is not.
+ */
+export function useCloneLink() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...input }: CloneLinkInput & { id: string }) =>
+      request(`/links/${id}/clone`, Link, { method: "POST", body: input }),
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["links"] });
       qc.invalidateQueries({ queryKey: ["analytics"] });
     },


### PR DESCRIPTION
## What does this PR do?

Fixes #236

`POST /links/:id/clone` duplicates a link's destination, routing chain, UTM, redirect type and the whole expiry/activation window under a new back-half.

As the issue predicted, most of the work was already there. Clone builds a `CreateLinkInput` out of the source and hands it to the **same write path** `create` uses — extracted into a private `insert` — so slug generation, collision retry, routing validation, the projection outbox and the activity record are shared rather than reimplemented. A second copy of that sequence would drift the first time one of them changed.

### What is deliberately not copied

Anything that would be false on a new link: **click counters start at zero**, and a clone of an archived link is active.

### The password default, which is the decision worth arguing with

The password cannot travel through `CreateLinkInput` — that carries a plaintext the caller has and we do not — so it is resolved to a hash separately and passed alongside. It follows `UpdateLinkInput`'s tri-state, and **the default is to inherit**:

| `password` | Result |
| --- | --- |
| omitted | keeps the source's protection |
| `null` | removes it, deliberately |
| a string | replaces it |

The alternative default — dropping protection unless asked — means duplicating a private beta link and quietly publishing an open one. That is a failure nobody sees until the wrong person clicks, so this **fails closed**, consistent with `satisfiesRole` in `auth.guard.ts`.

### Two smaller calls

- **`POST /links/:id/clone`, not `PATCH`.** The source link is untouched; this creates something. A subresource POST returning the new link says that.
- **It emits `link.created`, not a new `link.cloned` event.** A clone *is* a new link, and anything subscribed to `link.created` needs to hear about it. Where it came from goes in the metadata as `clonedFrom`, rather than becoming a second event type every existing subscriber would have to learn.

### UI

A `⧉⧉ duplicate` action next to the existing copy button on each link row, revealed on hover like its neighbour. It sends no slug, so the server generates one — a duplicate reusing the back-half would collide with the link it came from.

## Requirement/Documentation

Issue #236. Nothing here contradicts an existing entry in `docs/DECISIONS.md`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Purely additive: one new endpoint, one new contract schema, one new hook. No existing behaviour changes — `create` is now a thin wrapper over the extracted `insert`, with identical semantics.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass locally.

New end-to-end coverage in `scripts/smoke.sh`, which runs against a live Postgres 18 in CI — the only thing that actually exercises the new SQL path:

- A source link with a routing chain, UTM, a click limit and non-default flags, then assertions that the clone carries destination, redirect type, routing chain, UTM and click limit across.
- **Clicks reset to zero**, and the clone is a genuinely new row with a generated back-half.
- **Cloning the password-protected `$RUN-locked` link stays protected** — the security-critical default.
- **`password: null` drops protection**, proving the escape hatch works and is explicit.
- Cloning onto an already-taken back-half returns **409**.

I could not run the smoke or integration suites locally: there is no Docker daemon in this environment and the only local Postgres is 16, which cannot run this schema (`uuidv7()` needs 18).

The fixture for the new mutation is added in the same change, per the repo's rule that a hook without a matching fixture appears to work and is entirely fake when `NEXT_PUBLIC_USE_FIXTURES` is on. It mirrors the server, including the inherit-by-default password behaviour.

## Not done, and why

- **No UI for the options.** The button clones with defaults — generated slug, same domain, inherited password. The endpoint accepts `slug`, `domain` and `password`, so a dialog offering them is a UI change only. Duplicating and then editing is the common path, and a modal in front of a one-click action would slow the common case to serve the rare one.
- **`title` is not copied, because nothing ever sets it.** `title` exists on the row, the DTO, search and the CSV export, but no write path in `LinksService` assigns it — it is always null. Copying null faithfully is what happens; worth knowing that the column is currently vestigial rather than assuming clone dropped something.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_