### PR TITLE
Give public form submission its own rate limit

### DIFF
--- a/apps/api/src/public/public.controller.ts
+++ b/apps/api/src/public/public.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, HttpCode, Param, Post, Query } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
 import { SubmitFormInput, UnlockLinkInput } from "@snapurl/contract";
 import { zodBody } from "../common/zod.pipe.js";
 import { Public } from "../auth/auth.guard.js";
@@ -46,7 +47,22 @@ export class PublicController {
      caller is a person filling in a form, and per-field messages are the
      useful answer — a 400 would put them in the error branch of every client
      with nothing per-field to show. A missing form is still a 404. */
+
+  /* The only unauthenticated *write* in the API, so it does not get to share
+     the global 120/minute budget the read endpoints use.
+
+     A form may declare 50 fields of 4,000 characters, so an accepted
+     submission stores up to ~200 KB. At the global limit a single address
+     could write roughly 24 MB a minute into someone else's workspace — a
+     storage bill and a spam problem rather than a break-in, but neither is
+     something the workspace opted into.
+
+     Ten a minute is far more than a person filling in a form and far less
+     than a script is worth writing. It is a floor, not a substitute for the
+     proof-of-work or honeypot this will want if the endpoint is ever abused
+     in earnest. */
   @Public()
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
   @Post("forms/:slug")
   @HttpCode(200)
   submit(@Param("slug") slug: string, @Body(zodBody(SubmitFormInput)) input: SubmitFormInput) {


### PR DESCRIPTION
## What does this PR do?

Fixes #262

`POST /public/forms/:slug` is the API's only unauthenticated **write**, and it was sharing the global throttle budget (`THROTTLE_LIMIT=120` / `THROTTLE_TTL_SECONDS=60`) that is sized for the unauthenticated *reads* around it — public form render, public link unlock, bio pages.

A form may declare 50 fields and each answer is capped at 4,000 characters, so an accepted submission stores up to roughly 200 KB. At 120/minute one source address can write about 24 MB a minute into a workspace that never opted into receiving it. Nothing is read and nothing escalates — this is a storage bill and a moderation problem rather than a break-in — but it is still the workspace owner's problem and not their choice.

This adds a per-route override of ten submissions per minute:

```ts
@Public()
@Throttle({ default: { limit: 10, ttl: 60_000 } })
@Post("forms/:slug")
```

Ten leaves a person filling in a form untouched while making the return per source address small enough that a script is not worth writing. The comment in the file says the same thing, and says plainly that this is a floor rather than a solution.

The override targets the `default` throttler because `ThrottlerModule.forRootAsync` in `app.module.ts` registers a single unnamed throttler, which `@nestjs/throttler` names `default`.

## Requirement/Documentation

No requirement or design document — this came out of a security review of the auth, forms and public modules added in #241 and #239, run at the repository owner's request. The two other findings from that review are filed as #263 (OAuth ID tokens are not bound to a nonce) and #264 (form slugs are globally unique), neither of which is touched here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Non-breaking in the sense that matters: no client that behaves like a human is affected. A client submitting more than ten forms a minute from one address now gets a 429 where it previously got a 200.

## How should this be tested?

No new environment variables. `THROTTLE_TTL_SECONDS` and `THROTTLE_LIMIT` still govern every other route and still default to 60/120.

Commands run locally, all green:

```
pnpm install --frozen-lockfile
pnpm type-check
SNAPURL_ALLOW_UNCONFIGURED_BUILD=true pnpm build
pnpm test          # 89 passed, 19 skipped (no DB), 7 files
```

To exercise the limit by hand, against a running API with a published form:

```
for i in $(seq 1 12); do
  curl -s -o /dev/null -w '%{http_code}\n' \
    -X POST "$API/public/forms/<slug>" \
    -H 'Content-Type: application/json' \
    -d '{"answers":{"name":"x"}}'
done
```

Expect ten `200`s then `429`s. Note that `main.ts` sets `trustProxy: true`, so behind a proxy the throttler keys on the real client address rather than the proxy's.

`scripts/smoke.sh` submits to this route twice, well under the new limit, so its assertions are unaffected — no assertion was changed, relaxed or removed.

## Checklist

- I have read the [contributing guide](https://github.com/DhananjayThomble/URL-Shortener-App/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings

## Noticed but not fixed

- **The limit is per source address only.** Rotating addresses defeats it entirely. If this endpoint is ever abused deliberately it wants a honeypot field or proof-of-work, which is a larger change and belongs in its own issue.
- **No per-form or per-workspace submission cap.** A workspace cannot say "this form accepts 500 responses and then closes". That is a product feature with UI attached, not a security control.
- **`docs/DECISIONS.md` is untouched.** Ten per minute is a threshold, not an architectural assumption, and nothing in that file is contradicted by it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCocs2zqfSqag1dG3Fu7hF)_