### PR TITLE
fix(settings): remove the billing controls rather than fake what is behind them

### DIFF
--- a/docs/COMPETITIVE-GAP-ANALYSIS.md
+++ b/docs/COMPETITIVE-GAP-ANALYSIS.md
@@ -18,7 +18,7 @@ This is a product-surface comparison, not a security or performance review. InAp
 | CSV export | UI gap | The Links page shows `Export`, and settings mention export/import, but no complete export endpoint/workflow is implemented. |
 | Link cloning | Missing | No clone operation is exposed in the link contract or API. |
 | Google and Apple login | Missing | SnapURL currently implements email/password authentication. InApp exposes Google and Apple sign-in. |
-| Billing and subscriptions | UI/demo gap | SnapURL displays plan and billing controls, but there is no implemented payment, upgrade, downgrade, or subscription lifecycle. |
+| Billing and subscriptions | Not built, and no longer implied | The unbacked controls are gone: no `Manage billing` button, and no quota gauge drawing a cap nothing enforces. The settings page now says everything is free and nothing is metered, which is true. Reasoning in [DECISIONS.md](./DECISIONS.md). |
 
 ## Partial or parity features
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -334,6 +334,38 @@ access to this account.
 Lambda's configuration. That was already true of the database password before this
 change, and it is the same trade, made once, for the same reason.
 
+### Billing: the controls are removed rather than faked
+
+**Asked by #242, whose own answer — "removing is the honest interim state" — is the one
+I took, for a reason worth recording.**
+
+Real billing is not buildable here. There is no payment provider configured, no
+credentials for one, and the brief this work runs under does not add dependencies — a
+provider SDK is exactly that. So the choice was never "implement or remove"; it was
+"remove, or leave a button that lies."
+
+What was actually unbacked, once separated from what was real:
+
+| | |
+| --- | --- |
+| `Manage billing` button | **Nothing behind it.** No payment integration, no upgrade path. Removed. |
+| The click quota bar | `clicksUsed` is genuinely counted from the rollups. `clicksIncluded` is a real column that **nothing reads but the display** — no code anywhere enforces it. The bar therefore drew a cap that does not exist, filled to 100%, and kept going. Now a plain count. |
+| "Five domains on the free plan" | Contradicted the settings page, which said Custom domains: Unlimited. Nothing enforces either. The landing page was the unbacked one. |
+
+`clicksIncluded` stays as a column and a contract field. It is real data, and a future
+billing implementation would want it — the problem was presenting it as a limit, not
+storing it.
+
+The domains contradiction is the part worth dwelling on. Two screens disagreed about the
+same number and neither was enforced, which is the same failure as the analytics and
+conversions disagreement above: a reader who notices stops trusting both screens, not
+just the wrong one.
+
+**What would revisit it:** a decision to charge for this, which needs a provider, a
+plan model, entitlement enforcement on the write paths, and an upgrade/downgrade
+lifecycle. That is a feature, not a button. Until it exists, the settings page says
+everything is free and nothing is metered, which has the advantage of being true.
+
 ### Third-party tracking pixels: declined
 
 **Asked by #243, which was right to refuse to be implemented silently.**

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -65,7 +65,6 @@ export default function SettingsPage() {
     }
   }
 
