### PR TITLE
feat(analytics): city-level geo, from the edge, with a floor under it

### DIFF
--- a/apps/api/src/analytics/analytics.service.test.ts
+++ b/apps/api/src/analytics/analytics.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fillSeries, iso, percentChange, windowFor } from "./analytics.service.js";
+import { CITY_MIN_CLICKS, OTHER_CITIES, applyCityFloor, fillSeries, iso, percentChange, windowFor } from "./analytics.service.js";
 
 /* The three pure helpers behind every number on the analytics screen. Each has
    a failure mode that renders as a plausible-looking chart rather than an
@@ -123,5 +123,74 @@ describe("fillSeries", () => {
 describe("iso", () => {
   it("formats a date as the YYYY-MM-DD key the rollups are keyed on", () => {
     expect(iso(new Date("2026-03-01T13:45:00.000Z"))).toBe("2026-03-01");
+  });
+});
+
+describe("applyCityFloor", () => {
+  const total = (rows: Array<{ value: number }>) => rows.reduce((n, r) => n + r.value, 0);
+
+  it("names a city that clears the threshold", () => {
+    const out = applyCityFloor([{ label: "Pune", value: CITY_MIN_CLICKS }]);
+    expect(out).toEqual([{ label: "Pune", value: CITY_MIN_CLICKS }]);
+  });
+
+  it("folds a city one click short of the threshold", () => {
+    // The whole point: "Pune · 1 click" beside one iPhone and one referrer is
+    // a person, not a statistic.
+    const out = applyCityFloor([{ label: "Pune", value: CITY_MIN_CLICKS - 1 }]);
+    expect(out).toEqual([{ label: OTHER_CITIES, value: CITY_MIN_CLICKS - 1 }]);
+  });
+
+  it("keeps the total intact when it folds", () => {
+    const rows = [
+      { label: "Mumbai", value: 40 },
+      { label: "Pune", value: 3 },
+      { label: "Nashik", value: 2 },
+      { label: "Satara", value: 1 },
+    ];
+    const out = applyCityFloor(rows);
+    expect(total(out)).toBe(total(rows));
+    expect(out).toEqual([
+      { label: "Mumbai", value: 40 },
+      { label: OTHER_CITIES, value: 6 },
+    ]);
+  });
+
+  it("passes Unknown through however small it is", () => {
+    // Unknown is already an aggregate of every click CloudFront could not
+    // place, so it identifies nobody — and folding it would lose the
+    // difference between "we don't know" and "too few to say".
+    const out = applyCityFloor([{ label: "Unknown", value: 1 }, { label: "Pune", value: 1 }]);
+    expect(out).toEqual([
+      { label: "Unknown", value: 1 },
+      { label: OTHER_CITIES, value: 1 },
+    ]);
+  });
+
+  it("adds no bucket when nothing was folded", () => {
+    const out = applyCityFloor([{ label: "Mumbai", value: 9 }]);
+    expect(out.some((r) => r.label === OTHER_CITIES)).toBe(false);
+  });
+
+  it("rolls the trimmed tail into the bucket rather than dropping it", () => {
+    // Trimming to the top N *after* folding would silently lose volume, and
+    // the dashboard totals would stop agreeing with the click count.
+    const rows = Array.from({ length: 12 }, (_, i) => ({ label: `City${i}`, value: 100 - i }));
+    const out = applyCityFloor(rows, CITY_MIN_CLICKS, 8);
+    expect(out).toHaveLength(9);
+    expect(out[8]!.label).toBe(OTHER_CITIES);
+    expect(total(out)).toBe(total(rows));
+  });
+
+  it("returns the strongest cities first", () => {
+    const out = applyCityFloor([
+      { label: "Small", value: 6 },
+      { label: "Big", value: 60 },
+    ]);
+    expect(out.map((r) => r.label)).toEqual(["Big", "Small"]);
+  });
+
+  it("handles an empty window", () => {
+    expect(applyCityFloor([])).toEqual([]);
   });
 });

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -64,8 +64,12 @@ export class AnalyticsService {
       .groupBy(clickDaily.day)
       .orderBy(clickDaily.day);
 
-    const [countries, devices, browsers, referrers] = await Promise.all([
+    const [countries, cities, devices, browsers, referrers] = await Promise.all([
       this.breakdown(workspaceId, "country", start, query.linkId),
+      /* Unlimited, because the k-anonymity floor has to see the whole tail to
+         fold it — taking the top 8 first would discard the small cities rather
+         than aggregate them, and the total would stop adding up. */
+      this.breakdown(workspaceId, "city", start, query.linkId, 0).then(applyCityFloor),
       this.breakdown(workspaceId, "device", start, query.linkId),
       this.breakdown(workspaceId, "browser", start, query.linkId),
       this.breakdown(workspaceId, "referrer", start, query.linkId),
