### PR TITLE
docs(privacy): decline third-party tracking pixels, and make it enforceable

### DIFF
--- a/docs/COMPETITIVE-GAP-ANALYSIS.md
+++ b/docs/COMPETITIVE-GAP-ANALYSIS.md
@@ -12,7 +12,7 @@ This is a product-surface comparison, not a security or performance review. InAp
 | Custom forms | Missing | No form builder, shareable form URL, response table, or CSV response export. |
 | Native-app deep linking | Partial | SnapURL has a `deepLink` flag, but no app-specific routing, app fallback configuration, or supported-app integrations. InApp advertises YouTube, Spotify, Instagram, X, Amazon, TikTok, WhatsApp, Facebook, SoundCloud, and Etsy. |
 | City-level analytics | Present | Resolved from CloudFront's edge header, so no IP is stored to produce it, and cities below a five-click floor are folded into "Other cities" rather than named. The reasoning is in [DECISIONS.md](./DECISIONS.md). |
-| Tracking pixels | Missing | No tracking-pixel configuration or delivery path is implemented. |
+| Tracking pixels | **Declined** | Not a gap. Delivering one needs an HTML interstitial in place of the 302, needs EU/UK consent before it may run, and contradicts three public claims. `POST /conversions` plus webhooks already serve the attribution need server-side. Reasoning in [DECISIONS.md](./DECISIONS.md). |
 | Scheduled activation | Missing | SnapURL supports expiry dates and expiry fallbacks, but not a future activation/start date. |
 | Bulk link creation | UI gap | The Links page shows a `Bulk create` action, but no complete bulk-create workflow or contract is implemented. |
 | CSV export | UI gap | The Links page shows `Export`, and settings mention export/import, but no complete export endpoint/workflow is implemented. |
