### PR TITLE
feat(auth): Google and Apple sign-in, with the second factor still applying

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import type { FastifyRequest } from "fastify";
 import {
   LoginInput,
   LogoutInput,
+  OAuthSignInInput,
   RefreshInput,
   RegisterInput,
   TotpDisableInput,
@@ -28,6 +29,15 @@ export class AuthController {
   @HttpCode(200)
   login(@Body(zodBody(LoginInput)) input: LoginInput, @Req() req: FastifyRequest) {
     return this.auth.login(input, req.headers["user-agent"]);
+  }
+
+  /* Public by necessity — this is how someone without a session gets one. The
+     ID token is the credential, and OAuthService treats it as hostile until
+     every claim checks out. */
+  @Public()
+  @Post("oauth")
+  oauth(@Body(zodBody(OAuthSignInInput)) input: OAuthSignInInput, @Req() req: FastifyRequest) {
+    return this.auth.oauthSignIn(input.provider, input.idToken, req.headers["user-agent"]);
   }
 
   @Public()

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { AuthController } from "./auth.controller.js";
 import { AuthService } from "./auth.service.js";
 import { TokenService } from "./token.service.js";
 import { TotpService } from "./totp.service.js";
+import { OAuthService } from "./oauth.service.js";
 
 /* Global because AuthGuard is bound application-wide in app.module and needs
    TokenService wherever it runs. */
@@ -11,7 +12,7 @@ import { TotpService } from "./totp.service.js";
 @Module({
   imports: [JwtModule.register({})],
   controllers: [AuthController],
-  providers: [AuthService, TokenService, TotpService],
-  exports: [AuthService, TokenService, TotpService],
+  providers: [AuthService, TokenService, TotpService, OAuthService],
+  exports: [AuthService, TokenService, TotpService, OAuthService],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { and, eq, isNull, sql } from "@snapurl/database";
 import {
   domains,
   memberships,
+  oauthIdentities,
   recoveryCodes,
   users,
   workspaces,
@@ -28,6 +29,7 @@ import { DB } from "../database/database.module.js";
 import { ENV, type Env } from "../config/env.js";
 import { TokenService } from "./token.service.js";
 import { TotpService } from "./totp.service.js";
+import { OAuthService, type OAuthProvider } from "./oauth.service.js";
 
 /** "Dhananjay Thomble" → "DT". The UI renders these in avatars. */
 export function initialsOf(name: string): string {
@@ -51,6 +53,7 @@ export class AuthService {
     @Inject(ENV) private readonly env: Env,
     private readonly tokens: TokenService,
     private readonly totp: TotpService,
+    private readonly oauth: OAuthService,
   ) {}
 
   async register(input: RegisterInput, userAgent?: string): Promise<AuthSession> {
@@ -78,54 +81,154 @@ export class AuthService {
         .values({ name: input.name.trim(), email, passwordHash })
         .returning();
 
-      const baseSlug = slugify(input.name) || "workspace";
-      const [workspace] = await tx
-        .insert(workspaces)
-        .values({
-          name: `${input.name.trim()}'s workspace`,
-          slug: await uniqueWorkspaceSlug(tx, baseSlug),
-          defaultRedirect: "302",
-        })
-        .returning();
-
-      /* The shared short domain is a system domain owned by nobody, so every
-         workspace points at the same row rather than trying to claim it.
-         The first registration creates it; the rest find it. */
-      await tx
-        .insert(domains)
-        .values({
-          workspaceId: null,
-          domain: this.env.DEFAULT_DOMAIN,
-          isSystem: true,
-          status: "live",
-          ssl: "active",
-          verifiedAt: new Date(),
-        })
-        .onConflictDoNothing();
-
-      const [systemDomain] = await tx
-        .select({ id: domains.id })
-        .from(domains)
-        .where(sql`lower(${domains.domain}) = ${this.env.DEFAULT_DOMAIN.toLowerCase()}`)
-        .limit(1);
-
-      if (systemDomain) {
-        await tx.update(workspaces).set({ defaultDomainId: systemDomain.id }).where(eq(workspaces.id, workspace!.id));
-      }
-
-      await tx.insert(memberships).values({
-        workspaceId: workspace!.id,
-        userId: user!.id,
-        email,
-        role: "owner",
-        status: "active",
-        acceptedAt: new Date(),
-      });
-
-      return { user: user!, workspace: workspace!, role: "owner" as const };
+      const workspace = await this.provisionWorkspace(tx, user!.id, input.name, email);
+      return { user: user!, workspace, role: "owner" as const };
     });
 
     return this.issueSession(user, workspace.id, role, userAgent);
+  }
+
+  /**
+   * Everything a brand new account needs besides the user row.
+   *
+   * Shared by password registration and first-time OAuth sign-in so the two
+   * cannot drift into producing differently-shaped accounts — the kind of
+   * difference that surfaces months later as "domains work for people who
+   * signed up with email".
+   */
+  private async provisionWorkspace(tx: Executor, userId: string, displayName: string, email: string) {
+    const baseSlug = slugify(displayName) || "workspace";
+    const [workspace] = await tx
+      .insert(workspaces)
+      .values({
+        name: `${displayName.trim()}'s workspace`,
+        slug: await uniqueWorkspaceSlug(tx, baseSlug),
+        defaultRedirect: "302",
+      })
+      .returning();
+
+    /* The shared short domain is a system domain owned by nobody, so every
+       workspace points at the same row rather than trying to claim it.
+       The first registration creates it; the rest find it. */
+    await tx
+      .insert(domains)
+      .values({
+        workspaceId: null,
+        domain: this.env.DEFAULT_DOMAIN,
+        isSystem: true,
+        status: "live",
+        ssl: "active",
+        verifiedAt: new Date(),
+      })
+      .onConflictDoNothing();
+
+    const [systemDomain] = await tx
+      .select({ id: domains.id })
+      .from(domains)
+      .where(sql`lower(${domains.domain}) = ${this.env.DEFAULT_DOMAIN.toLowerCase()}`)
+      .limit(1);
+
+    if (systemDomain) {
+      await tx.update(workspaces).set({ defaultDomainId: systemDomain.id }).where(eq(workspaces.id, workspace!.id));
+    }
+
+    await tx.insert(memberships).values({
+      workspaceId: workspace!.id,
+      userId,
+      email,
+      role: "owner",
+      status: "active",
+      acceptedAt: new Date(),
+    });
+
+    return workspace!;
+  }
+
+  /**
+   * Sign in with an ID token from Google or Apple.
+   *
+   * Three cases, in the order they are checked, and the order is the security
+   * argument:
+   *
+   * 1. **The identity is already linked** — (provider, subject) matches a row.
+   *    Sign that user in. Email is never consulted, so a provider-side address
+   *    change cannot move the account.
+   * 2. **The email matches an existing account** — link, but only if the
+   *    provider asserts the address is verified. An unverified assertion is
+   *    someone typing an address into a form, and honouring it would let
+   *    anyone who can create an account at a sloppy provider claim any
+   *    SnapURL account by email. Refused rather than silently creating a
+   *    duplicate account, which would be confusing in a different way.
+   * 3. **Nobody has that email** — create the account with no password and
+   *    provision it exactly as registration does.
+   *
+   * Two-factor still applies. A user who turned TOTP on did so for this
+   * account; the provider having its own second factor is not something we can
+   * verify, and skipping ours would mean a compromised Google account walks
+   * straight past a control the person deliberately added.
+   */
+  async oauthSignIn(provider: OAuthProvider, idToken: string, userAgent?: string): Promise<LoginResult> {
+    const profile = await this.oauth.verify(provider, idToken);
+
+    const [linked] = await this.db
+      .select({ userId: oauthIdentities.userId })
+      .from(oauthIdentities)
+      .where(and(eq(oauthIdentities.provider, provider), eq(oauthIdentities.subject, profile.subject)))
+      .limit(1);
+
+    let userId = linked?.userId ?? null;
+
+    if (!userId) {
+      const [existing] = await this.db
+        .select({ id: users.id })
+        .from(users)
+        .where(sql`lower(${users.email}) = ${profile.email}`)
+        .limit(1);
+
+      if (existing) {
+        if (!profile.emailVerified) {
+          throw new UnauthorizedException(
+            "That provider has not verified this email address, so it cannot be linked to an existing account. Sign in with your password instead.",
+          );
+        }
+        await this.db
+          .insert(oauthIdentities)
+          .values({ userId: existing.id, provider, subject: profile.subject, email: profile.email });
+        userId = existing.id;
+      } else {
+        // Apple sends a name only on the very first authorisation, and may
+        // send none at all, so the local-part is the fallback rather than an
+        // empty string that would render as a blank account everywhere.
+        const displayName = profile.name ?? profile.email.split("@")[0] ?? "there";
+        userId = await this.db.transaction(async (tx) => {
+          const [user] = await tx
+            .insert(users)
+            .values({
+              name: displayName,
+              email: profile.email,
+              passwordHash: null,
+              // The provider checked it; recording that avoids asking again.
+              emailVerifiedAt: profile.emailVerified ? new Date() : null,
+            })
+            .returning();
+          await tx
+            .insert(oauthIdentities)
+            .values({ userId: user!.id, provider, subject: profile.subject, email: profile.email });
+          await this.provisionWorkspace(tx, user!.id, displayName, profile.email);
+          return user!.id;
+        });
+      }
+    }
+
+    const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) throw new UnauthorizedException();
+
+    if (user.totpEnabledAt && user.totpSecret) {
+      return { challenge: "totp" as const, challengeToken: await this.tokens.signChallengeToken(user.id) };
+    }
+
+    const membership = await this.primaryMembership(user.id);
+    return this.issueSession(user, membership.workspaceId, membership.role, userAgent);
   }
 
   async login(input: LoginInput, userAgent?: string): Promise<LoginResult> {
@@ -136,13 +239,25 @@ export class AuthService {
       .where(sql`lower(${users.email}) = ${email}`)
       .limit(1);
 
+    /* A user with no password hash signs in through a provider and cannot
+       authenticate here at all. argon2.verify would throw on null and the
+       catch below would turn that into `false`, which is the right answer by
+       accident — this makes it the right answer on purpose, and keeps the
+       dummy-hash timing for that case too.
+
+       The error stays the generic one. Saying "this account uses Google"
+       would be friendlier and would also confirm to an attacker that the
+       address is registered, which is the property the DUMMY_HASH comparison
+       below exists to protect. */
+    const hash = user?.passwordHash ?? null;
+
     // Always do the work, even for an unknown address, so response time does
     // not tell an attacker which emails have accounts.
-    const ok = user
-      ? await argon2.verify(user.passwordHash, input.password).catch(() => false)
+    const ok = hash
+      ? await argon2.verify(hash, input.password).catch(() => false)
       : await argon2.verify(DUMMY_HASH, input.password).catch(() => false);
 
-    if (!user || !ok) {
+    if (!user || !hash || !ok) {
       throw new UnauthorizedException("That email and password don't match.");
     }
 
@@ -226,6 +341,17 @@ export class AuthService {
   async disableTotp(userId: string, password: string): Promise<void> {
     const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
     if (!user) throw new UnauthorizedException();
+    /* Turning 2FA off is a step down in security, so it is gated on proving
+       the first factor. An account that signs in through a provider has no
+       password to prove, and accepting one anyway — or letting argon2 throw
+       its way to a rejection — are both worse than saying so. Naming the
+       situation is safe here: the caller is already authenticated as this
+       user, so there is nothing left to enumerate. */
+    if (!user.passwordHash) {
+      throw new UnauthorizedException(
+        "This account signs in with a provider and has no password, so two-factor authentication can't be turned off this way.",
+      );
+    }
     if (!(await argon2.verify(user.passwordHash, password).catch(() => false))) {
       throw new UnauthorizedException("That password isn't right.");
     }

--- a/apps/api/src/auth/oauth.service.test.ts
+++ b/apps/api/src/auth/oauth.service.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { readKid, toProfile } from "./oauth.service.js";
+
+const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+
+describe("readKid", () => {
+  it("reads the key id from the header without trusting the rest", () => {
+    expect(readKid(`${b64({ alg: "RS256", kid: "abc" })}.x.y`)).toBe("abc");
+  });
+
+  it("returns null for a header with no kid", () => {
+    expect(readKid(`${b64({ alg: "RS256" })}.x.y`)).toBeNull();
+  });
+
+  it("returns null for a non-string kid rather than coercing it", () => {
+    expect(readKid(`${b64({ kid: 42 })}.x.y`)).toBeNull();
+  });
+
+  it("returns null rather than throwing on garbage", () => {
+    expect(readKid("not-a-jwt")).toBeNull();
+    expect(readKid("")).toBeNull();
+    expect(readKid("!!!.x.y")).toBeNull();
+  });
+});
+
+describe("toProfile", () => {
+  const base = { sub: "1234", email: "Person@Example.com", email_verified: true };
+
+  it("takes the subject and lowercases the email", () => {
+    const p = toProfile(base)!;
+    expect(p.subject).toBe("1234");
+    expect(p.email).toBe("person@example.com");
+    expect(p.emailVerified).toBe(true);
+  });
+
+  it("accepts Apple's string \"true\" as verified", () => {
+    // Google sends a boolean, Apple has sent the string. Both mean verified.
+    expect(toProfile({ ...base, email_verified: "true" })!.emailVerified).toBe(true);
+  });
+
+  it("treats the string \"false\" as NOT verified", () => {
+    // The bug this exists to prevent: a bare truthiness check reads "false"
+    // as true, and account linking is gated on this exact field.
+    expect(toProfile({ ...base, email_verified: "false" })!.emailVerified).toBe(false);
+  });
+
+  it("treats anything else as not verified", () => {
+    for (const value of [undefined, null, 0, 1, "yes", {}]) {
+      expect(toProfile({ ...base, email_verified: value })!.emailVerified).toBe(false);
+    }
+  });
+
+  it("refuses a token with no subject", () => {
+    expect(toProfile({ email: "a@b.com", email_verified: true })).toBeNull();
+  });
+
+  it("refuses a token with no email", () => {
+    expect(toProfile({ sub: "1234", email_verified: true })).toBeNull();
+  });
+
+  it("refuses non-string claims rather than coercing them", () => {
+    expect(toProfile({ sub: 1234, email: "a@b.com" })).toBeNull();
+    expect(toProfile({ sub: "1234", email: { toString: () => "a@b.com" } })).toBeNull();
+  });
+
+  it("returns a null name rather than an empty one", () => {
+    expect(toProfile({ ...base, name: "   " })!.name).toBeNull();
+    expect(toProfile(base)!.name).toBeNull();
+    expect(toProfile({ ...base, name: " Ada " })!.name).toBe("Ada");
+  });
+});

--- a/apps/api/src/auth/oauth.service.ts
+++ b/apps/api/src/auth/oauth.service.ts
@@ -1,0 +1,186 @@
+import { Inject, Injectable, Logger, UnauthorizedException } from "@nestjs/common";
+import { createPublicKey, type KeyObject } from "node:crypto";
+import { JwtService } from "@nestjs/jwt";
+import { ENV, type Env } from "../config/env.js";
+
+/* ============================================================
+   Verifying an ID token from Google or Apple.
+
+   No new dependency: Node's crypto imports a JWK directly, and
+   the JwtService already here does the signature check. The
+   provider's public keys are fetched over HTTPS and cached.
+
+   Everything below is written on the assumption that the token
+   is hostile until every claim has been checked, because it
+   arrives from the browser and the only thing standing between
+   a forged one and a session is this file.
+   ============================================================ */
+
+export interface OAuthProfile {
+  /** The `sub` claim — the provider's stable id for this person. */
+  subject: string;
+  email: string;
+  /** Only a provider-asserted true permits linking to an existing account. */
+  emailVerified: boolean;
+  name: string | null;
+}
+
+interface ProviderConfig {
+  /** Non-empty tuple: the verifier's `issuer` option will not accept a possibly-empty array. */
+  issuers: [string, ...string[]];
+  jwksUri: string;
+  algorithms: string[];
+  audience: string | undefined;
+}
+
+export const OAUTH_PROVIDERS = ["google", "apple"] as const;
+export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
+
+/** How long a fetched key set is trusted before being fetched again. */
+const JWKS_TTL_MS = 60 * 60 * 1000;
+
+interface Jwk {
+  kid?: string;
+  kty?: string;
+  alg?: string;
+  use?: string;
+  [key: string]: unknown;
+}
+
+@Injectable()
+export class OAuthService {
+  private readonly logger = new Logger(OAuthService.name);
+  private readonly cache = new Map<OAuthProvider, { keys: Jwk[]; fetchedAt: number }>();
+
+  constructor(
+    @Inject(ENV) private readonly env: Env,
+    private readonly jwt: JwtService,
+  ) {}
+
+  private config(provider: OAuthProvider): ProviderConfig {
+    return provider === "google"
+      ? {
+          // Google issues both spellings and has done for years.
+          issuers: ["https://accounts.google.com", "accounts.google.com"],
+          jwksUri: "https://www.googleapis.com/oauth2/v3/certs",
+          algorithms: ["RS256"],
+          audience: this.env.GOOGLE_OAUTH_CLIENT_ID,
+        }
+      : {
+          issuers: ["https://appleid.apple.com"],
+          jwksUri: "https://appleid.apple.com/auth/keys",
+          algorithms: ["ES256", "RS256"],
+          audience: this.env.APPLE_OAUTH_CLIENT_ID,
+        };
+  }
+
+  /** A provider with no client id configured is switched off, not misconfigured. */
+  enabled(provider: OAuthProvider): boolean {
+    return Boolean(this.config(provider).audience);
+  }
+
+  get enabledProviders(): OAuthProvider[] {
+    return OAUTH_PROVIDERS.filter((p) => this.enabled(p));
+  }
+
+  private async keysFor(provider: OAuthProvider, force = false): Promise<Jwk[]> {
+    const hit = this.cache.get(provider);
+    if (!force && hit && Date.now() - hit.fetchedAt < JWKS_TTL_MS) return hit.keys;
+
+    const { jwksUri } = this.config(provider);
+    const res = await fetch(jwksUri, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) throw new UnauthorizedException("Could not reach the sign-in provider. Try again.");
+
+    const body = (await res.json()) as { keys?: Jwk[] };
+    const keys = body.keys ?? [];
+    this.cache.set(provider, { keys, fetchedAt: Date.now() });
+    return keys;
+  }
+
+  /**
+   * Find the signing key named by the token's header.
+   *
+   * Refetches once on a miss, because providers rotate keys without warning
+   * and a cached set is the ordinary reason a valid token looks unsigned.
+   */
+  private async keyFor(provider: OAuthProvider, kid: string): Promise<string> {
+    for (const force of [false, true]) {
+      const jwk = (await this.keysFor(provider, force)).find((k) => k.kid === kid);
+      if (jwk) {
+        const key: KeyObject = createPublicKey({ key: jwk as never, format: "jwk" });
+        // Exported to PEM because the verifier's types accept a string or a
+        // Buffer, not a KeyObject. The conversion is lossless for a public key.
+        return key.export({ type: "spki", format: "pem" }) as string;
+      }
+    }
+    throw new UnauthorizedException("That sign-in token was not signed by a key we recognise.");
+  }
+
+  /**
+   * Verify an ID token and return only what we are willing to act on.
+   *
+   * Throws for anything short of a complete match. There is deliberately no
+   * "mostly valid" path.
+   */
+  async verify(provider: OAuthProvider, idToken: string): Promise<OAuthProfile> {
+    const { issuers, algorithms, audience } = this.config(provider);
+    if (!audience) throw new UnauthorizedException(`${provider} sign-in is not configured.`);
+
+    const kid = readKid(idToken);
+    if (!kid) throw new UnauthorizedException("That sign-in token is malformed.");
+
+    const key = await this.keyFor(provider, kid);
+
+    let claims: Record<string, unknown>;
+    try {
+      claims = await this.jwt.verifyAsync(idToken, {
+        publicKey: key,
+        // Pinned explicitly, all three. Left to the library, `algorithms`
+        // defaults to permitting any — including "none" in some versions —
+        // and an unpinned audience would accept a token minted for a
+        // different application entirely.
+        algorithms: algorithms as never,
+        audience,
+        issuer: issuers,
+      });
+    } catch {
+      throw new UnauthorizedException("That sign-in token is not valid.");
+    }
+
+    const profile = toProfile(claims);
+    if (!profile) throw new UnauthorizedException("The sign-in provider did not return an email address.");
+    return profile;
+  }
+}
+
+/** The `kid` from a JWT header, without trusting anything else in the token. */
+export function readKid(token: string): string | null {
+  const header = token.split(".")[0];
+  if (!header) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(header, "base64url").toString("utf8")) as { kid?: unknown };
+    return typeof parsed.kid === "string" ? parsed.kid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Narrow verified claims to the three things we use.
+ *
+ * `email_verified` arrives as a boolean from Google and as either a boolean or
+ * the string "true" from Apple, which is the kind of difference that turns
+ * into an account-linking hole when it is read with a bare truthiness check —
+ * the string "false" is truthy.
+ */
+export function toProfile(claims: Record<string, unknown>): OAuthProfile | null {
+  const subject = typeof claims.sub === "string" ? claims.sub : null;
+  const email = typeof claims.email === "string" ? claims.email.toLowerCase().trim() : null;
+  if (!subject || !email) return null;
+
+  const raw = claims.email_verified;
+  const emailVerified = raw === true || raw === "true";
+
+  const name = typeof claims.name === "string" && claims.name.trim() ? claims.name.trim() : null;
+  return { subject, email, emailVerified, name };
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -35,6 +35,13 @@ export const EnvSchema = z.object({
      is not true. Either set this or soften the copy. See docs/DECISIONS.md A10. */
   GOOGLE_SAFE_BROWSING_API_KEY: z.string().optional(),
 
+  /* OAuth sign-in. Each provider is enabled by the presence of its client id
+     and switched off by its absence, so a deployment that has not set one up
+     simply does not offer it. The client id is public — it ships in the page
+     that starts the flow — so neither of these is a secret. */
+  GOOGLE_OAUTH_CLIENT_ID: z.string().optional(),
+  APPLE_OAUTH_CLIENT_ID: z.string().optional(),
+
   /** Local dev writes mail to logs/outbox instead of sending. */
   MAIL_TRANSPORT: z.enum(["outbox", "ses"]).default("outbox"),
   MAIL_FROM: z.string().default("SnapURL <no-reply@snapurl.local>"),

--- a/packages/contract/src/auth.ts
+++ b/packages/contract/src/auth.ts
@@ -80,6 +80,24 @@ export type TotpVerifyInput = z.infer<typeof TotpVerifyInput>;
 export const TotpDisableInput = z.object({ password: z.string().min(1) });
 export type TotpDisableInput = z.infer<typeof TotpDisableInput>;
 
+/**
+ * Sign in with an ID token obtained from Google or Apple in the browser.
+ *
+ * The token, not an authorization code: the browser SDKs already return a
+ * signed ID token, and taking it directly avoids needing a client *secret*
+ * server-side — which Apple only issues as a JWT you must sign yourself and
+ * rotate twice a year.
+ *
+ * The response is the same shape as password login, including the TOTP
+ * challenge: a second factor the user turned on is not skipped because the
+ * first factor came from somewhere else.
+ */
+export const OAuthSignInInput = z.object({
+  provider: z.enum(["google", "apple"]),
+  idToken: z.string().min(1),
+});
+export type OAuthSignInInput = z.infer<typeof OAuthSignInInput>;
+
 /* G2 — logout was client-side only, so the refresh token stayed valid for its
    full 30-day life after the user signed out. This revokes the whole family. */
 export const LogoutInput = z.object({

--- a/packages/database/drizzle/0005_oauth_identities.sql
+++ b/packages/database/drizzle/0005_oauth_identities.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "oauth_identities" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"provider" varchar(20) NOT NULL,
+	"subject" varchar(255) NOT NULL,
+	"email" varchar(255),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "password_hash" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "oauth_identities" ADD CONSTRAINT "oauth_identities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "oauth_identities_provider_subject_key" ON "oauth_identities" USING btree ("provider","subject");

--- a/packages/database/drizzle/meta/0005_snapshot.json
+++ b/packages/database/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2814 @@
+{
+  "id": "738605d4-aa24-45d6-9859-8b51dad7f776",
+  "prevId": "8e457225-0e47-4fd7-9b08-cdac85502603",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invite_token_hash": {
+          "name": "invite_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_workspace_email_key": {
+          "name": "memberships_workspace_email_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_identities": {
+      "name": "oauth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_identities_provider_subject_key": {
+          "name": "oauth_identities_provider_subject_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_identities_user_id_users_id_fk": {
+          "name": "oauth_identities_user_id_users_id_fk",
+          "tableFrom": "oauth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recovery_codes": {
+      "name": "recovery_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recovery_codes_user_idx": {
+          "name": "recovery_codes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_user_id_users_id_fk": {
+          "name": "recovery_codes_user_id_users_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_hash_key": {
+          "name": "refresh_tokens_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_family_idx": {
+          "name": "refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled_at": {
+          "name": "totp_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Free'"
+        },
+        "default_domain_id": {
+          "name": "default_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_redirect": {
+          "name": "default_redirect",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "clicks_included": {
+          "name": "clicks_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000000
+        },
+        "retention_years": {
+          "name": "retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cookieless_analytics": {
+          "name": "cookieless_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scan_on_create": {
+          "name": "scan_on_create",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_previews": {
+          "name": "public_previews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_key": {
+          "name": "workspaces_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verifying'"
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ssl_renews_at": {
+          "name": "ssl_renews_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_redirect": {
+          "name": "root_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_redirect": {
+          "name": "not_found_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domains_domain_key": {
+          "name": "domains_domain_key",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domains_workspace_idx": {
+          "name": "domains_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_workspace_id_workspaces_id_fk": {
+          "name": "domains_workspace_id_workspaces_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_to": {
+          "name": "expires_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activates_at": {
+          "name": "activates_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_to": {
+          "name": "scheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_limit": {
+          "name": "click_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forward_query": {
+          "name": "forward_query",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_referrer": {
+          "name": "hide_referrer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_preview": {
+          "name": "public_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cloaked": {
+          "name": "cloaked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safe_browsing_status": {
+          "name": "safe_browsing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "safe_browsing_checked_at": {
+          "name": "safe_browsing_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_clicks": {
+          "name": "unique_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "links_domain_slug_key": {
+          "name": "links_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_created_idx": {
+          "name": "links_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_tags_idx": {
+          "name": "links_workspace_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "links_expires_idx": {
+          "name": "links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_activates_idx": {
+          "name": "links_activates_idx",
+          "columns": [
+            {
+              "expression": "activates_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"activates_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "links_workspace_id_workspaces_id_fk": {
+          "name": "links_workspace_id_workspaces_id_fk",
+          "tableFrom": "links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "links_domain_id_domains_id_fk": {
+          "name": "links_domain_id_domains_id_fk",
+          "tableFrom": "links",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "links_created_by_users_id_fk": {
+          "name": "links_created_by_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projection_outbox": {
+      "name": "projection_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projection_outbox_pending_idx": {
+          "name": "projection_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"projection_outbox\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_rules": {
+      "name": "routing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "when_country": {
+          "name": "when_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_device": {
+          "name": "when_device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_language": {
+          "name": "when_language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "then": {
+          "name": "then",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_rules_link_position_key": {
+          "name": "routing_rules_link_position_key",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_rules_link_id_links_id_fk": {
+          "name": "routing_rules_link_id_links_id_fk",
+          "tableFrom": "routing_rules",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.breakdown_daily": {
+      "name": "breakdown_daily",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "breakdown_daily_key": {
+          "name": "breakdown_daily_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"link_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "breakdown_daily_lookup_idx": {
+          "name": "breakdown_daily_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "breakdown_daily_workspace_id_workspaces_id_fk": {
+          "name": "breakdown_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "breakdown_daily_link_id_links_id_fk": {
+          "name": "breakdown_daily_link_id_links_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily": {
+      "name": "click_daily",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scans": {
+          "name": "scans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "click_daily_workspace_day_idx": {
+          "name": "click_daily_workspace_day_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_daily_link_id_links_id_fk": {
+          "name": "click_daily_link_id_links_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_daily_workspace_id_workspaces_id_fk": {
+          "name": "click_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_link_id_day_pk": {
+          "name": "click_daily_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_events": {
+      "name": "click_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_host": {
+          "name": "referrer_host",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_qr": {
+          "name": "is_qr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_rule_id": {
+          "name": "matched_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_up_at": {
+          "name": "rolled_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "click_events_link_time_idx": {
+          "name": "click_events_link_time_idx",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_workspace_time_idx": {
+          "name": "click_events_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_pending_idx": {
+          "name": "click_events_pending_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"click_events\".\"rolled_up_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_events_link_id_links_id_fk": {
+          "name": "click_events_link_id_links_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_events_workspace_id_workspaces_id_fk": {
+          "name": "click_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversions": {
+      "name": "conversions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "value_minor": {
+          "name": "value_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversions_workspace_time_idx": {
+          "name": "conversions_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversions_external_key": {
+          "name": "conversions_external_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversions\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversions_workspace_id_workspaces_id_fk": {
+          "name": "conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversions_link_id_links_id_fk": {
+          "name": "conversions_link_id_links_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_salts": {
+      "name": "daily_salts",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_visitors": {
+      "name": "daily_visitors",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "daily_visitors_link_id_links_id_fk": {
+          "name": "daily_visitors_link_id_links_id_fk",
+          "tableFrom": "daily_visitors",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "daily_visitors_link_id_day_visitor_hash_pk": {
+          "name": "daily_visitors_link_id_day_visitor_hash_pk",
+          "columns": [
+            "link_id",
+            "day",
+            "visitor_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_last4": {
+          "name": "key_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_hash_key": {
+          "name": "api_keys_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_workspace_idx": {
+          "name": "api_keys_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_time_idx": {
+          "name": "audit_log_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_workspace_id_workspaces_id_fk": {
+          "name": "audit_log_workspace_id_workspaces_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_blocks": {
+      "name": "bio_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "bio_page_id": {
+          "name": "bio_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked": {
+          "name": "locked",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::jsonb"
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "bio_blocks_page_position_key": {
+          "name": "bio_blocks_page_position_key",
+          "columns": [
+            {
+              "expression": "bio_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_blocks_bio_page_id_bio_pages_id_fk": {
+          "name": "bio_blocks_bio_page_id_bio_pages_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "bio_pages",
+          "columnsFrom": [
+            "bio_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_blocks_link_id_links_id_fk": {
+          "name": "bio_blocks_link_id_links_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_pages": {
+      "name": "bio_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "profile_name": {
+          "name": "profile_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_bio": {
+          "name": "profile_bio",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bio_pages_domain_slug_key": {
+          "name": "bio_pages_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_pages_workspace_id_workspaces_id_fk": {
+          "name": "bio_pages_workspace_id_workspaces_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_pages_domain_id_domains_id_fk": {
+          "name": "bio_pages_domain_id_domains_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_webhook_idx": {
+          "name": "webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_workspace_idx": {
+          "name": "webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_workspace_id_workspaces_id_fk": {
+          "name": "webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787989531374,
       "tag": "0004_click_city",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787990842083,
+      "tag": "0005_oauth_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/identity.ts
+++ b/packages/database/src/schema/identity.ts
@@ -30,8 +30,17 @@ export const users = pgTable(
     id: id(),
     name: varchar("name", { length: 120 }).notNull(),
     email: varchar("email", { length: 255 }).notNull(),
-    /** argon2id. Never bcrypt — it silently truncates at 72 bytes. */
-    passwordHash: text("password_hash").notNull(),
+    /**
+     * argon2id. Never bcrypt — it silently truncates at 72 bytes.
+     *
+     * Nullable since OAuth: a user who has only ever signed in with Google or
+     * Apple has no password, and null says that honestly rather than storing a
+     * placeholder someone might one day try to verify against. `AuthService`
+     * refuses the password path outright when this is null — see the guard
+     * there, which exists so the behaviour is a decision rather than a
+     * consequence of argon2 happening to throw.
+     */
+    passwordHash: text("password_hash"),
     emailVerifiedAt: timestamp("email_verified_at", { withTimezone: true }),
 
     /* G6 — the team page renders a 2FA column, so it needs a real flow. */
@@ -140,6 +149,35 @@ export const refreshTokens = pgTable(
     index("refresh_tokens_user_idx").on(t.userId),
     index("refresh_tokens_family_idx").on(t.familyId),
   ],
+);
+
+/**
+ * A sign-in identity held by an external provider.
+ *
+ * Separate from `users` rather than a pair of columns on it, because one
+ * account may legitimately carry several — Google today, Apple tomorrow — and
+ * a column pair forces a choice between them.
+ *
+ * The unique index is on (provider, subject), never on email. `subject` is the
+ * provider's stable identifier for the person; email is a display attribute
+ * that providers allow to change, and treating a mutable attribute as an
+ * identity key is how accounts get taken over.
+ */
+export const oauthIdentities = pgTable(
+  "oauth_identities",
+  {
+    id: id(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    provider: varchar("provider", { length: 20 }).notNull(),
+    /** The `sub` claim. Stable for the life of the account at that provider. */
+    subject: varchar("subject", { length: 255 }).notNull(),
+    /** What the provider said at link time. Informational; never used to match. */
+    email: varchar("email", { length: 255 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex("oauth_identities_provider_subject_key").on(t.provider, t.subject)],
 );
 
 export const usersRelations = relations(users, ({ many }) => ({

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -195,6 +195,29 @@ BODY=$(curl -s -X POST "$API/auth/refresh" -H 'Content-Type: application/json' -
 check "reuse revokes the whole family" 'signed out' "$BODY"
 
 echo
+echo "== oauth sign-in =="
+# CI configures no client id, so both providers are switched off. A provider
+# that is off must refuse rather than half-run — this is the state most
+# deployments are in, and it is the one worth pinning.
+BODY=$(curl -s -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \
+  -d '{"provider":"google","idToken":"eyJhbGciOiJSUzI1NiIsImtpZCI6IngifQ.e30.sig"}')
+check "an unconfigured provider is refused" 'not configured' "$BODY"
+
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \
+  -d '{"provider":"google","idToken":"not-a-jwt"}')
+status "a malformed token is refused" "401" "$CODE" ""
+
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \
+  -d '{"provider":"myspace","idToken":"x"}')
+status "an unknown provider fails validation" "400" "$CODE" ""
+
+# The endpoint has to be reachable without a session — it is how someone
+# without one gets a session — but it must never accept an empty credential.
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \
+  -d '{"provider":"google","idToken":""}')
+status "an empty token fails validation" "400" "$CODE" ""
+
+echo
 echo "== analytics geo =="
 BODY=$(curl -s "$API/analytics?range=30d" -H "Authorization: Bearer $ACCESS")
 check "analytics reports countries" '"countries"' "$BODY"


### PR DESCRIPTION
## What does this PR do?

Fixes #241

`POST /auth/oauth` accepts an ID token from Google or Apple, verifies it properly, and returns the same response shape as password login — including the TOTP challenge.

**No new dependency.** Node imports a provider's JWK directly (`createPublicKey({ format: "jwk" })`), and the `JwtService` already present checks the signature. The whole path is `fetch` + `node:crypto` + what was in the tree.

**ID token, not authorization code.** The browser SDKs already return a signed ID token, and taking it directly avoids needing a client *secret* server-side — which Apple only issues as a JWT you sign yourself and rotate twice a year.

## The three things the issue asked about

**1. TOTP still applies.** A user who turned it on did so *for this account*, and whether the provider ran its own second factor is not something we can verify from the token. Skipping ours would mean a compromised Google account walks straight past a control the person deliberately added.

**2. Linking requires a verified email — and the lookup order is the security argument.**

```
1. (provider, subject) matches an identity  → sign in.  Email never consulted.
2. email matches an existing account        → link, but ONLY if provider says verified.
3. nobody has that email                    → create, no password, provision like register.
```

Checking `subject` first means a provider-side address change cannot move an account. An *unverified* email assertion is someone typing an address into a form — honouring it would let anyone who can create an account at a careless provider claim a SnapURL account by email. That is why the unique index is on `(provider, subject)` and never on email: email is a mutable display attribute, and treating one as an identity key is how accounts get taken over.

**3. The invitation flow.** OAuth sign-up provisions a workspace through the **same** `provisionWorkspace` helper as `register`, extracted rather than copied, so an account created through a provider cannot end up shaped differently from one created with a password.

## `password_hash` becoming nullable needed care in two places, not one

This is the riskiest part of the change and the reason to read the diff.

- **Login** now refuses a null hash **explicitly**, rather than relying on `argon2.verify(null, …)` throwing its way to a rejection. Same outcome, but by decision. It keeps the generic *"That email and password don't match"* and the `DUMMY_HASH` timing comparison, so the response still cannot be used to tell which addresses exist. That costs UX — someone who signed up with Google and forgets will be told their password is wrong forever — and I kept it because the anti-enumeration property was a deliberate existing choice, not an accident.
- **Disabling 2FA** also verifies a password. It now says plainly that an account without one cannot use that route. Safe to be specific there: the caller is already authenticated as that user, so there is nothing left to enumerate.

## Requirement/Documentation

Issue #241. Both providers are **off unless a client id is configured** (`GOOGLE_OAUTH_CLIENT_ID`, `APPLE_OAUTH_CLIENT_ID`) — a deployment that has not set one up simply does not offer it. Neither value is a secret; both ship in the page that starts the flow.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Additive. Existing password accounts are untouched; the migration only drops a `NOT NULL`, which cannot fail.

## How should this be tested?

```bash
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test
```

All four pass. Migration `0005_oauth_identities.sql`, generated with `drizzle-kit`.

**12 new unit tests** (API suite 89, up from 77), concentrated on the claim handling because that is where a forged token would get through:

- `email_verified` is accepted as `true` or the string `"true"` — and **the string `"false"` is rejected**, which a bare truthiness check would read as verified. Account linking is gated on exactly this field, so it has its own test.
- Non-string `sub`/`email` are refused rather than coerced, including an object with a `toString`.
- `readKid` returns null rather than throwing on garbage, a non-string `kid`, or an empty string.

Smoke assertions in CI, where no client id is configured — so "provider is off" is the deterministic, and most common, deployment state: an unconfigured provider is refused, a malformed token is 401, an unknown provider and an empty token both fail validation at the pipe.

## Not done, and why — please read this part

- **The dashboard has no Google/Apple buttons.** Wiring them means loading a provider's third-party script into the login page and having a real client id, and I have neither a credential to test with nor a way to verify the handshake. The API is complete and testable; the client integration is a separate, verifiable-by-someone-with-credentials step.
- **The provider handshake itself is unexercised.** Claim narrowing, key selection and the linking rules are unit-tested; *"does Google's real token verify against Google's real JWKS"* has not been run. It cannot be from here. Treat the first configured sign-in as a test.
- **In the current AWS topology this cannot work at all**, for the same reason Safe Browsing cannot: the Lambdas sit in isolated subnets with no NAT, so they cannot fetch a provider's JWKS. That is documented in `docs/DEPLOYMENT.md` for Safe Browsing and applies identically here. Enabling either needs egress.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_