@@ -125,6 +129,7 @@ export class AnalyticsService {
         value: c.value,
         icon: FLAGS[c.label] ?? "🌐",
       })),
+      cities,
       devices,
       browsers,
       referrers,
@@ -133,7 +138,13 @@ export class AnalyticsService {
     };
   }
 
-  private async breakdown(workspaceId: string, dimension: string, start: Date, linkId?: string): Promise<Breakdown[]> {
+  private async breakdown(
+    workspaceId: string,
+    dimension: string,
+    start: Date,
+    linkId?: string,
+    limit = 8,
+  ): Promise<Breakdown[]> {
     const filters = [
       eq(breakdownDaily.workspaceId, workspaceId),
       eq(breakdownDaily.dimension, dimension),
@@ -146,10 +157,9 @@ export class AnalyticsService {
       .from(breakdownDaily)
       .where(and(...filters))
       .groupBy(breakdownDaily.value)
-      .orderBy(desc(sql`sum(${breakdownDaily.count})`))
-      .limit(8);
+      .orderBy(desc(sql`sum(${breakdownDaily.count})`));
 
-    return rows.map((r) => ({ label: r.label, value: r.value }));
+    return (limit > 0 ? rows.slice(0, limit) : rows).map((r) => ({ label: r.label, value: r.value }));
   }
 
   /** Tags live on the link, not on the click, so this joins rather than
@@ -178,6 +188,48 @@ export class AnalyticsService {
       .limit(8);
     return rows.map((r) => ({ label: r.slug, value: r.value }));
   }
+}
+
+/**
+ * The smallest number of clicks a city may be named for.
+ *
+ * Country plus device plus browser identifies nobody. City plus device plus
+ * browser plus OS plus referrer, somewhere small enough, can. Five is a
+ * judgement, not a standard — raise it here and everywhere follows.
+ */
+export const CITY_MIN_CLICKS = 5;
+
+/** What the folded remainder is called. */
+export const OTHER_CITIES = "Other cities";
+
+/**
+ * Fold thinly-populated cities into one bucket.
+ *
+ * The total is preserved, so the workspace loses no volume — it loses only the
+ * ability to read "one visitor, this city" off the dashboard beside a single
+ * device and a single referrer. See docs/DECISIONS.md.
+ *
+ * "Unknown" is passed through whatever its size: it is already an aggregate of
+ * every click CloudFront could not place, so it identifies no one, and folding
+ * it into "Other cities" would lose the distinction between "we don't know"
+ * and "too few to say".
+ */
+export function applyCityFloor(rows: Breakdown[], min = CITY_MIN_CLICKS, limit = 8): Breakdown[] {
+  const named: Breakdown[] = [];
+  let folded = 0;
+
+  for (const row of rows) {
+    if (row.label === "Unknown" || row.value >= min) named.push(row);
+    else folded += row.value;
+  }
+
+  named.sort((a, b) => b.value - a.value);
+  // Trim before adding the bucket, so the bucket cannot itself be trimmed away
+  // and take the tail's volume with it.
+  const top = named.slice(0, limit);
+  for (const row of named.slice(limit)) folded += row.value;
+
+  return folded > 0 ? [...top, { label: OTHER_CITIES, value: folded }] : top;
 }
 
 export function iso(d: Date): string {

--- a/apps/redirect/src/click-sink.ts
+++ b/apps/redirect/src/click-sink.ts
@@ -15,6 +15,7 @@ export interface ClickEvent {
   occurredAt: Date;
   visitorHash: string;
   country: string | null;
+  city: string | null;
   device: string | null;
   browser: string | null;
   os: string | null;
@@ -40,6 +41,7 @@ export class PostgresClickSink implements ClickSink {
       occurredAt: event.occurredAt,
       visitorHash: event.visitorHash,
       country: event.country,
+      city: event.city,
       device: event.device,
       browser: event.browser,
       os: event.os,

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -219,6 +219,10 @@ function record(
         occurredAt: new Date(),
         visitorHash: hash,
         country: ((request.headers["cloudfront-viewer-country"] as string) ?? "").toUpperCase().slice(0, 2) || null,
+        /* Deliberately not paired with CloudFront-Viewer-Latitude/Longitude,
+           which the same header family offers: a city is a population, a
+           coordinate is a location. */
+        city: ((request.headers["cloudfront-viewer-city"] as string) ?? "").slice(0, 100) || null,
         device: parseDevice(userAgent),
         browser: parseBrowser(userAgent),
         os: parseOs(userAgent),

--- a/apps/worker/src/jobs/rollup.ts
+++ b/apps/worker/src/jobs/rollup.ts
@@ -88,6 +88,7 @@ export async function rollupClicks(db: Database, batchSize = 50_000): Promise<Ro
     // dashboard renders them identically.
     for (const [dimension, column] of [
       ["country", sql`country`],
+      ["city", sql`city`],
       ["device", sql`device`],
       ["browser", sql`browser`],
       ["referrer", sql`referrer_host`],

--- a/docs/COMPETITIVE-GAP-ANALYSIS.md
+++ b/docs/COMPETITIVE-GAP-ANALYSIS.md
@@ -11,7 +11,7 @@ This is a product-surface comparison, not a security or performance review. InAp
 | --- | --- | --- |
 | Custom forms | Missing | No form builder, shareable form URL, response table, or CSV response export. |
 | Native-app deep linking | Partial | SnapURL has a `deepLink` flag, but no app-specific routing, app fallback configuration, or supported-app integrations. InApp advertises YouTube, Spotify, Instagram, X, Amazon, TikTok, WhatsApp, Facebook, SoundCloud, and Etsy. |
-| City-level analytics | Missing | SnapURL reports country, device, browser, referrer, tags, links, QR scans, and conversions. Its documented geo input is country-level, not city-level. |
+| City-level analytics | Present | Resolved from CloudFront's edge header, so no IP is stored to produce it, and cities below a five-click floor are folded into "Other cities" rather than named. The reasoning is in [DECISIONS.md](./DECISIONS.md). |
 | Tracking pixels | Missing | No tracking-pixel configuration or delivery path is implemented. |
 | Scheduled activation | Missing | SnapURL supports expiry dates and expiry fallbacks, but not a future activation/start date. |
 | Bulk link creation | UI gap | The Links page shows a `Bulk create` action, but no complete bulk-create workflow or contract is implemented. |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -334,6 +334,44 @@ access to this account.
 Lambda's configuration. That was already true of the database password before this
 change, and it is the same trade, made once, for the same reason.
 
+### City-level geo: CloudFront's header, never an IP, never coordinates
+
+**Asked by #240, which was right to block on it.**
+
+Three options, and the licensed GeoIP database is excluded twice over. It needs the
+visitor's IP in the redirect process's memory to do the lookup, which reintroduces
+exactly what `click_events` was designed without, and it means shipping megabytes of
+database into a 512 MB Lambda that sits on the hot path.
+
+**What I chose:** CloudFront resolves the IP at its edge and hands us
+`CloudFront-Viewer-City` as a header, already a name. Our code never sees an IP for
+geolocation. `click_events` still has no `ip` column, no cookie is set, and nothing is
+stored on the visitor's device — every claim on the landing page and the settings page
+stays literally true, which is the bar #217 set and I did not want to quietly lower.
+
+**But city is more identifying than country, and that is the part worth saying out
+loud.** Country plus device plus browser identifies nobody. City plus device plus
+browser plus OS plus referrer, in a small enough place, can. So two limits come with
+it:
+
+- **The city name only. Never `CloudFront-Viewer-Latitude/Longitude`,** which the same
+  header family offers and which is the easy mistake to make — they are adjacent in
+  AWS's documentation. A city name is a population; a coordinate pair is a location.
+- **A k-anonymity floor of five.** A city with fewer than five clicks in the window is
+  folded into "Other cities" rather than given its own row. The total still adds up, so
+  the workspace loses no volume — but "Bengaluru · 1 click" never renders beside a
+  single iPhone and a single referrer. The threshold is one named constant, so raising
+  or removing it is a one-line decision rather than an archaeology exercise.
+
+**What it costs:** coverage. CloudFront's city data is coarse and frequently absent,
+particularly on mobile networks and behind VPNs. Those clicks roll up as "Unknown".
+That is the honest price of not shipping a GeoIP database, and it is visible in the
+dashboard rather than hidden.
+
+**What would revisit it:** anyone needing reliable or finer-grained location. That is a
+different product with a different promise, and the marketing copy would have to change
+before the code did — not after.
+
 ### `cdk synth` was staging its own output into itself
 
 **Found by:** running it. The stack merged in #246 did not synthesise at all.

--- a/packages/contract/src/analytics.ts
+++ b/packages/contract/src/analytics.ts
@@ -34,6 +34,12 @@ export const Analytics = z.object({
   }),
   series: z.array(TimeseriesPoint),
   countries: z.array(Breakdown),
+  /**
+   * Cities, with a k-anonymity floor applied — anything below the threshold is
+   * folded into "Other cities" rather than named. Resolved from CloudFront's
+   * edge header, so no IP is stored to produce it. See docs/DECISIONS.md.
+   */
+  cities: z.array(Breakdown),
   devices: z.array(Breakdown),
   browsers: z.array(Breakdown),
   referrers: z.array(Breakdown),

--- a/packages/database/drizzle/0004_click_city.sql
+++ b/packages/database/drizzle/0004_click_city.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "click_events" ADD COLUMN "city" varchar(100);

--- a/packages/database/drizzle/meta/0004_snapshot.json
+++ b/packages/database/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2727 @@
+{
+  "id": "8e457225-0e47-4fd7-9b08-cdac85502603",
+  "prevId": "6ffe1664-9ab0-4e2f-b711-d30494862f6a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invite_token_hash": {
+          "name": "invite_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_workspace_email_key": {
+          "name": "memberships_workspace_email_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recovery_codes": {
+      "name": "recovery_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recovery_codes_user_idx": {
+          "name": "recovery_codes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_user_id_users_id_fk": {
+          "name": "recovery_codes_user_id_users_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_hash_key": {
+          "name": "refresh_tokens_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_family_idx": {
+          "name": "refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled_at": {
+          "name": "totp_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Free'"
+        },
+        "default_domain_id": {
+          "name": "default_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_redirect": {
+          "name": "default_redirect",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "clicks_included": {
+          "name": "clicks_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000000
+        },
+        "retention_years": {
+          "name": "retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cookieless_analytics": {
+          "name": "cookieless_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scan_on_create": {
+          "name": "scan_on_create",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_previews": {
+          "name": "public_previews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_key": {
+          "name": "workspaces_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verifying'"
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ssl_renews_at": {
+          "name": "ssl_renews_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_redirect": {
+          "name": "root_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_redirect": {
+          "name": "not_found_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domains_domain_key": {
+          "name": "domains_domain_key",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domains_workspace_idx": {
+          "name": "domains_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_workspace_id_workspaces_id_fk": {
+          "name": "domains_workspace_id_workspaces_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_to": {
+          "name": "expires_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activates_at": {
+          "name": "activates_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_to": {
+          "name": "scheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_limit": {
+          "name": "click_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forward_query": {
+          "name": "forward_query",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_referrer": {
+          "name": "hide_referrer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_preview": {
+          "name": "public_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cloaked": {
+          "name": "cloaked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safe_browsing_status": {
+          "name": "safe_browsing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "safe_browsing_checked_at": {
+          "name": "safe_browsing_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_clicks": {
+          "name": "unique_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "links_domain_slug_key": {
+          "name": "links_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_created_idx": {
+          "name": "links_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_tags_idx": {
+          "name": "links_workspace_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "links_expires_idx": {
+          "name": "links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_activates_idx": {
+          "name": "links_activates_idx",
+          "columns": [
+            {
+              "expression": "activates_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"activates_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "links_workspace_id_workspaces_id_fk": {
+          "name": "links_workspace_id_workspaces_id_fk",
+          "tableFrom": "links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "links_domain_id_domains_id_fk": {
+          "name": "links_domain_id_domains_id_fk",
+          "tableFrom": "links",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "links_created_by_users_id_fk": {
+          "name": "links_created_by_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projection_outbox": {
+      "name": "projection_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projection_outbox_pending_idx": {
+          "name": "projection_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"projection_outbox\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_rules": {
+      "name": "routing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "when_country": {
+          "name": "when_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_device": {
+          "name": "when_device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_language": {
+          "name": "when_language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "then": {
+          "name": "then",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_rules_link_position_key": {
+          "name": "routing_rules_link_position_key",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_rules_link_id_links_id_fk": {
+          "name": "routing_rules_link_id_links_id_fk",
+          "tableFrom": "routing_rules",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.breakdown_daily": {
+      "name": "breakdown_daily",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "breakdown_daily_key": {
+          "name": "breakdown_daily_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"link_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "breakdown_daily_lookup_idx": {
+          "name": "breakdown_daily_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "breakdown_daily_workspace_id_workspaces_id_fk": {
+          "name": "breakdown_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "breakdown_daily_link_id_links_id_fk": {
+          "name": "breakdown_daily_link_id_links_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily": {
+      "name": "click_daily",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scans": {
+          "name": "scans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "click_daily_workspace_day_idx": {
+          "name": "click_daily_workspace_day_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_daily_link_id_links_id_fk": {
+          "name": "click_daily_link_id_links_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_daily_workspace_id_workspaces_id_fk": {
+          "name": "click_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_link_id_day_pk": {
+          "name": "click_daily_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_events": {
+      "name": "click_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_host": {
+          "name": "referrer_host",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_qr": {
+          "name": "is_qr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_rule_id": {
+          "name": "matched_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_up_at": {
+          "name": "rolled_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "click_events_link_time_idx": {
+          "name": "click_events_link_time_idx",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_workspace_time_idx": {
+          "name": "click_events_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_pending_idx": {
+          "name": "click_events_pending_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"click_events\".\"rolled_up_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_events_link_id_links_id_fk": {
+          "name": "click_events_link_id_links_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_events_workspace_id_workspaces_id_fk": {
+          "name": "click_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversions": {
+      "name": "conversions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "value_minor": {
+          "name": "value_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversions_workspace_time_idx": {
+          "name": "conversions_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversions_external_key": {
+          "name": "conversions_external_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversions\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversions_workspace_id_workspaces_id_fk": {
+          "name": "conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversions_link_id_links_id_fk": {
+          "name": "conversions_link_id_links_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_salts": {
+      "name": "daily_salts",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_visitors": {
+      "name": "daily_visitors",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_visitors_link_id_links_id_fk": {
+          "name": "daily_visitors_link_id_links_id_fk",
+          "tableFrom": "daily_visitors",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_visitors_link_id_day_visitor_hash_pk": {
+          "name": "daily_visitors_link_id_day_visitor_hash_pk",
+          "columns": [
+            "link_id",
+            "day",
+            "visitor_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_last4": {
+          "name": "key_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_hash_key": {
+          "name": "api_keys_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_workspace_idx": {
+          "name": "api_keys_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_time_idx": {
+          "name": "audit_log_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_workspace_id_workspaces_id_fk": {
+          "name": "audit_log_workspace_id_workspaces_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_blocks": {
+      "name": "bio_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "bio_page_id": {
+          "name": "bio_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked": {
+          "name": "locked",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::jsonb"
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "bio_blocks_page_position_key": {
+          "name": "bio_blocks_page_position_key",
+          "columns": [
+            {
+              "expression": "bio_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_blocks_bio_page_id_bio_pages_id_fk": {
+          "name": "bio_blocks_bio_page_id_bio_pages_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "bio_pages",
+          "columnsFrom": [
+            "bio_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_blocks_link_id_links_id_fk": {
+          "name": "bio_blocks_link_id_links_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_pages": {
+      "name": "bio_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "profile_name": {
+          "name": "profile_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_bio": {
+          "name": "profile_bio",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bio_pages_domain_slug_key": {
+          "name": "bio_pages_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_pages_workspace_id_workspaces_id_fk": {
+          "name": "bio_pages_workspace_id_workspaces_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_pages_domain_id_domains_id_fk": {
+          "name": "bio_pages_domain_id_domains_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_webhook_idx": {
+          "name": "webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_workspace_idx": {
+          "name": "webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_workspace_id_workspaces_id_fk": {
+          "name": "webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787931698295,
       "tag": "0003_scheduled_activation",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1787989531374,
+      "tag": "0004_click_city",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/analytics.ts
+++ b/packages/database/src/schema/analytics.ts
@@ -44,6 +44,11 @@ export const clickEvents = pgTable(
     visitorHash: varchar("visitor_hash", { length: 32 }).notNull(),
 
     country: varchar("country", { length: 2 }),
+    /* Resolved by CloudFront at the edge and handed to us as a name, so no IP
+       is ever seen here for geolocation and none is stored. The city name and
+       nothing finer — never the latitude/longitude the same header family
+       offers. See docs/DECISIONS.md. */
+    city: varchar("city", { length: 100 }),
     device: varchar("device", { length: 10 }),
     browser: varchar("browser", { length: 40 }),
     os: varchar("os", { length: 20 }),

--- a/scripts/smoke-redirect.sh
+++ b/scripts/smoke-redirect.sh
@@ -81,7 +81,7 @@ contains "click-time UTM wins over stored" "utm_source=twitter" "$(loc "$RUN-utm
 
 echo
 echo "== routing chain =="
-contains "India goes to the India store" "example.in" "$(loc "$RUN-geo" -H 'CloudFront-Viewer-Country: IN')"
+contains "India goes to the India store" "example.in" "$(loc "$RUN-geo" -H 'CloudFront-Viewer-Country: IN' -H 'CloudFront-Viewer-City: Pune')"
 contains "iOS goes to the App Store" "apps.apple.com" "$(loc "$RUN-geo" -H 'User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)')"
 contains "everyone else gets the default" "example.com/rest" "$(loc "$RUN-geo" -H 'CloudFront-Viewer-Country: FR')"
 
@@ -129,6 +129,17 @@ if dbq "select column_name from information_schema.columns where table_name='cli
 else ok "click_events has no ip column"; fi
 HASHES=$(dbq "select count(distinct visitor_hash) from click_events where link_id in (select id from links where slug like '$RUN%')" | tr -d '[:space:]')
 [ -n "$HASHES" ] && ok "clicks recorded with visitor hashes ($HASHES distinct)" || bad "click recording" "no rows"
+
+# City comes from CloudFront's edge header, already resolved — the reason no IP
+# is needed to produce it. See docs/DECISIONS.md.
+CITY=$(dbq "select count(*) from click_events where city = 'Pune' and link_id in (select id from links where slug like '$RUN%')" | tr -d '[:space:]')
+[ "${CITY:-0}" -ge 1 ] && ok "the CloudFront city header is recorded" || bad "city not recorded" "count=$CITY"
+
+# The other half of that decision: a city name is a population, a coordinate is
+# a location, and only one of them belongs here.
+if dbq "select column_name from information_schema.columns where table_name='click_events' and column_name in ('latitude','longitude','lat','lon')" | grep -q .; then
+  bad "click_events stores no coordinates" "a latitude/longitude column exists"
+else ok "click_events has no coordinate columns"; fi
 
 echo
 echo "----------------------------------------"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -195,6 +195,16 @@ BODY=$(curl -s -X POST "$API/auth/refresh" -H 'Content-Type: application/json' -
 check "reuse revokes the whole family" 'signed out' "$BODY"
 
 echo
+echo "== analytics geo =="
+BODY=$(curl -s "$API/analytics?range=30d" -H "Authorization: Bearer $ACCESS")
+check "analytics reports countries" '"countries"' "$BODY"
+check "analytics reports cities"    '"cities"'    "$BODY"
+# The privacy line this feature had to stay behind: city is resolved at the
+# CDN edge and handed over as a name, so no IP column exists to hold one.
+NOIP=$(curl -s "$API/analytics?range=30d" -H "Authorization: Bearer $ACCESS" | grep -c '"ip"' || true)
+if [ "$NOIP" = "0" ]; then ok "analytics exposes no IP"; else bad "ip leaked in analytics" "$BODY"; fi
+
+echo
 echo "== bulk create =="
 mkbulk() { # mkbulk <json-array-of-links>
   curl -s -X POST "$API/links/bulk" -H "Authorization: Bearer $ACCESS" -H 'Content-Type: application/json' -d "{\"links\":$1}"

--- a/web/src/app/(app)/analytics/page.tsx
+++ b/web/src/app/(app)/analytics/page.tsx
@@ -101,6 +101,7 @@ export default function AnalyticsPage() {
             {(
               [
                 ["Countries", data.countries],
+                ["Cities", data.cities],
                 ["Browsers", data.browsers],
                 ["Tags", data.tags],
               ] as const

--- a/web/src/app/(app)/links/[id]/page.tsx
+++ b/web/src/app/(app)/links/[id]/page.tsx
@@ -264,6 +264,7 @@ export default function LinkDetailPage() {
         {(
           [
             ["Countries", a?.countries],
+            ["Cities", a?.cities],
             ["Devices", a?.devices],
             ["Referrers", a?.referrers],
           ] as const

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 const FEATURES = [
   { icon: "◈", title: "Your domain, your links", body: "Bring any domain, get automatic SSL, and set root and 404 redirects. Five domains on the free plan — not one." },
   { icon: "⇄", title: "Route by anything", body: "Send India to the India store, iOS to the App Store, and split the rest 50/50 for an A/B test. Rules run at the edge." },
-  { icon: "▤", title: "Analytics without cookies", body: "Country, device, browser, referrer and conversions — measured with a daily-rotating hash. Nothing stored on the visitor's device." },
+  { icon: "▤", title: "Analytics without cookies", body: "Country, city, device, browser, referrer and conversions — measured with a daily-rotating hash. No IP stored, nothing left on the visitor's device." },
   { icon: "▩", title: "QR that stays correct", body: "Print it once, change where it points forever. SVG, PDF and EPS export, with your logo in the middle." },
   { icon: "🛡", title: "Trust, made visible", body: "Anyone can add + to a short link to see exactly where it goes, who made it and what it sets, before clicking." },
   { icon: "⌘", title: "Built for automation", body: "REST API, typed SDKs, real-time webhooks, a CLI and an MCP server. Your agents can ship links too." },

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -304,6 +304,17 @@ export const ANALYTICS: Analytics = {
     { label: "Singapore", value: 22406, icon: "🇸🇬" },
     { label: "Australia", value: 16008, icon: "🇦🇺" },
   ],
+  /* Shaped the way the API returns it: the long tail of small cities is
+     folded into one bucket rather than named, so the fixture cannot teach a
+     UI habit the real endpoint will not support. */
+  cities: [
+    { label: "Mumbai", value: 51204 },
+    { label: "Bengaluru", value: 38110 },
+    { label: "London", value: 26440 },
+    { label: "New York", value: 21008 },
+    { label: "Unknown", value: 18902 },
+    { label: "Other cities", value: 9877 },
+  ],
   devices: [
     { label: "iOS", value: 34980, icon: "📱" },
     { label: "Android", value: 29104, icon: "🤖" },


### PR DESCRIPTION
## What does this PR do?

Fixes #240

The issue was right to block on a decision. **The decision is written into `docs/DECISIONS.md`**, not just into this description — that was the actual deliverable.

### The decision

A **licensed GeoIP database is excluded twice over**: it needs the visitor's IP in the redirect process's memory to do the lookup — reintroducing exactly what `click_events` was designed without — and it means shipping megabytes into a 512 MB Lambda that sits on the hot path.

**CloudFront resolves the IP at its edge and hands over a name.** `CloudFront-Viewer-City` arrives already resolved. Our code never sees an IP for geolocation, `click_events` still has no `ip` column, no cookie is set, and nothing is stored on the visitor's device. Every public claim stays literally true — the bar #217 set, which I did not want to quietly lower to ship a competitor-parity feature.

### But city is more identifying than country, so two limits ship with it

Country + device + browser identifies nobody. City + device + browser + OS + referrer, in a small enough place, can.

**1. The city name only — never coordinates.** `CloudFront-Viewer-Latitude/Longitude` is offered by the same header family and sits next to it in AWS's documentation, which makes taking both the easy mistake. A city name is a population; a coordinate pair is a location. There is now a smoke assertion that **no coordinate column exists**, so adding one later has to be deliberate rather than incidental.

**2. A k-anonymity floor of five.** A city below it is folded into `Other cities` rather than named. The total is preserved, so the workspace loses no volume — it loses only the ability to read *"one visitor, this city"* off the dashboard beside a single device and a single referrer. The threshold is one named constant.

One ordering detail that matters: **the fold happens before the top-eight trim.** Trimming first would drop the tail's volume instead of aggregating it, and the dashboard totals would stop agreeing with the click count. There is a test for exactly that.

### What it costs

Coverage. CloudFront's city data is coarse and frequently absent, particularly on mobile networks and behind VPNs. Those clicks report `Unknown` — visibly, rather than being quietly attributed somewhere plausible. That is the honest price of not shipping a GeoIP database.

### Copy corrected

The landing page listed *"Country, device, browser, referrer and conversions"*; it now includes city and states **"No IP stored"**, which is the claim a reader would reasonably start doubting once they see city-level data. `COMPETITIVE-GAP-ANALYSIS.md` moves this row from Missing to Present with the constraints named.

## Requirement/Documentation

- Issue #240, which asked for the posture to be decided first.
- `docs/DECISIONS.md` — new entry with the three options, what was chosen, what it costs, and what would revisit it.

This does not contradict an existing decision. It sits directly alongside the cookieless/visitor-hash reasoning and keeps every claim #224 made honest.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

Additive: one nullable column, one contract field, one rollup dimension. Existing clicks record `city` as null and roll up as `Unknown`.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass. Migration is `0004_click_city.sql`, generated with `drizzle-kit` so the snapshot and journal stay usable.

**8 new unit tests** on `applyCityFloor` (API suite 77, up from 69) — the enforcement mechanism is pure, so it is verified here rather than only in CI:

- A city at the threshold is named; one click short is folded.
- **The total is preserved when folding** — the property the design rests on.
- **The trimmed tail rolls into the bucket rather than being dropped.**
- `Unknown` passes through at any size: it is already an aggregate of unplaceable clicks, and folding it would lose the difference between *"we don't know"* and *"too few to say"*.
- No bucket is added when nothing was folded.

End-to-end in CI against live Postgres 18:

- `scripts/smoke.sh` — analytics returns `cities`, and exposes no `ip`.
- `scripts/smoke-redirect.sh` — a click carrying `CloudFront-Viewer-City` is **recorded with that city**, `click_events` still has no `ip` column, and **no latitude/longitude column exists**.

I could not run the smoke or integration suites locally — no Docker daemon here, and the only local Postgres is 16, which cannot run this schema.

## Not done, and why

- **Nothing enables the city header on the CloudFront distribution.** `infra/lib/snapurl-stack.ts` uses `ALL_VIEWER_EXCEPT_HOST_HEADER` as its origin request policy, which forwards viewer headers but does **not** add CloudFront's generated `CloudFront-Viewer-*` set — those need a managed policy or a custom one that names them. The stack has never been deployed (#233), so I have left the topology alone rather than change infrastructure I cannot verify. Until that policy is set, `city` is null in production and everything reports `Unknown` — correctly, and visibly. Worth a follow-up issue against the stack rather than a speculative edit here.
- **No city-level routing rule.** The routing chain matches on country, device and language. Adding city as a condition is a separate feature and a larger surface (`packages/domain/src/routing.ts`, the rules editor, the redirect evaluator), not implied by an analytics issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_