@@ -80,4 +80,4 @@ Evidence: [packages/contract/src/link.ts](../packages/contract/src/link.ts), [pa
 4. Build forms and response export as a separate product module.
 5. Add city-level analytics only after choosing a privacy-preserving geo data source.
 6. Add OAuth and billing once account and commercial requirements are defined.
-7. Add tracking pixels only with clear consent, privacy, and browser-blocking expectations.
+7. Tracking pixels are declined, not deferred — see [DECISIONS.md](./DECISIONS.md). If that is ever reversed, the order is marketing copy first, preview-page disclosure second, code last.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -334,6 +334,47 @@ access to this account.
 Lambda's configuration. That was already true of the database password before this
 change, and it is the same trade, made once, for the same reason.
 
+### Third-party tracking pixels: declined
+
+**Asked by #243, which was right to refuse to be implemented silently.**
+
+The competitor offers Meta and Google pixels on redirects. This does not, and the
+decision is to keep it that way. Four reasons, in the order they'd bite.
+
+**It cannot be done with a 302.** A pixel has to execute in the visitor's browser, so
+the redirect stops being a redirect and becomes an HTML interstitial that loads
+third-party script, waits for it, then navigates. That throws away the reason
+`apps/redirect` exists as a separate dependency-light service on the hot path, and it
+puts a full page load in front of every QR scan on mobile data. The smoke suite now
+asserts that a successful redirect is a 3xx and not HTML, so this cannot be reintroduced
+by accident.
+
+**It is unlawful in the EU and UK without prior consent.** ePrivacy requires consent
+before non-essential third-party storage. So the interstitial needs a consent banner —
+a cookie banner in the middle of a redirect, shown to everyone who clicks a short link.
+That is a worse product than not having the feature, and the version without the banner
+is worse still, because it is illegal rather than merely annoying.
+
+**Three public claims would have to be reworded**, and the schema's guarantees would
+stop being mechanisms and become marketing: "no tracking cookies" on the landing page,
+"we do not set cookies, and we never sell click data" on the public preview page, and
+"nothing is stored on their device" in settings. Giving click data away to Meta for
+free is not meaningfully better than selling it.
+
+**The need behind the request is already met, server-side.** People asking for pixels
+want ad-campaign attribution. `POST /conversions` exists for exactly that — scoped to an
+API key so the customer's own site reports the conversion — alongside
+`conversion.recorded` webhooks and UTM forwarding, so the advertiser's own analytics
+attributes the click. That reaches the same business outcome without putting a third
+party on the visitor's device, and it keeps working for the growing share of visitors
+whose browsers block pixels outright.
+
+**What would revisit it:** a deliberate decision to stop competing on privacy. #243
+already describes the honest shape if so — opt-in per link, disclosed on the public
+preview page, marketing copy changed first. The ordering in that sentence is the
+important part: copy first, then disclosure, then code. Shipping the code first is how
+a privacy product becomes a surveillance product without anyone deciding to.
+
 ### City-level geo: CloudFront's header, never an IP, never coordinates
 
 **Asked by #240, which was right to block on it.**

--- a/scripts/smoke-redirect.sh
+++ b/scripts/smoke-redirect.sh
@@ -141,6 +141,19 @@ if dbq "select column_name from information_schema.columns where table_name='cli
   bad "click_events stores no coordinates" "a latitude/longitude column exists"
 else ok "click_events has no coordinate columns"; fi
 
+# A tracking pixel cannot run inside a 302 — it needs an HTML interstitial to
+# execute third-party script in the visitor's browser. Asserting that a
+# successful redirect is still a bare 3xx turns "we don't do that" from a
+# claim on the landing page into something CI enforces. See DECISIONS.md.
+RH=$(curl -s -o /dev/null -D - "$RD/$RUN-plain" | tr -d '\r')
+if echo "$RH" | grep -qi "content-type: *text/html"; then
+  bad "a redirect is a redirect, not an interstitial" "$(echo "$RH" | head -3)"
+else ok "a redirect is a redirect, not an interstitial"; fi
+
+BODY_BYTES=$(curl -s "$RD/$RUN-plain" | wc -c | tr -d '[:space:]')
+if [ "$BODY_BYTES" -lt 256 ]; then ok "the redirect carries no page to hang a pixel on ($BODY_BYTES bytes)";
+else bad "redirect body is large enough to be a page" "$BODY_BYTES bytes"; fi
+
 echo
 echo "----------------------------------------"
 echo "  $PASSES passed, $FAILS failed"


### PR DESCRIPTION
## What does this PR do?

Fixes #243

The issue asked for an explicit decision and asked not to be implemented silently. **The decision is to decline**, and it is written into `docs/DECISIONS.md` rather than left in a closed issue where the next person to ask will not find it.

To be clear about what this PR is: it adds no pixel feature. It records a decision and adds two assertions that keep it true.

### Why decline — four reasons, in the order they bite

**1. It cannot be done with a 302.** A pixel has to execute in the visitor's browser. So the redirect stops being a redirect and becomes an HTML interstitial that loads third-party script, waits for it, then navigates. That throws away the reason `apps/redirect` exists as a separate, dependency-light service on the hot path — and puts a full page load in front of every QR scan on mobile data.

**2. It is unlawful in the EU and UK without prior consent.** ePrivacy requires consent before non-essential third-party storage. So the interstitial needs a **consent banner in the middle of a redirect**, shown to everyone who clicks a short link. That is a worse product than not having the feature — and the version without the banner is worse still, because it is illegal rather than merely annoying.

**3. Three public claims would have to be reworded**, and the schema's guarantees would stop being mechanisms and become marketing:

| Where | Claim |
| --- | --- |
| Landing page | "No tracking cookies" |
| Public preview page | "We do not set cookies, and we never sell click data" |
| Settings | "Nothing is stored on their device" |

All three verified still present. Giving click data to Meta for free is not meaningfully better than selling it.

**4. The need behind the request is already met, server-side.** People asking for pixels want ad-campaign attribution. `POST /conversions` exists for exactly that — scoped to `conversions:write` so a customer's own site reports the conversion with an API key — alongside `conversion.recorded` webhooks and UTM forwarding, so the advertiser's own analytics attributes the click. Same business outcome, no third party on the visitor's device, and it keeps working for the growing share of visitors whose browsers block pixels outright.

### Making it a mechanism, not a claim

A decision in a document decays. Two smoke assertions now hold the line, in the same spirit as the existing `click_events has no ip column` check:

- **A successful redirect must not be `text/html`.**
- **Its body must stay under 256 bytes** — too small to be a page.

Both are true today, and both would fail the moment an interstitial appeared, which is the shape reintroducing this would necessarily take.

## Requirement/Documentation

- Issue #243, which set the bar: *"Do not implement silently."*
- `docs/DECISIONS.md` — the full reasoning and what would revisit it.
- `docs/COMPETITIVE-GAP-ANALYSIS.md` — this row moves from *Missing* to **Declined**. It is not a gap; it is a differentiator, and listing it as missing invites someone to close it.

## Type of change

- [x] This change requires a documentation update
- [x] Chore (adds test coverage that pins an existing invariant)

No runtime code changes.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass. The two new assertions run in `scripts/smoke-redirect.sh` against the live redirect service in CI. I could not run that suite locally — no Docker daemon here, and the only local Postgres is 16, which cannot run this schema.

## This is a reversible decision, and the reversal has an order

If you want pixels anyway, that is your call to make, not mine — I have recorded a decision, not closed a door. #243 already describes the honest shape: opt-in per link, disclosed on the public preview page, marketing copy changed first.

**The ordering in that sentence is the important part.** Copy first, then disclosure, then code. Shipping the code first is how a privacy product becomes a surveillance product without anyone having decided to. If you'd like it built, say so and I will do it in that order — starting with the copy, so the claims stop being true only after they have stopped being made.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_