### PR TITLE
feat(links): bulk create, all-or-nothing, with a line per row either way

### DIFF
--- a/apps/api/src/links/links.controller.ts
+++ b/apps/api/src/links/links.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, Get, Header, HttpCode, Param, Patch, Post, Query, Res } from "@nestjs/common";
 import type { FastifyReply } from "fastify";
-import { CloneLinkInput, CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
+import { BulkCreateLinksInput, CloneLinkInput, CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
 import { zodBody, zodQuery } from "../common/zod.pipe.js";
 import { Actor, Roles, Scope, type RequestActor } from "../auth/auth.guard.js";
 import { LinksService } from "./links.service.js";
@@ -52,6 +52,18 @@ export class LinksController {
   @Scope("links:write")
   create(@Actor() actor: RequestActor, @Body(zodBody(CreateLinkInput)) input: CreateLinkInput) {
     return this.links.create(actor.workspaceId, toActor(actor), input);
+  }
+
+  /* Always 200, never 207.
+     Either every row was written or none was, so there is no "multi-status" to
+     report — the per-row detail is in the body, where a caller can act on it,
+     rather than in a status code they would have to special-case. */
+  @Post("bulk")
+  @Roles("editor")
+  @Scope("links:write")
+  @HttpCode(200)
+  bulkCreate(@Actor() actor: RequestActor, @Body(zodBody(BulkCreateLinksInput)) input: BulkCreateLinksInput) {
+    return this.links.bulkCreate(actor.workspaceId, toActor(actor), input);
   }
 
   /* A creation, not a mutation of :id — the source link is untouched, so this

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -1,7 +1,16 @@
 import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import * as argon2 from "argon2";
 import { and, asc, clickDaily, desc, domains, eq, gte, inArray, isNull, links, projectionOutbox, routingRules, sql, users, type Database, type Executor } from "@snapurl/database";
-import type { CloneLinkInput, CreateLinkInput, Link, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
+import type {
+  BulkCreateLinksInput,
+  BulkCreateLinksResult,
+  BulkLinkOutcome,
+  CloneLinkInput,
+  CreateLinkInput,
+  Link,
+  ListLinksQuery,
+  UpdateLinkInput,
+} from "@snapurl/contract";
 import { SLUG_RETRY_LIMIT, generateSlug, isSlugAvailableShape, validateRoutingChain, validateSchedule } from "@snapurl/domain";
 import { DB } from "../database/database.module.js";
 import { SafeBrowsingService } from "../safe-browsing/safe-browsing.service.js";
@@ -145,6 +154,232 @@ export class LinksService {
   async create(workspaceId: string, actor: Actor, input: CreateLinkInput): Promise<Link> {
     const passwordHash = input.password ? await argon2.hash(input.password, ARGON_OPTIONS) : null;
     return this.insert(workspaceId, actor, input, passwordHash);
+  }
+
+  /**
+   * Create many links in one request.
+   *
+   * Two phases, and the split is the whole design.
+   *
+   * **Phase one validates every row and writes nothing.** Destination, slug
+   * shape, routing chain, activation window, domain — all checked up front,
+   * along with the two things a single-link create never has to think about:
+   * two rows asking for the same back-half, and a requested back-half that is
+   * already taken. If any row fails, the response describes every row and the
+   * database is untouched.
+   *
+   * **Phase two writes the whole batch in one transaction.** Nothing partial
+   * survives a failure.
+   *
+   * That combination is what makes the feature safe to retry. A partial import
+   * would leave the caller unable to resubmit — fixing three bad rows and
+   * sending the file again would duplicate the ninety-seven good ones, because
+   * generated back-halves differ every time. All-or-nothing means resubmitting
+   * the corrected file is always the right move.
+   *
+   * `results` is the same length as the input and in the same order, so no row
+   * is ever silently dropped, which is the failure this feature exists to
+   * avoid being worse than not having it.
+   */
+  async bulkCreate(
+    workspaceId: string,
+    actor: Actor,
+    input: BulkCreateLinksInput,
+  ): Promise<BulkCreateLinksResult> {
+    const rows = input.links;
+    const errors = new Map<number, string>();
+
+    /* One lookup per distinct domain rather than per row: a hundred links on
+       the same domain is the normal shape of a batch. */
+    const domainCache = new Map<string, { id: string; name: string } | string>();
+    const resolveDomainCached = async (name: string) => {
+      const key = name.toLowerCase();
+      const hit = domainCache.get(key);
+      if (hit !== undefined) return hit;
+      try {
+        const row = await this.resolveDomain(workspaceId, name);
+        const resolved = { id: row.id, name: row.domain };
+        domainCache.set(key, resolved);
+        return resolved;
+      } catch (err) {
+        // Kept as a per-row failure; one bad domain must not 400 the batch.
+        const message = err instanceof BadRequestException ? String(err.message) : `${name} isn't usable.`;
+        domainCache.set(key, message);
+        return message;
+      }
+    };
+
+    type Prepared = {
+      index: number;
+      input: CreateLinkInput;
+      domainId: string;
+      slug: string;
+      /** True when we chose the slug, so a collision can be redrawn. */
+      generated: boolean;
+      passwordHash: string | null;
+      scan: { status: string; checkedAt: Date };
+    };
+    const prepared: Prepared[] = [];
+
+    for (const [index, row] of rows.entries()) {
+      const problems = [...validateRoutingChain(row.rules), ...validateSchedule(row.activatesAt, row.expiresAt)];
+      if (row.slug) {
+        const shape = isSlugAvailableShape(row.slug);
+        // isSlugAvailableShape returns { ok: boolean; reason?: string } rather
+        // than a discriminated union, so `reason` does not narrow here.
+        if (!shape.ok) problems.push(shape.reason ?? "That back-half isn't usable.");
+      }
+      const domain = await resolveDomainCached(row.domain);
+      if (typeof domain === "string") problems.push(domain);
+
+      if (problems.length) {
+        errors.set(index, problems.join(" "));
+        continue;
+      }
+
+      prepared.push({
+        index,
+        input: row,
+        domainId: (domain as { id: string }).id,
+        slug: row.slug || generateSlug(),
+        generated: !row.slug,
+        passwordHash: row.password ? await argon2.hash(row.password, ARGON_OPTIONS) : null,
+        scan: await this.safeBrowsing.check(row.destination),
+      });
+    }
+
+    /* Two rows asking for the same back-half. The unique index would catch it,
+       but only by failing the transaction — which tells the caller nothing
+       about which two rows disagreed. */
+    const seen = new Map<string, number>();
+    for (const item of prepared) {
+      if (!item.generated) {
+        const key = `${item.domainId}:${item.slug.toLowerCase()}`;
+        const first = seen.get(key);
+        if (first !== undefined) {
+          errors.set(item.index, `Row ${first + 1} already asks for /${item.slug} in this batch.`);
+        } else {
+          seen.set(key, item.index);
+        }
+      }
+    }
+
+    /* Back-halves already in the database. Checked here so a taken one is
+       reported against its row, and so a generated one that happens to collide
+       can simply be redrawn — the in-transaction retry `create` uses is not
+       available once every row shares a transaction. */
+    for (let pass = 0; pass < SLUG_RETRY_LIMIT; pass++) {
+      const live = prepared.filter((p) => !errors.has(p.index));
+      if (!live.length) break;
+
+      const takenPairs = new Set<string>();
+      for (const domainId of new Set(live.map((p) => p.domainId))) {
+        const wanted = live.filter((p) => p.domainId === domainId).map((p) => p.slug.toLowerCase());
+        const existing = await this.db
+          .select({ slug: links.slug })
+          .from(links)
+          .where(and(eq(links.domainId, domainId), inArray(sql`lower(${links.slug})`, wanted)));
+        for (const e of existing) takenPairs.add(`${domainId}:${e.slug.toLowerCase()}`);
+      }
+      if (!takenPairs.size) break;
+
+      let redrew = false;
+      for (const item of live) {
+        if (!takenPairs.has(`${item.domainId}:${item.slug.toLowerCase()}`)) continue;
+        if (item.generated) {
+          item.slug = generateSlug();
+          redrew = true;
+        } else {
+          errors.set(item.index, `${item.input.domain}/${item.slug} is already taken. Try another back-half.`);
+        }
+      }
+      if (!redrew) break;
+    }
+
+    /* Nothing is written when anything failed. See the note above: a partial
+       import cannot be safely resubmitted. */
+    if (errors.size) {
+      return {
+        created: 0,
+        failed: rows.length,
+        results: rows.map((row, index) => ({
+          ok: false as const,
+          index,
+          destination: row.destination,
+          error:
+            errors.get(index) ??
+            "Not created — another row in this batch was invalid, and a batch is all or nothing.",
+        })),
+      };
+    }
+
+    const ids = await this.db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(links)
+        .values(
+          prepared.map((p) => ({
+            workspaceId,
+            domainId: p.domainId,
+            slug: p.slug,
+            destination: p.input.destination,
+            comment: p.input.comment ?? null,
+            tags: p.input.tags ?? [],
+            folder: p.input.folder ?? null,
+            redirectType: p.input.redirectType,
+            expiresAt: p.input.expiresAt ? new Date(p.input.expiresAt) : null,
+            expiresTo: p.input.expiresTo ?? null,
+            activatesAt: p.input.activatesAt ? new Date(p.input.activatesAt) : null,
+            scheduledTo: p.input.scheduledTo ?? null,
+            clickLimit: p.input.clickLimit ?? null,
+            passwordHash: p.passwordHash,
+            forwardQuery: p.input.forwardQuery,
+            deepLink: p.input.deepLink,
+            hideReferrer: p.input.hideReferrer,
+            publicPreview: p.input.publicPreview,
+            safeBrowsingStatus: p.scan.status,
+            safeBrowsingCheckedAt: p.scan.checkedAt,
+            utm: p.input.utm ?? null,
+            social: p.input.social ?? null,
+            createdBy: actor.userId,
+          })),
+        )
+        .returning({ id: links.id });
+
+      const rules = prepared.flatMap((p, i) =>
+        p.input.rules.map((rule, position) => ({
+          linkId: inserted[i]!.id,
+          position,
+          whenCountry: rule.when.country?.toUpperCase() ?? null,
+          whenDevice: rule.when.device ?? null,
+          whenLanguage: rule.when.language?.toLowerCase() ?? null,
+          then: rule.then,
+          weight: rule.weight ?? null,
+        })),
+      );
+      if (rules.length) await tx.insert(routingRules).values(rules);
+
+      for (const r of inserted) await this.enqueueProjection(tx, r.id, "upsert");
+      return inserted.map((r) => r.id);
+    });
+
+    /* Read back and record activity after the commit, never inside it — the
+       links exist by now, so a failure here must not undo them. */
+    const results: BulkLinkOutcome[] = [];
+    for (const [i, id] of ids.entries()) {
+      const link = await this.get(workspaceId, id);
+      await recordActivity(this.db, this.logger, {
+        workspaceId,
+        actor,
+        auditAction: "link.created",
+        webhookEvent: "link.created",
+        targetType: "link",
+        targetId: link.id,
+        metadata: { slug: link.slug, domain: link.domain, destination: link.destination, bulk: true },
+      });
+      results.push({ ok: true, index: prepared[i]!.index, link });
+    }
+
+    return { created: results.length, failed: 0, results };
   }
 
   /**

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import * as argon2 from "argon2";
 import { and, asc, clickDaily, desc, domains, eq, gte, inArray, isNull, links, projectionOutbox, routingRules, sql, users, type Database, type Executor } from "@snapurl/database";
+import { CreateLinkInput as CreateLinkInputSchema } from "@snapurl/contract";
 import type {
   BulkCreateLinksInput,
   BulkCreateLinksResult,
@@ -189,6 +190,12 @@ export class LinksService {
     const rows = input.links;
     const errors = new Map<number, string>();
 
+    /* Echoed back on every failure so the UI can name the row without
+       re-reading its own input. Read off the raw row, because a row that
+       failed to parse has no typed destination to read. */
+    const destinationOf = (raw: Record<string, unknown>) =>
+      typeof raw.destination === "string" ? raw.destination : "";
+
     /* One lookup per distinct domain rather than per row: a hundred links on
        the same domain is the normal shape of a batch. */
     const domainCache = new Map<string, { id: string; name: string } | string>();
@@ -221,7 +228,20 @@ export class LinksService {
     };
     const prepared: Prepared[] = [];
 
-    for (const [index, row] of rows.entries()) {
+    for (const [index, raw] of rows.entries()) {
+      /* Parsed per row rather than by the pipe. See BulkCreateLinksInput: a
+         schema on the array would reject the whole request for one bad URL
+         and never reach this report. */
+      const parsed = CreateLinkInputSchema.safeParse(raw);
+      if (!parsed.success) {
+        errors.set(
+          index,
+          parsed.error.issues.map((i) => `${i.path.join(".") || "row"}: ${i.message}`).join(" "),
+        );
+        continue;
+      }
+      const row = parsed.data;
+
       const problems = [...validateRoutingChain(row.rules), ...validateSchedule(row.activatesAt, row.expiresAt)];
       if (row.slug) {
         const shape = isSlugAvailableShape(row.slug);
@@ -302,10 +322,10 @@ export class LinksService {
       return {
         created: 0,
         failed: rows.length,
-        results: rows.map((row, index) => ({
+        results: rows.map((raw, index) => ({
           ok: false as const,
           index,
-          destination: row.destination,
+          destination: destinationOf(raw),
           error:
             errors.get(index) ??
             "Not created — another row in this batch was invalid, and a batch is all or nothing.",

--- a/packages/contract/src/link.ts
+++ b/packages/contract/src/link.ts
@@ -165,6 +165,53 @@ export const UpdateLinkInput = CreateLinkInput.omit({ domain: true, slug: true }
 export type UpdateLinkInput = z.infer<typeof UpdateLinkInput>;
 
 /**
+ * Create many links in one request.
+ *
+ * Capped deliberately. Each row costs a Safe Browsing lookup, which is a
+ * network call when a key is configured, so an uncapped batch is a request
+ * that times out halfway and leaves the caller guessing.
+ */
+export const BulkCreateLinksInput = z.object({
+  links: z.array(CreateLinkInput).min(1, "Add at least one link.").max(100, "100 links per batch."),
+});
+export type BulkCreateLinksInput = z.infer<typeof BulkCreateLinksInput>;
+
+/**
+ * What happened to one row, carrying the index it arrived at.
+ *
+ * A discriminated union rather than an object with two optional fields,
+ * because "created but also has an error" is not a state that should be
+ * representable.
+ */
+export const BulkLinkOutcome = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true), index: z.number().int(), link: Link }),
+  z.object({
+    ok: z.literal(false),
+    index: z.number().int(),
+    /** Echoed back so the UI can name the row without re-reading its input. */
+    destination: z.string(),
+    error: z.string(),
+  }),
+]);
+export type BulkLinkOutcome = z.infer<typeof BulkLinkOutcome>;
+
+/**
+ * The result of a batch.
+ *
+ * `results` is always the same length as the input and in the same order, so a
+ * row can never be silently dropped — the failure mode the whole feature has
+ * to avoid. Either every row was written or none was: a batch with any invalid
+ * row writes nothing, so fixing the bad rows and resubmitting cannot duplicate
+ * the good ones.
+ */
+export const BulkCreateLinksResult = z.object({
+  created: z.number().int(),
+  failed: z.number().int(),
+  results: z.array(BulkLinkOutcome),
+});
+export type BulkCreateLinksResult = z.infer<typeof BulkCreateLinksResult>;
+
+/**
  * Duplicate an existing link under a new back-half.
  *
  * Everything that decides where a visitor lands is copied — destination,

--- a/packages/contract/src/link.ts
+++ b/packages/contract/src/link.ts
@@ -172,7 +172,23 @@ export type UpdateLinkInput = z.infer<typeof UpdateLinkInput>;
  * that times out halfway and leaves the caller guessing.
  */
 export const BulkCreateLinksInput = z.object({
-  links: z.array(CreateLinkInput).min(1, "Add at least one link.").max(100, "100 links per batch."),
+  /**
+   * Rows are deliberately **not** validated here.
+   *
+   * `z.array(CreateLinkInput)` is the obvious spelling and it defeats the
+   * feature: the validation pipe rejects the whole request before the handler
+   * runs, so one malformed URL — the single most common thing wrong with a
+   * pasted list — comes back as `links.1.destination: ...` and never reaches
+   * the per-row report this endpoint exists to produce.
+   *
+   * Each row is parsed against CreateLinkInput individually inside the
+   * service, where a failure can be attributed to the row that caused it.
+   * Only the envelope is checked here: an array of objects, within the cap.
+   */
+  links: z
+    .array(z.record(z.string(), z.unknown()))
+    .min(1, "Add at least one link.")
+    .max(100, "100 links per batch."),
 });
 export type BulkCreateLinksInput = z.infer<typeof BulkCreateLinksInput>;
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -195,6 +195,43 @@ BODY=$(curl -s -X POST "$API/auth/refresh" -H 'Content-Type: application/json' -
 check "reuse revokes the whole family" 'signed out' "$BODY"
 
 echo
+echo "== bulk create =="
+mkbulk() { # mkbulk <json-array-of-links>
+  curl -s -X POST "$API/links/bulk" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' -d "{\"links\":$1}"
+}
+row() { # row <destination> [slug]
+  node -e 'const [d,s]=process.argv.slice(1);process.stdout.write(JSON.stringify({destination:d,domain:"localhost:3002",...(s?{slug:s}:{}),tags:[],redirectType:"302",rules:[],forwardQuery:true,deepLink:false,hideReferrer:false,publicPreview:true}))' "$1" "${2:-}"
+}
+
+BODY=$(mkbulk "[$(row https://example.com/bulk-a "$RUN-bulk-a"),$(row https://example.com/bulk-b)]")
+check "bulk creates every valid row"        '"created":2'  "$BODY"
+check "bulk reports no failures"            '"failed":0'   "$BODY"
+check "bulk honours an explicit back-half"  "$RUN-bulk-a"  "$BODY"
+check "each row carries its own outcome"    '"index":1'    "$BODY"
+
+# All-or-nothing: one bad row must stop the whole batch, and the good row must
+# still be reported rather than silently dropped.
+BODY=$(mkbulk "[$(row https://example.com/good "$RUN-bulk-good"),$(row not-a-url)]")
+check "one bad row creates nothing"          '"created":0' "$BODY"
+check "the bad row is named"                 'not-a-url'   "$BODY"
+check "the good row is reported, not dropped" 'all or nothing' "$BODY"
+
+FOUND=$(curl -s "$API/links?search=$RUN-bulk-good" -H "Authorization: Bearer $ACCESS" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).total')
+if [ "$FOUND" = "0" ]; then ok "a failed batch wrote nothing at all"; else bad "partial write" "found $FOUND rows for $RUN-bulk-good"; fi
+
+# Two rows competing for the same back-half is a batch-only failure: the unique
+# index would catch it, but only by failing without saying which rows collided.
+BODY=$(mkbulk "[$(row https://example.com/dup1 "$RUN-dup"),$(row https://example.com/dup2 "$RUN-dup")]")
+check "two rows wanting one back-half is refused" 'already asks for' "$BODY"
+
+BODY=$(mkbulk "[$(row https://example.com/taken "$RUN-bulk-a")]")
+check "a back-half already in use is refused" 'already taken' "$BODY"
+
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/links/bulk" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' \
+  -d "$(node -e 'const l={destination:"https://example.com/x",domain:"localhost:3002",tags:[],redirectType:"302",rules:[],forwardQuery:true,deepLink:false,hideReferrer:false,publicPreview:true};process.stdout.write(JSON.stringify({links:Array(101).fill(l)}))')")
+status "a batch over the cap is refused" "400" "$CODE" ""
+
+echo
 echo "== clone =="
 # A link worth copying: routing chain, UTM and a click limit, so the clone has
 # something to get wrong.

--- a/web/src/app/(app)/links/page.tsx
+++ b/web/src/app/(app)/links/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { PageHead } from "@/components/app-shell";
+import { BulkCreatePanel } from "@/components/links/bulk-create-panel";
 import { LinkRow } from "@/components/links/link-row";
 import { Button, Card, EmptyState, ErrorState, Input, Skeleton, Tabs } from "@/components/ui";
 import { useDomains, useExportLinks, useLinks } from "@/lib/api/hooks";
@@ -22,6 +23,7 @@ const SELECT_CLASS =
 
 export default function LinksPage() {
   const [filter, setFilter] = useState<ListLinksQuery["status"]>("all");
+  const [bulkOpen, setBulkOpen] = useState(false);
   const exportLinks = useExportLinks();
   const [view, setView] = useState<"list" | "grid">("list");
 
@@ -92,6 +94,7 @@ export default function LinksPage() {
         }
         actions={
           <>
+            <Button onClick={() => setBulkOpen((v) => !v)}>{bulkOpen ? "Cancel" : "Bulk create"}</Button>
             {/* Exports whatever the current filter shows, not always everything —
                 otherwise "Export" after filtering to Expiring would quietly hand
                 back the full workspace. */}
@@ -101,6 +104,8 @@ export default function LinksPage() {
           </>
         }
       />
+
+      {bulkOpen ? <BulkCreatePanel onClose={() => setBulkOpen(false)} /> : null}
 
       {exportLinks.error ? (
         <p className="text-[12.5px] text-bad mb-2" role="alert">

--- a/web/src/components/links/bulk-create-panel.tsx
+++ b/web/src/components/links/bulk-create-panel.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button, Card, CardBody, CardHeader, Chip, Field } from "@/components/ui";
+import { useBulkCreateLinks, useDomains } from "@/lib/api/hooks";
+import type { CreateLinkInput } from "@snapurl/contract";
+
+const MAX_ROWS = 100;
+
+const TEXTAREA_CLASS =
+  "w-full px-[11px] py-[9px] rounded-[var(--radius-sm)] bg-surface-2 border border-line-2 text-[12.5px] text-ink font-mono " +
+  "placeholder:text-ink-3 focus:outline-none focus:border-accent focus:bg-surface focus:ring-[3px] focus:ring-accent-wash";
+
+/**
+ * One input line becomes one link.
+ *
+ * `https://example.com/a, spring` — everything before the first comma is the
+ * destination, anything after it is the back-half you want. The comma is
+ * optional; without one the server generates a back-half.
+ *
+ * Split on the *first* comma only, because destinations legitimately contain
+ * them in query strings.
+ */
+export function parseRows(text: string): Array<{ destination: string; slug?: string }> {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const comma = line.indexOf(",");
+      if (comma === -1) return { destination: line };
+      const slug = line.slice(comma + 1).trim();
+      return { destination: line.slice(0, comma).trim(), ...(slug ? { slug } : {}) };
+    });
+}
+
+export function BulkCreatePanel({ onClose }: { onClose: () => void }) {
+  const { data: domains } = useDomains();
+  const bulk = useBulkCreateLinks();
+
+  const [text, setText] = useState("");
+  const [domain, setDomain] = useState("");
+
+  const rows = useMemo(() => parseRows(text), [text]);
+  const chosenDomain = domain || domains?.[0]?.domain || "";
+  const tooMany = rows.length > MAX_ROWS;
+
+  async function submit() {
+    if (!rows.length || !chosenDomain || tooMany) return;
+    // The rest of CreateLinkInput's defaults are applied by the server; only
+    // what a row can actually express is sent.
+    const links = rows.map(
+      (r) =>
+        ({
+          destination: r.destination,
+          domain: chosenDomain,
+          ...(r.slug ? { slug: r.slug } : {}),
+          tags: [],
+          redirectType: "302",
+          rules: [],
+          forwardQuery: true,
+          deepLink: false,
+          hideReferrer: false,
+          publicPreview: true,
+        }) as CreateLinkInput,
+    );
+    try {
+      await bulk.mutateAsync({ links });
+    } catch {
+      /* surfaced below via bulk.error */
+    }
+  }
+
+  const result = bulk.data;
+
+  return (
+    <Card className="mb-3.5">
+      <CardHeader
+        title="Bulk create"
+        right={
+          <Chip tone={tooMany ? "bad" : "default"}>
+            {rows.length} of {MAX_ROWS}
+          </Chip>
+        }
+      />
+      <CardBody className="flex flex-col gap-3">
+        <Field
+          label="One link per line"
+          help="Add a comma and a back-half to choose one — otherwise we generate it. Everything before the first comma is the destination, so query strings are safe."
+          error={tooMany ? `That's ${rows.length} rows. Split it into batches of ${MAX_ROWS}.` : undefined}
+        >
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={8}
+            spellCheck={false}
+            placeholder={"https://acme.com/spring\nhttps://acme.com/summer, summer-sale\nhttps://acme.com/pricing?ref=a, pricing"}
+            className={TEXTAREA_CLASS}
+          />
+        </Field>
+
+        <div className="flex items-end gap-3 flex-wrap">
+          <Field label="Domain">
+            <select
+              value={chosenDomain}
+              onChange={(e) => setDomain(e.target.value)}
+              className="inline-flex items-center px-[10px] py-[8px] bg-surface border border-line-2 rounded-[var(--radius-sm)] text-[12.5px] text-ink"
+            >
+              {(domains ?? []).map((d) => (
+                <option key={d.id} value={d.domain}>
+                  {d.domain}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Button variant="primary" onClick={submit} disabled={bulk.isPending || !rows.length || tooMany}>
+            {bulk.isPending ? "Creating…" : `Create ${rows.length || ""} link${rows.length === 1 ? "" : "s"}`}
+          </Button>
+          <Button onClick={onClose}>Close</Button>
+        </div>
+
+        {bulk.error ? (
+          <p className="text-[12.5px] text-bad" role="alert">
+            {(bulk.error as Error).message}
+          </p>
+        ) : null}
+
+        {result ? (
+          <>
+            {/* The point of the whole feature: every submitted row gets a line,
+                so nothing is ever silently dropped. */}
+            <p className="text-[12.5px] text-ink-2 m-0">
+              {result.created > 0 ? (
+                <>
+                  <b className="text-good">{result.created} created.</b> They are in the list below.
+                </>
+              ) : (
+                <>
+                  <b className="text-bad">Nothing was created.</b> A batch is all or nothing, so fix the rows
+                  below and submit the same list again — the good rows cannot be duplicated by retrying.
+                </>
+              )}
+            </p>
+            <ol className="flex flex-col gap-[6px] m-0 p-0 list-none max-h-[260px] overflow-y-auto">
+              {result.results.map((r) => (
+                <li
+                  key={r.index}
+                  className="flex items-start gap-2 text-[12px] border border-line rounded-[var(--radius-sm)] px-[10px] py-[7px] bg-surface-2"
+                >
+                  <span className={r.ok ? "text-good" : "text-bad"}>{r.ok ? "✓" : "✗"}</span>
+                  <span className="text-ink-3 tnum shrink-0">{r.index + 1}</span>
+                  {r.ok ? (
+                    <span className="font-mono text-ink truncate">
+                      {r.link.domain}/{r.link.slug}
+                    </span>
+                  ) : (
+                    <span className="min-w-0">
+                      <span className="font-mono text-ink-2 block truncate">{r.destination}</span>
+                      <span className="text-bad">{r.error}</span>
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </>
+        ) : null}
+      </CardBody>
+    </Card>
+  );
+}

--- a/web/src/components/links/bulk-create-panel.tsx
+++ b/web/src/components/links/bulk-create-panel.tsx
@@ -65,7 +65,7 @@ export function BulkCreatePanel({ onClose }: { onClose: () => void }) {
         }) as CreateLinkInput,
     );
     try {
-      await bulk.mutateAsync({ links });
+      await bulk.mutateAsync(links);
     } catch {
       /* surfaced below via bulk.error */
     }

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -567,6 +567,64 @@ export async function fixtureRequest<T>(
     };
     linkStore.unshift(link);
     data = link;
+  } else if (m(/^\/links\/bulk$/) && method === "POST") {
+    const body = opts.body as { links: Array<{ destination: string; domain: string; slug?: string }> };
+    /* Mirrors the server's all-or-nothing rule: one invalid row means nothing
+       is written, and every row still gets an outcome so none is silently
+       dropped. The fixture only validates what it can see — a destination that
+       is not a URL, and a back-half already used in this store. */
+    const taken = new Set(linkStore.map((l) => `${l.domain}:${l.slug.toLowerCase()}`));
+    const problems = new Map<number, string>();
+    body.links.forEach((row, i) => {
+      try {
+        new URL(row.destination);
+      } catch {
+        problems.set(i, "That doesn't look like a URL — include https://");
+        return;
+      }
+      if (row.slug && taken.has(`${row.domain}:${row.slug.toLowerCase()}`)) {
+        problems.set(i, `${row.domain}/${row.slug} is already taken. Try another back-half.`);
+      }
+      if (row.slug) taken.add(`${row.domain}:${row.slug.toLowerCase()}`);
+    });
+
+    if (problems.size) {
+      data = {
+        created: 0,
+        failed: body.links.length,
+        results: body.links.map((row, index) => ({
+          ok: false,
+          index,
+          destination: row.destination,
+          error:
+            problems.get(index) ??
+            "Not created — another row in this batch was invalid, and a batch is all or nothing.",
+        })),
+      };
+    } else {
+      const results = body.links.map((row, index) => {
+        const link: Link = {
+          ...LINKS[0],
+          id: uid("lnk"),
+          slug: row.slug || Math.random().toString(36).slice(2, 9),
+          domain: row.domain,
+          destination: row.destination,
+          title: null,
+          comment: null,
+          tags: [],
+          status: "active",
+          clicks: 0,
+          uniqueClicks: 0,
+          rules: [],
+          sparkline: Array(15).fill(0),
+          createdAt: new Date().toISOString(),
+          createdBy: SESSION.user.name,
+        };
+        linkStore.unshift(link);
+        return { ok: true, index, link };
+      });
+      data = { created: results.length, failed: 0, results };
+    }
   } else if (m(/^\/links\/([^/]+)\/clone$/) && method === "POST") {
     const source = findLink(m(/^\/links\/([^/]+)\/clone$/)![1]);
     if (!source) throw new Error(`No fixture link ${path}`);

--- a/web/src/lib/api/hooks/links.ts
+++ b/web/src/lib/api/hooks/links.ts
@@ -8,7 +8,6 @@ import {
   BulkCreateLinksResult,
   Link,
   LinkList,
-  type BulkCreateLinksInput,
   type CloneLinkInput,
   type CreateLinkInput,
   type ListLinksQuery,
@@ -106,8 +105,12 @@ export function useUpdateLink() {
 export function useBulkCreateLinks() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input: BulkCreateLinksInput) =>
-      request("/links/bulk", BulkCreateLinksResult, { method: "POST", body: input }),
+    /* Typed as CreateLinkInput[] here even though the endpoint accepts rows
+       loosely. The looseness exists so the *server* can attribute a bad row to
+       its index; there is no reason for the dashboard to send anything it
+       cannot describe. */
+    mutationFn: (links: CreateLinkInput[]) =>
+      request("/links/bulk", BulkCreateLinksResult, { method: "POST", body: { links } }),
     onSuccess: (result) => {
       // Only worth invalidating when something was actually written.
       if (result.created > 0) {

--- a/web/src/lib/api/hooks/links.ts
+++ b/web/src/lib/api/hooks/links.ts
@@ -5,8 +5,10 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import {
+  BulkCreateLinksResult,
   Link,
   LinkList,
+  type BulkCreateLinksInput,
   type CloneLinkInput,
   type CreateLinkInput,
   type ListLinksQuery,
@@ -89,6 +91,29 @@ export function useUpdateLink() {
       qc.setQueryData(qk.link(link.id), link);
       qc.invalidateQueries({ queryKey: ["links"] });
       qc.invalidateQueries({ queryKey: ["analytics"] });
+    },
+  });
+}
+
+/**
+ * Create many links at once.
+ *
+ * The response is never a bare success: it carries one outcome per submitted
+ * row, in order, so the caller can show which rows landed and which did not.
+ * A batch that reports `created: 0` wrote nothing at all, which is what makes
+ * fixing the bad rows and resubmitting the whole list safe.
+ */
+export function useBulkCreateLinks() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: BulkCreateLinksInput) =>
+      request("/links/bulk", BulkCreateLinksResult, { method: "POST", body: input }),
+    onSuccess: (result) => {
+      // Only worth invalidating when something was actually written.
+      if (result.created > 0) {
+        qc.invalidateQueries({ queryKey: ["links"] });
+        qc.invalidateQueries({ queryKey: ["analytics"] });
+      }
     },
   });
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #235

`POST /links/bulk` creates up to 100 links in one request, with a UI behind the button.

**One correction to the issue's premise:** the dead `Bulk create` button is already gone. #246 removed it along with the rest of the Links page header actions when it added Export CSV. So this isn't wiring up an existing button — it builds the feature and puts the button back with something behind it.

### The design decision the issue leaves open

The issue asks for *"an endpoint that is transactional **or** clearly partial-failure-reporting"*. This does both, in two phases:

1. **Validate every row, write nothing.** Destination, back-half shape, routing chain, activation window, domain — plus the two failures a single-link create never has to think about: two rows competing for the same back-half, and a back-half already in the database.
2. **Write the whole batch in one transaction.**

I went all-or-nothing rather than partial, and the reason is retry safety rather than purity. **A partial import cannot be resubmitted.** Fix three bad rows in a 100-row file, send it again, and you duplicate the ninety-seven that worked — because generated back-halves differ every time, so nothing stops them. All-or-nothing means resubmitting the corrected file is always the right move, and the UI can say so without qualification.

Per-row reporting is the other half, and it's the part the issue cares most about: `results` is always the **same length as the input and in the same order**, so a row can never be silently dropped. Rows that were themselves fine are explicitly told they were not created and why, rather than being omitted from the response.

### Two smaller calls

- **`200`, never `207 Multi-Status`.** Either everything was written or nothing was, so there is no multi-status to report. The detail lives in the body where a caller can act on it, not in a status code they'd have to special-case.
- **Slug collision retry could not be reused as-is.** `create` retries inside its own transaction; a unique violation aborts a transaction the whole batch is sharing, so an in-transaction redraw is not available. Generated back-halves are checked against the database *before* any write and redrawn if taken — the same idea, moved earlier.
- **Capped at 100.** Each row costs a Safe Browsing lookup, a network call when a key is configured. An uncapped batch is a request that times out halfway and leaves the caller guessing.

### UI

A `Bulk create` toggle on the Links page opens a panel: one link per line, `destination[, back-half]`. The parser splits on the **first** comma only, because destinations legitimately contain them in query strings. Results render one line per submitted row — `✓` with the short URL, or `✗` with the destination and the reason.

## Requirement/Documentation

Issue #235. Builds on the private `insert` seam extracted in #254. Nothing here contradicts `docs/DECISIONS.md`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Additive: one endpoint, three contract schemas, one hook, one component. No existing behaviour changes.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass locally.

New end-to-end coverage in `scripts/smoke.sh`, against a live Postgres 18 in CI:

- A valid batch creates every row, honours an explicit back-half, and gives each row its own indexed outcome.
- **One bad row creates nothing** — and the *good* row in the same batch is still reported rather than dropped.
- **A follow-up query proves the failed batch wrote nothing at all**, which is the claim the whole design rests on.
- Two rows competing for one back-half is refused, naming the earlier row.
- A back-half already in use is refused.
- A 101-row batch is refused with 400.

I could not run the smoke or integration suites locally — no Docker daemon here, and the only local Postgres is 16, which cannot run this schema (`uuidv7()` needs 18).

The fixture for the new mutation is added in the same change, per the repo's rule, and mirrors the server's all-or-nothing behaviour.

## Not done, and why

- **`parseRows` has no unit test.** `web/` has no test runner, and adding vitest there would mean a new dependency and a repo-wide config change — the same reasoning that leaves `pnpm lint` deliberately broken. The function is exported so a test can be added the day `web` gains a runner. Its one subtlety, splitting on the first comma so query strings survive, is covered by a placeholder example in the UI rather than by a test.
- **The panel only sends what a line can express** — destination, back-half, domain. Tags, UTM, expiry and routing rules are not per-row settable from the textarea. The endpoint accepts full `CreateLinkInput` per row, so a richer importer (CSV upload with columns) is a UI change only. A line-per-link paste is the shape people actually have when they bulk import.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_