-  const usedPct = ws ? Math.min(100, Math.round((ws.clicksUsed / ws.clicksIncluded) * 100)) : 0;
 
   return (
     <>
@@ -251,18 +250,18 @@ export default function SettingsPage() {
 
         <div className="flex flex-col gap-3.5">
           <Card>
-            <CardHeader title="Plan & usage" right={<Chip tone="accent">{ws?.plan ?? "—"}</Chip>} />
+            <CardHeader title="Usage" right={<Chip tone="accent">{ws?.plan ?? "—"}</Chip>} />
             <CardBody className="flex flex-col gap-3.5">
-              <div>
-                <div className="flex justify-between text-[11.5px] text-ink-3 mb-[6px]">
-                  <span>Clicks this month</span>
-                  <b className="text-ink-2 font-mono tnum">
-                    {ws ? `${ws.clicksUsed.toLocaleString()} / ${ws.clicksIncluded.toLocaleString()}` : "—"}
-                  </b>
-                </div>
-                <div className="h-1 bg-surface-4 rounded-full overflow-hidden">
-                  <i className="block h-full bg-accent rounded-full" style={{ width: `${usedPct}%` }} />
-                </div>
+              {/* A real number, counted from the click rollups for the calendar
+                  month. It used to be drawn as a bar against clicksIncluded,
+                  which implied a cap — and nothing anywhere enforces one, so
+                  the bar filled up and then simply kept going. A count that is
+                  true beats a gauge that is not. */}
+              <div className="flex justify-between items-baseline">
+                <span className="text-[12.5px] text-ink-3">Clicks this month</span>
+                <b className="text-ink font-mono tnum text-[17px]">
+                  {ws ? ws.clicksUsed.toLocaleString() : "—"}
+                </b>
               </div>
               <div className="flex flex-col">
                 {["Links", "QR codes", "Destination edits", "Custom domains", "Bio pages", "Team members"].map((k) => (
@@ -272,11 +271,18 @@ export default function SettingsPage() {
                   </div>
                 ))}
               </div>
+              {/* The "Manage billing" button that used to sit here went
+                  nowhere: there is no payment integration, no entitlement
+                  enforcement and no upgrade path behind it. A control that
+                  does nothing is worse than an absent one, because someone
+                  eventually presses it. See docs/DECISIONS.md. */}
               <div className="px-[13px] py-[11px] bg-wash-good rounded-[var(--radius-sm)] text-[12.5px] text-good leading-[1.5]">
-                <b>Clicks are the only thing we count.</b>{" "}
-                <span className="text-ink-2">Nothing else is metered, on any plan.</span>
+                <b>Everything is free while SnapURL is in development.</b>{" "}
+                <span className="text-ink-2">
+                  Nothing is metered and there is no billing to manage. Clicks are counted so you can see them, not
+                  to charge for them.
+                </span>
               </div>
-              <Button className="justify-center">Manage billing</Button>
             </CardBody>
           </Card>
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 const FEATURES = [
-  { icon: "◈", title: "Your domain, your links", body: "Bring any domain, get automatic SSL, and set root and 404 redirects. Five domains on the free plan — not one." },
+  { icon: "◈", title: "Your domain, your links", body: "Bring any domain, get automatic SSL, and set root and 404 redirects. As many as you want — domains aren't metered." },
   { icon: "⇄", title: "Route by anything", body: "Send India to the India store, iOS to the App Store, and split the rest 50/50 for an A/B test. Rules run at the edge." },
   { icon: "▤", title: "Analytics without cookies", body: "Country, city, device, browser, referrer and conversions — measured with a daily-rotating hash. No IP stored, nothing left on the visitor's device." },
   { icon: "▩", title: "QR that stays correct", body: "Print it once, change where it points forever. SVG, PDF and EPS export, with your logo in the middle." },


### PR DESCRIPTION
## What does this PR do?

Fixes #242

The issue offers "implement it or remove the controls" and answers itself: *"Removing is the honest interim state."* I took that, because **the other option was never available**. Real billing needs a payment provider — there is none configured, no credentials for one, and adding a provider SDK is a new dependency, which this work does not do. So the choice was not "implement or remove"; it was *"remove, or leave a button that lies."*

## Separating what was fake from what was real

That was most of the work, and the middle row is the one worth reading.

| | Status | What changed |
| --- | --- | --- |
| **`Manage billing` button** | Nothing behind it | Removed. No payment integration, no upgrade path, no handler. A control that does nothing is worse than an absent one, because someone eventually presses it. |
| **The click quota bar** | Half real | `clicksUsed` is **genuinely counted** from the click rollups for the calendar month — that number is real and stays. `clicksIncluded` is a real column too, but **nothing anywhere reads it except the display**. So the bar drew a cap that does not exist, filled to 100%, and then kept going. Now a plain count. |
| **"Five domains on the free plan"** | Contradicted itself | The landing page said five; the settings page said Custom domains: Unlimited. Nothing enforces either, so one was simply wrong. |

`clicksIncluded` **stays** as a column and a contract field. It is real data and a future billing implementation would want it — the problem was presenting it as a limit, not storing it. Removing it would have been destruction dressed up as honesty.

### The contradiction is the part I'd flag

Two screens disagreed about the same number and neither was enforced. That is the same failure as the analytics-vs-conversions disagreement already recorded in `DECISIONS.md`: a reader who notices stops trusting **both** screens, not just the inaccurate one. Since nothing enforces a five-domain limit, "unlimited" was the true one and the landing page was the unbacked claim — exactly the category #217 existed to clear out, which had survived it.

## Requirement/Documentation

- Issue #242.
- `docs/DECISIONS.md` — new entry: what was unbacked, what was real, why `clicksIncluded` survives, and what revisiting it would actually require.
- `docs/COMPETITIVE-GAP-ANALYSIS.md` — row updated from "UI/demo gap" to "Not built, and no longer implied".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

No API or schema changes. The contract is untouched; only what the settings page renders changed.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass.

This is a UI-copy and control-removal change, so there is nothing new to assert — the honest test is reading the settings page: a real click count, a list of things that genuinely are unlimited because nothing enforces limits on them, and a note saying everything is free and nothing is metered. All three are now true statements.

## Not done, and why

- **No entitlement enforcement.** I could have made `clicksIncluded` real by enforcing it — but "we start dropping your clicks at a million" is a product decision with consequences for live links, and nobody asked for it. Displaying an unenforced limit and enforcing an undiscussed one are both wrong; not claiming a limit is the third option.
- **The `plan` chip stays.** It reads from a real column that defaults to `Free`. With the billing button gone it no longer implies purchasable tiers, and it is accurate.
- **Billing itself.** It needs a provider, a plan model, enforcement on every write path, and an upgrade/downgrade lifecycle. That is a feature, not a button, and it should start from a product decision about what is actually being sold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_