### PR TITLE
feat(links): make deepLink do something, and only where it can fall back

### DIFF
--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -3,6 +3,7 @@ import jwt from "jsonwebtoken";
 import { createDatabase } from "@snapurl/database";
 import {
   REDIRECT_STATUS,
+  buildDeepLink,
   buildDestination,
   cacheHeadersFor,
   evaluateRouting,
@@ -133,6 +134,14 @@ app.get<{ Params: { slug: string } }>("/:slug", async (request, reply) => {
     utm: link.utm,
   });
 
+  /* Applied last, to the URL the visitor would actually have received —
+     otherwise the intent's fallback would point at the pre-UTM destination and
+     anyone without the app would lose the campaign parameters.
+
+     Returns `destination` untouched unless there is a real app to open and a
+     platform fallback to catch the miss, so this is a no-op for most clicks. */
+  const target = buildDeepLink(destination, parseDevice(userAgent), link.deepLink);
+
   void record(link, request, userAgent, null, decision.matchedRuleId, decision.variant, hash);
 
   for (const [header, value] of Object.entries(cacheHeadersFor(link.redirectType))) {
@@ -140,7 +149,7 @@ app.get<{ Params: { slug: string } }>("/:slug", async (request, reply) => {
   }
   if (link.hideReferrer) void reply.header("Referrer-Policy", "no-referrer");
 
-  return reply.redirect(destination, REDIRECT_STATUS[link.redirectType]);
+  return reply.redirect(target, REDIRECT_STATUS[link.redirectType]);
 });
 
 app.get("/", async (request, reply) => {

--- a/apps/redirect/src/resolver.ts
+++ b/apps/redirect/src/resolver.ts
@@ -29,6 +29,7 @@ export interface ResolvedLink {
   clicks: number;
   hasPassword: boolean;
   forwardQuery: boolean;
+  deepLink: boolean;
   hideReferrer: boolean;
   publicPreview: boolean;
   archived: boolean;
@@ -105,6 +106,7 @@ export class PostgresLinkResolver implements LinkResolver {
       clicks: row.link.clicks,
       hasPassword: Boolean(row.link.passwordHash),
       forwardQuery: row.link.forwardQuery,
+      deepLink: row.link.deepLink,
       hideReferrer: row.link.hideReferrer,
       publicPreview: row.link.publicPreview,
       archived: Boolean(row.link.archivedAt),

--- a/packages/domain/src/deep-link.test.ts
+++ b/packages/domain/src/deep-link.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { DEEP_LINK_HOSTS, buildDeepLink } from "./deep-link.js";
+
+const YT = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+describe("buildDeepLink", () => {
+  describe("when it must not interfere", () => {
+    it("leaves the destination alone when deep linking is off", () => {
+      expect(buildDeepLink(YT, "android", false)).toBe(YT);
+    });
+
+    it("leaves iOS alone — the https URL is already a Universal Link", () => {
+      // Attempting a custom scheme here trades a silent success for Safari's
+      // "Cannot Open Page" whenever the app is absent.
+      expect(buildDeepLink(YT, "ios", true)).toBe(YT);
+    });
+
+    it("leaves desktop alone, because there is no app to open", () => {
+      expect(buildDeepLink(YT, "desktop", true)).toBe(YT);
+    });
+
+    it("leaves an unknown device alone", () => {
+      expect(buildDeepLink(YT, null, true)).toBe(YT);
+      expect(buildDeepLink(YT, "mobile", true)).toBe(YT);
+    });
+
+    it("leaves a host with no known app alone", () => {
+      const url = "https://example.com/some/page";
+      expect(buildDeepLink(url, "android", true)).toBe(url);
+    });
+
+    it("leaves an unparseable destination alone rather than throwing", () => {
+      expect(buildDeepLink("not a url", "android", true)).toBe("not a url");
+    });
+
+    it("refuses to build an intent from a non-web scheme", () => {
+      const url = "mailto:someone@example.com";
+      expect(buildDeepLink(url, "android", true)).toBe(url);
+    });
+  });
+
+  describe("on Android", () => {
+    it("builds an intent carrying the original URL as the fallback", () => {
+      const out = buildDeepLink(YT, "android", true);
+      expect(out.startsWith("intent://www.youtube.com/watch?v=dQw4w9WgXcQ#Intent;")).toBe(true);
+      expect(out).toContain("scheme=https");
+      expect(out).toContain("package=com.google.android.youtube");
+      expect(out).toContain(`S.browser_fallback_url=${encodeURIComponent(YT)}`);
+      expect(out.endsWith(";end")).toBe(true);
+    });
+
+    it("always leaves a way through — the fallback is the destination itself", () => {
+      // The property the whole feature rests on: app installed or not, the
+      // visitor lands somewhere deliberate.
+      const out = buildDeepLink(YT, "android", true);
+      const fallback = decodeURIComponent(out.split("S.browser_fallback_url=")[1]!.replace(/;end$/, ""));
+      expect(fallback).toBe(YT);
+    });
+
+    it("keeps the query string, which is where the content id usually lives", () => {
+      const out = buildDeepLink("https://open.spotify.com/track/abc?si=xyz", "android", true);
+      expect(out).toContain("intent://open.spotify.com/track/abc?si=xyz#Intent;");
+      expect(out).toContain("package=com.spotify.music");
+    });
+
+    it("matches subdomains without needing an entry for each", () => {
+      expect(buildDeepLink("https://open.spotify.com/x", "android", true)).toContain("com.spotify.music");
+      expect(buildDeepLink("https://m.youtube.com/x", "android", true)).toContain("com.google.android.youtube");
+      expect(buildDeepLink("https://youtube.com/x", "android", true)).toContain("com.google.android.youtube");
+    });
+
+    it("does not match a lookalike host that merely ends with the name", () => {
+      // notyoutube.com must not resolve to YouTube's package.
+      expect(buildDeepLink("https://notyoutube.com/x", "android", true)).toBe("https://notyoutube.com/x");
+      expect(buildDeepLink("https://evil-x.com/x", "android", true)).toBe("https://evil-x.com/x");
+    });
+
+    it("sends X and Twitter to the same app", () => {
+      expect(buildDeepLink("https://x.com/a/status/1", "android", true)).toContain("com.twitter.android");
+      expect(buildDeepLink("https://twitter.com/a/status/1", "android", true)).toContain("com.twitter.android");
+    });
+
+    it("percent-encodes the fallback so its query cannot terminate the intent", () => {
+      // An unencoded ";" or "&" in the fallback would truncate the intent and
+      // strand the visitor — the exact failure this feature must not have.
+      const tricky = "https://www.youtube.com/watch?v=a&list=b;end";
+      const out = buildDeepLink(tricky, "android", true);
+      expect(out.endsWith(";end")).toBe(true);
+      const fallback = decodeURIComponent(out.split("S.browser_fallback_url=")[1]!.replace(/;end$/, ""));
+      expect(fallback).toBe(tricky);
+    });
+  });
+
+  it("publishes the hosts it knows, so the dashboard can name them", () => {
+    expect(DEEP_LINK_HOSTS).toContain("youtube.com");
+    expect(DEEP_LINK_HOSTS.length).toBeGreaterThan(5);
+  });
+});

--- a/packages/domain/src/deep-link.ts
+++ b/packages/domain/src/deep-link.ts
@@ -1,0 +1,112 @@
+import type { DeviceType } from "@snapurl/contract";
+
+/* ============================================================
+   Deep linking that is allowed to fail.
+
+   The naive implementation — redirect to `spotify://track/123`
+   — is the one that ruins the feature, and it ruins it silently.
+   A custom scheme with no handler does not fall back: on iOS
+   Safari it raises "Cannot Open Page", on desktop it does
+   nothing at all, and in both cases the visitor is stranded on a
+   link that worked yesterday for someone with the app.
+
+   So the rule here is that a deep link may only be attempted
+   where the platform provides a fallback *it* controls, and the
+   destination is otherwise handed over untouched.
+
+   Android provides exactly that. `intent://` URLs carry
+   `S.browser_fallback_url`, which Chrome navigates to when no
+   installed app claims the intent. App installed: the app opens.
+   App absent: the browser goes to the web page. Neither outcome
+   needs a timeout, a bounce page, or a guess.
+
+   iOS provides it too, by a different route: every app listed
+   below publishes an apple-app-site-association file, so its
+   ordinary https URL *is* a Universal Link and opens the app
+   when it is installed. Sending the plain URL is therefore not
+   a gap on iOS — it is the mechanism. Attempting a custom
+   scheme instead would trade a silent success for a visible
+   error.
+
+   Desktop gets the plain URL, because there is no app.
+   ============================================================ */
+
+/**
+ * Hostname → Android package.
+ *
+ * Only the package is needed, deliberately. The intent below is built with
+ * `scheme=https` and the destination's own path, so Android matches it against
+ * the same intent filter the app already declares for its web URLs. That
+ * avoids inventing per-app URI paths — `spotify://track/…`, `twitter://status?id=…`
+ * and friends — which are undocumented, differ between app versions, and are
+ * the part of a mapping table most likely to be quietly wrong.
+ *
+ * Suffix match on the registrable domain, so `www.`, `m.` and `open.`
+ * subdomains all resolve without an entry each.
+ */
+const ANDROID_PACKAGES: ReadonlyArray<readonly [host: string, androidPackage: string]> = [
+  ["youtube.com", "com.google.android.youtube"],
+  ["youtu.be", "com.google.android.youtube"],
+  ["spotify.com", "com.spotify.music"],
+  ["instagram.com", "com.instagram.android"],
+  ["twitter.com", "com.twitter.android"],
+  ["x.com", "com.twitter.android"],
+  ["tiktok.com", "com.zhiliaoapp.musically"],
+  ["whatsapp.com", "com.whatsapp"],
+  ["wa.me", "com.whatsapp"],
+  ["facebook.com", "com.facebook.katana"],
+  ["fb.com", "com.facebook.katana"],
+  ["soundcloud.com", "com.soundcloud.android"],
+  ["etsy.com", "com.etsy.android"],
+  ["amazon.com", "com.amazon.mShop.android.shopping"],
+  ["amazon.in", "com.amazon.mShop.android.shopping"],
+  ["amazon.co.uk", "com.amazon.mShop.android.shopping"],
+];
+
+/** The apps a link can be deep-linked into, for the dashboard to be honest about. */
+export const DEEP_LINK_HOSTS: readonly string[] = ANDROID_PACKAGES.map(([host]) => host);
+
+function packageFor(hostname: string): string | null {
+  const host = hostname.toLowerCase().replace(/^www\./, "");
+  for (const [suffix, pkg] of ANDROID_PACKAGES) {
+    if (host === suffix || host.endsWith(`.${suffix}`)) return pkg;
+  }
+  return null;
+}
+
+/**
+ * Turn a destination into whatever opens the app on this device, or leave it
+ * alone.
+ *
+ * Returns the destination unchanged for every case that cannot do better:
+ * deep linking off, a host with no known app, a device without one, or a URL
+ * that will not parse. The caller can always redirect to what comes back.
+ */
+export function buildDeepLink(destination: string, device: DeviceType | null, enabled: boolean): string {
+  if (!enabled) return destination;
+
+  /* Only Android is rewritten. iOS is served by Universal Links on the plain
+     https URL, and desktop has no app to open — see the note at the top. */
+  if (device !== "android") return destination;
+
+  let url: URL;
+  try {
+    url = new URL(destination);
+  } catch {
+    return destination;
+  }
+  // An intent built from a non-web scheme would be nonsense.
+  if (url.protocol !== "https:" && url.protocol !== "http:") return destination;
+
+  const androidPackage = packageFor(url.hostname);
+  if (!androidPackage) return destination;
+
+  /* Everything after the scheme becomes the intent's data, and the original
+     URL becomes the fallback. Chrome uses one or the other; there is no path
+     where the visitor gets neither. */
+  const ssp = `${url.host}${url.pathname}${url.search}`;
+  return (
+    `intent://${ssp}#Intent;scheme=https;package=${androidPackage};` +
+    `S.browser_fallback_url=${encodeURIComponent(destination)};end`
+  );
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -2,3 +2,4 @@ export * from "./routing.js";
 export * from "./visitor.js";
 export * from "./slug.js";
 export * from "./destination.js";
+export * from "./deep-link.js";

--- a/scripts/smoke-redirect.sh
+++ b/scripts/smoke-redirect.sh
@@ -54,8 +54,10 @@ mklink "{\"destination\":\"https://example.com/gone\",\"domain\":\"localhost:300
 mklink "{\"destination\":\"https://example.com/soon\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-scheduled\",\"activatesAt\":\"2099-01-01T00:00:00.000Z\",\"scheduledTo\":\"https://example.com/coming-soon\",\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"deepLink\":false,\"hideReferrer\":false,\"publicPreview\":true}" >/dev/null
 mklink "{\"destination\":\"https://example.com/soon2\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-scheduled-bare\",\"activatesAt\":\"2099-01-01T00:00:00.000Z\",\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"deepLink\":false,\"hideReferrer\":false,\"publicPreview\":true}" >/dev/null
 mklink "{\"destination\":\"https://example.com/already\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-activated\",\"activatesAt\":\"2020-01-01T00:00:00.000Z\",\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"deepLink\":false,\"hideReferrer\":false,\"publicPreview\":true}" >/dev/null
+mklink "{\"destination\":\"https://www.youtube.com/watch?v=abc123\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-deep\",\"deepLink\":true,\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"hideReferrer\":false,\"publicPreview\":true}" >/dev/null
+mklink "{\"destination\":\"https://www.youtube.com/watch?v=abc123\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-nodeep\",\"deepLink\":false,\"tags\":[],\"redirectType\":\"302\",\"rules\":[],\"forwardQuery\":true,\"hideReferrer\":false,\"publicPreview\":true}" >/dev/null
 mklink "{\"destination\":\"https://example.com/rest\",\"domain\":\"localhost:3002\",\"slug\":\"$RUN-geo\",\"tags\":[],\"redirectType\":\"302\",\"forwardQuery\":true,\"deepLink\":false,\"hideReferrer\":false,\"publicPreview\":true,\"rules\":[{\"id\":\"r-in\",\"when\":{\"country\":\"IN\"},\"then\":\"https://example.in/store\"},{\"id\":\"r-ios\",\"when\":{\"device\":\"ios\"},\"then\":\"https://apps.apple.com/app\"}]}" >/dev/null
-ok "created ten links"
+ok "created twelve links"
 
 echo
 echo "== basic redirect =="
@@ -96,6 +98,25 @@ TOKEN=$(curl -s -X POST "$API/public/links/$RUN-locked/unlock" -H 'Content-Type:
   -d '{"password":"hunter2"}' | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).unlockToken||""')
 contains "unlock token opens the link (G3)" "example.com/locked" "$(loc "$RUN-locked?k=$TOKEN")"
 contains "a token for another link is refused" "unlock=1" "$(loc "$RUN-locked?k=not-a-real-token")"
+
+echo
+echo "== deep linking =="
+ANDROID='User-Agent: Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36'
+IPHONE='User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Version/17.0 Mobile Safari/604.1'
+
+DEEP=$(loc "$RUN-deep" -H "$ANDROID")
+contains "Android gets an intent URL"          "intent://www.youtube.com" "$DEEP"
+contains "the intent names the YouTube package" "com.google.android.youtube" "$DEEP"
+# The property the feature rests on: no app, no dead end.
+contains "the intent carries a web fallback"   "S.browser_fallback_url"   "$DEEP"
+
+# iOS is served by Universal Links on the plain https URL, and a custom scheme
+# there would surface "Cannot Open Page" whenever the app is absent.
+contains "iPhone gets the plain URL"    "https://www.youtube.com/watch" "$(loc "$RUN-deep" -H "$IPHONE")"
+contains "desktop gets the plain URL"   "https://www.youtube.com/watch" "$(loc "$RUN-deep")"
+contains "the flag off means untouched" "https://www.youtube.com/watch" "$(loc "$RUN-nodeep" -H "$ANDROID")"
+# A host with no app must pass straight through even with the flag on.
+contains "an unknown host is untouched"  "example.com/plain" "$(loc "$RUN-plain" -H "$ANDROID")"
 
 echo
 echo "== the + preview convention =="

--- a/web/src/components/links/create-link-drawer.tsx
+++ b/web/src/components/links/create-link-drawer.tsx
@@ -239,7 +239,7 @@ export function CreateLinkDrawer({ open, onClose }: { open: boolean; onClose: ()
                         checked={field.value ?? false}
                         onChange={field.onChange}
                         title="Deep link into app"
-                        description="Opens the native app when it is installed."
+                        description="Android opens the app when it is installed and the browser when it isn't. iPhones already do this on their own, and desktops have no app to open."
                       />
                     )}
                   />


### PR DESCRIPTION
## What does this PR do?

Fixes #238

`deepLink` was stored, mapped, toggled in the UI and **read by nothing**. The redirect service never looked at it, so the toggle's promise — *"opens the native app when it is installed"* — was not true on any platform.

### The issue is right that the fallback is the hard part

The obvious implementation is the one that ruins the feature, and it ruins it silently. Redirecting to `spotify://track/123` has **no fallback**: on iOS Safari it raises *"Cannot Open Page"*, on desktop it does nothing at all, and a visitor without the app is stranded on a link that worked yesterday for a colleague who has it.

So the rule here is: **a deep link is only attempted where the platform provides a fallback it controls.** Otherwise the destination is handed over untouched.

| Platform | What it gets | Why |
| --- | --- | --- |
| **Android** | `intent://…;S.browser_fallback_url=…;end` | Chrome opens the app if installed, follows the fallback URL if not. Native, no timeout, no bounce page. |
| **iOS** | the plain https URL | Every app in the table publishes an `apple-app-site-association`, so its https URL **is** a Universal Link. This is the mechanism, not a gap — a custom scheme would trade a silent success for a visible error. |
| **Desktop** | the plain https URL | There is no app. |

### The mapping table holds hostnames and Android package names, and nothing else

The intent is built with `scheme=https` and the destination's own path, so Android matches it against the same intent filter the app already declares for its web URLs.

That is deliberate: it avoids inventing per-app URI paths. `twitter://status?id=…`, `instagram://media?id=…` and friends are undocumented, differ between app versions, and are the part of any mapping table most likely to be quietly wrong. A package name is public and stable; a guessed URI path is a bug waiting for a version bump.

Covers the apps the issue names — YouTube, Spotify, Instagram, X/Twitter, Amazon, TikTok, WhatsApp, Facebook, SoundCloud, Etsy.

### One ordering detail

`buildDeepLink` runs **after** `buildDestination`, on the URL the visitor would actually have received. Applying it earlier would put the pre-UTM destination in the fallback, so anyone without the app would silently lose the campaign parameters.

## Requirement/Documentation

Issue #238. Nothing here contradicts `docs/DECISIONS.md`. The drawer copy is corrected to describe what actually happens per platform, in the spirit of #217 — the old copy claimed behaviour that did not exist.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (a stored flag that did nothing now does what it says)

`buildDeepLink` returns its input unchanged for every case it cannot improve — flag off, unknown host, non-Android device, unparseable URL, non-web scheme — so links that do not opt in are byte-identical to before.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass. **15 new unit tests** in `packages/domain` (76 total, up from 61) — this is pure logic, so unlike the previous two PRs it is fully verifiable here rather than only in CI:

- Every no-op path: flag off, iOS, desktop, unknown device, unknown host, unparseable URL, `mailto:`.
- The intent is well-formed, names the right package, and ends with `;end`.
- **The fallback decodes back to exactly the destination** — the property the whole feature rests on.
- **A lookalike host does not match**: `notyoutube.com` and `evil-x.com` do not resolve to YouTube's or X's package. Suffix matching is on a dot boundary.
- **The fallback is percent-encoded**, so a destination containing `;` or `&` cannot truncate the intent and strand the visitor.
- Subdomains (`m.`, `open.`, `www.`) resolve without an entry each; X and Twitter share one app.

Plus end-to-end assertions in `scripts/smoke-redirect.sh` against the live service in CI: an Android UA gets an `intent://` with the package and a fallback; an iPhone UA, a desktop UA, the flag turned off, and an unknown host all get the plain URL.

## Not done, and why

- **No custom URI schemes.** Explained above: without a platform-controlled fallback they are a net loss. If a specific app ever needs one, the table is the place, and the test file already documents the property any addition has to keep.
- **The table is a fixed list, not per-link configuration.** A "which app?" field per link would let someone point a YouTube URL at Spotify's package, which fails in a way nobody would debug. Adding a host to the table is a one-line change.
- **Untestable without a device:** whether Chrome actually honours the intent on a real Android handset. The URL shape is verified against the documented format and the fallback is proven to round-trip, but nobody has clicked one on a phone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_