### PR TITLE
Replace exact daily_visitors with an application-side HyperLogLog sketch (#269)

### DIFF
--- a/apps/worker/src/jobs/rollup.test.ts
+++ b/apps/worker/src/jobs/rollup.test.ts
@@ -96,7 +96,8 @@ describeDb("rollupClicks", () => {
 
   afterAll(async () => {
     // Cascades through domains, links, click_events, click_daily and
-    // daily_visitors. CI runs smoke.sh against this same database afterwards.
+    // click_daily_uniques (the HLL sketch store). CI runs smoke.sh against this
+    // same database afterwards.
     if (workspaceId) await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
     await handle?.close();
   });
@@ -122,9 +123,28 @@ describeDb("rollupClicks", () => {
     const result = await rollupClicks(db);
     expect(result.events).toBeGreaterThanOrEqual(4);
 
+    /* uniques is now a HyperLogLog estimate rather than an exact count, but at
+       these tiny cardinalities (two distinct visitors) the estimator falls in
+       its linear-counting range, which is exact - so the assertion stays === 2
+       rather than a tolerance. The approximation only shows up at thousands of
+       distinct visitors, which these DB tests do not reach. */
     const row = await daily();
     expect(row.clicks).toBe(4);
     expect(row.uniques).toBe(2);
+  });
+
+  it("does not change uniques when the same events are rolled up again", async () => {
+    /* The idempotency guarantee, stated directly. rollupClicks marks events as
+       consumed so a re-run claims nothing, but the deeper reason a re-run is
+       safe is that the sketch merge is register-wise max: even if the same
+       batch were folded in twice, the stored sketch and therefore the derived
+       uniques would not move. Assert the observable half: uniques is stable
+       across a second pass. */
+    const before = await daily();
+    await rollupClicks(db);
+    const after = await daily();
+    expect(after.uniques).toBe(before.uniques);
+    expect(after.uniques).toBeLessThanOrEqual(after.clicks);
   });
 
   it("marks the events it consumed, so a second run is a no-op", async () => {
@@ -140,9 +160,11 @@ describeDb("rollupClicks", () => {
   it("never lets uniques exceed clicks, across separate batches", async () => {
     /* The bug the comment names. A visitor who clicks twice on the same day,
        with the two clicks landing in different batches, must be counted once.
-       Adding uniques per batch instead of recomputing them from
-       daily_visitors is what would break this — and it is invisible until
-       someone notices a link with more unique visitors than clicks. */
+       Adding uniques per batch instead of re-deriving them from the merged HLL
+       sketch is what would break this - and it is invisible until someone
+       notices a link with more unique visitors than clicks. The sketch's
+       register-wise-max merge is what keeps the second click a no-op on the
+       count. */
     await addClick({ visitor: "visitor-c", hour: 5 });
     await rollupClicks(db);
     const afterFirst = await daily();

--- a/apps/worker/src/jobs/rollup.test.ts
+++ b/apps/worker/src/jobs/rollup.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { clickEvents, createDatabase, domains, eq, links, sql, workspaces, type Database } from "@snapurl/database";
+import { addHashed, createSketch, estimate, serialize } from "@snapurl/domain";
 import { rollupClicks } from "./rollup.js";
 
 /* ============================================================
@@ -145,6 +146,60 @@ describeDb("rollupClicks", () => {
     const after = await daily();
     expect(after.uniques).toBe(before.uniques);
     expect(after.uniques).toBeLessThanOrEqual(after.clicks);
+  });
+
+  it("re-merges against the stored sketch instead of overwriting it", async () => {
+    /* The convergence guarantee, stated directly. The rollup used to read the
+       stored sketch into Node, merge, and write "on conflict do update set
+       sketch = excluded.sketch" - a blind overwrite of a snapshot read that
+       would drop another writer's registers if two workers ever processed the
+       same (link, day) at once. The fix locks the row (insert-do-nothing then
+       select-for-update) and merges against the current committed value.
+
+       Simulate the "another writer already stored a sketch" case on a fresh
+       link/day: pre-seed click_daily_uniques with a sketch that already counts
+       one visitor, then roll up a batch of different visitors. If the rollup
+       overwrote, the pre-seeded visitor would be lost and uniques would equal
+       only the batch's distinct count; because it re-merges, the stored sketch
+       is the union and uniques covers both. */
+    const seededDay = new Date(day);
+    seededDay.setUTCDate(seededDay.getUTCDate() - 1);
+    const seededDayKey = seededDay.toISOString().slice(0, 10);
+    const seededAt = new Date(seededDay);
+    seededAt.setUTCHours(12, 0, 0, 0);
+
+    const preSeed = createSketch();
+    addHashed(preSeed, "preexisting-visitor");
+    await db.execute(sql`
+      insert into click_daily_uniques (link_id, day, sketch)
+      values (${linkId}::uuid, ${seededDayKey}::date, ${serialize(preSeed)})
+      on conflict (link_id, day) do update set sketch = excluded.sketch
+    `);
+    // click_daily needs a row for the same key so the derived-uniques update lands.
+    await db.execute(sql`
+      insert into click_daily (link_id, workspace_id, day, clicks, uniques, scans, blocked)
+      values (${linkId}::uuid, ${workspaceId}::uuid, ${seededDayKey}::date, 0, 0, 0, 0)
+      on conflict (link_id, day) do nothing
+    `);
+
+    await db.insert(clickEvents).values([
+      { linkId, workspaceId, occurredAt: seededAt, visitorHash: "batch-visitor-1", country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
+      { linkId, workspaceId, occurredAt: seededAt, visitorHash: "batch-visitor-2", country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
+    ]);
+    await rollupClicks(db);
+
+    const rows = (await db.execute(sql`
+      select uniques from click_daily where link_id = ${linkId}::uuid and day = ${seededDayKey}::date
+    `)) as unknown as Array<{ uniques: number }>;
+    // Union of the pre-seeded visitor and the two batch visitors is three
+    // distinct, exact in HLL's linear-counting range at this tiny N. An
+    // overwrite would have dropped the pre-seeded visitor and reported two.
+    const expected = createSketch();
+    addHashed(expected, "preexisting-visitor");
+    addHashed(expected, "batch-visitor-1");
+    addHashed(expected, "batch-visitor-2");
+    expect(rows[0]?.uniques).toBe(estimate(expected));
+    expect(rows[0]?.uniques).toBe(3);
   });
 
   it("marks the events it consumed, so a second run is a no-op", async () => {

--- a/apps/worker/src/jobs/rollup.test.ts
+++ b/apps/worker/src/jobs/rollup.test.ts
@@ -26,6 +26,19 @@ describeDb("rollupClicks", () => {
   let linkId: string;
   let secondLinkId: string;
 
+  /* The re-merge test seeds a sketch with a visitor that never produced a
+     click_event, so its (link, day) row legitimately holds uniques > clicks.
+     That is fine for what that test proves, but it would violate the two
+     workspace-wide aggregate assertions below ("uniques <= clicks for every
+     row" and "the denormalised counters on links") if it shared this suite's
+     workspace and link. Those aggregates describe REAL click traffic, where a
+     unique always implies at least one click. So the re-merge scenario gets its
+     own workspace and link, fully isolated from the shared fixtures: the
+     workspace-wide scan never sees the click-less seeded visitor, and the
+     shared link's denormalised counter never absorbs the seeded day's clicks. */
+  let remergeWorkspaceId: string;
+  let remergeLinkId: string;
+
   /** Yesterday, so the rows sit on one settled UTC day regardless of run time. */
   const day = new Date(Date.now() - 86_400_000);
   const dayKey = day.toISOString().slice(0, 10);
@@ -99,6 +112,31 @@ describeDb("rollupClicks", () => {
       .values({ workspaceId, domainId: dom!.id, slug: `r${stamp}b`, destination: "https://example.com/b" })
       .returning({ id: links.id });
     secondLinkId = two!.id;
+
+    /* A separate workspace + domain + link for the re-merge test. Kept out of
+       the shared workspace so its deliberately click-less seeded visitor cannot
+       be observed by the two workspace-wide aggregate assertions. */
+    const [remergeWs] = await db
+      .insert(workspaces)
+      .values({ name: "rollup remerge", slug: `rollup-remerge-${stamp}` })
+      .returning({ id: workspaces.id });
+    remergeWorkspaceId = remergeWs!.id;
+
+    const [remergeDom] = await db
+      .insert(domains)
+      .values({ workspaceId: remergeWorkspaceId, domain: `rollup-remerge-${stamp}.test` })
+      .returning({ id: domains.id });
+
+    const [remergeLink] = await db
+      .insert(links)
+      .values({
+        workspaceId: remergeWorkspaceId,
+        domainId: remergeDom!.id,
+        slug: `r${stamp}c`,
+        destination: "https://example.com/c",
+      })
+      .returning({ id: links.id });
+    remergeLinkId = remergeLink!.id;
   });
 
   afterAll(async () => {
@@ -106,6 +144,7 @@ describeDb("rollupClicks", () => {
     // click_daily_uniques (the HLL sketch store). CI runs smoke.sh against this
     // same database afterwards.
     if (workspaceId) await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    if (remergeWorkspaceId) await db.delete(workspaces).where(eq(workspaces.id, remergeWorkspaceId));
     await handle?.close();
   });
 
@@ -168,6 +207,11 @@ describeDb("rollupClicks", () => {
        overwrote, the pre-seeded visitor would be lost and uniques would equal
        only the batch's distinct count; because it re-merges, the stored sketch
        is the union and uniques covers both. */
+    /* Runs entirely inside remergeWorkspaceId / remergeLinkId, an isolated
+       workspace and link created in beforeAll. The pre-seeded sketch counts a
+       visitor with no matching click_event, so this (link, day) ends with
+       uniques > clicks. That is correct for what this test proves, but it must
+       not leak into the shared-workspace aggregate tests, hence the isolation. */
     const seededDay = new Date(day);
     seededDay.setUTCDate(seededDay.getUTCDate() - 1);
     const seededDayKey = seededDay.toISOString().slice(0, 10);
@@ -178,24 +222,24 @@ describeDb("rollupClicks", () => {
     addHashed(preSeed, hashForTesting("preexisting-visitor"));
     await db.execute(sql`
       insert into click_daily_uniques (link_id, day, sketch)
-      values (${linkId}::uuid, ${seededDayKey}::date, ${serialize(preSeed)})
+      values (${remergeLinkId}::uuid, ${seededDayKey}::date, ${serialize(preSeed)})
       on conflict (link_id, day) do update set sketch = excluded.sketch
     `);
     // click_daily needs a row for the same key so the derived-uniques update lands.
     await db.execute(sql`
       insert into click_daily (link_id, workspace_id, day, clicks, uniques, scans, blocked)
-      values (${linkId}::uuid, ${workspaceId}::uuid, ${seededDayKey}::date, 0, 0, 0, 0)
+      values (${remergeLinkId}::uuid, ${remergeWorkspaceId}::uuid, ${seededDayKey}::date, 0, 0, 0, 0)
       on conflict (link_id, day) do nothing
     `);
 
     await db.insert(clickEvents).values([
-      { linkId, workspaceId, occurredAt: seededAt, visitorHash: hashForTesting("batch-visitor-1"), country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
-      { linkId, workspaceId, occurredAt: seededAt, visitorHash: hashForTesting("batch-visitor-2"), country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
+      { linkId: remergeLinkId, workspaceId: remergeWorkspaceId, occurredAt: seededAt, visitorHash: hashForTesting("batch-visitor-1"), country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
+      { linkId: remergeLinkId, workspaceId: remergeWorkspaceId, occurredAt: seededAt, visitorHash: hashForTesting("batch-visitor-2"), country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
     ]);
     await rollupClicks(db);
 
     const rows = (await db.execute(sql`
-      select uniques from click_daily where link_id = ${linkId}::uuid and day = ${seededDayKey}::date
+      select uniques from click_daily where link_id = ${remergeLinkId}::uuid and day = ${seededDayKey}::date
     `)) as unknown as Array<{ uniques: number }>;
     // Union of the pre-seeded visitor and the two batch visitors is three
     // distinct, exact in HLL's linear-counting range at this tiny N. An

--- a/apps/worker/src/jobs/rollup.test.ts
+++ b/apps/worker/src/jobs/rollup.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { clickEvents, createDatabase, domains, eq, links, sql, workspaces, type Database } from "@snapurl/database";
-import { addHashed, createSketch, estimate, serialize } from "@snapurl/domain";
+import { addHashed, createSketch, estimate, hashForTesting, serialize } from "@snapurl/domain";
 import { rollupClicks } from "./rollup.js";
 
 /* ============================================================
@@ -36,6 +36,12 @@ describeDb("rollupClicks", () => {
     return d;
   };
 
+  /* The real click_events.visitor_hash is always a 32-hex-char HMAC digest
+     (see packages/domain/src/visitor.ts), and the HLL sketch validates that
+     shape loudly. Tests name visitors with readable labels ("visitor-a") and
+     run them through hashForTesting so the stored hash matches the production
+     contract while distinct labels stay distinct and a repeated label maps to
+     the identical hash, exactly the properties these assertions rely on. */
   async function addClick(opts: {
     link?: string;
     visitor: string;
@@ -48,7 +54,7 @@ describeDb("rollupClicks", () => {
       linkId: opts.link ?? linkId,
       workspaceId,
       occurredAt: at(opts.hour ?? 12),
-      visitorHash: opts.visitor,
+      visitorHash: hashForTesting(opts.visitor),
       country: "IN",
       device: "desktop",
       browser: "Chrome",
@@ -169,7 +175,7 @@ describeDb("rollupClicks", () => {
     seededAt.setUTCHours(12, 0, 0, 0);
 
     const preSeed = createSketch();
-    addHashed(preSeed, "preexisting-visitor");
+    addHashed(preSeed, hashForTesting("preexisting-visitor"));
     await db.execute(sql`
       insert into click_daily_uniques (link_id, day, sketch)
       values (${linkId}::uuid, ${seededDayKey}::date, ${serialize(preSeed)})
@@ -183,8 +189,8 @@ describeDb("rollupClicks", () => {
     `);
 
     await db.insert(clickEvents).values([
-      { linkId, workspaceId, occurredAt: seededAt, visitorHash: "batch-visitor-1", country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
-      { linkId, workspaceId, occurredAt: seededAt, visitorHash: "batch-visitor-2", country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
+      { linkId, workspaceId, occurredAt: seededAt, visitorHash: hashForTesting("batch-visitor-1"), country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
+      { linkId, workspaceId, occurredAt: seededAt, visitorHash: hashForTesting("batch-visitor-2"), country: "IN", device: "desktop", browser: "Chrome", isQr: false, isBot: false, blockedReason: null },
     ]);
     await rollupClicks(db);
 
@@ -195,9 +201,9 @@ describeDb("rollupClicks", () => {
     // distinct, exact in HLL's linear-counting range at this tiny N. An
     // overwrite would have dropped the pre-seeded visitor and reported two.
     const expected = createSketch();
-    addHashed(expected, "preexisting-visitor");
-    addHashed(expected, "batch-visitor-1");
-    addHashed(expected, "batch-visitor-2");
+    addHashed(expected, hashForTesting("preexisting-visitor"));
+    addHashed(expected, hashForTesting("batch-visitor-1"));
+    addHashed(expected, hashForTesting("batch-visitor-2"));
     expect(rows[0]?.uniques).toBe(estimate(expected));
     expect(rows[0]?.uniques).toBe(3);
   });

--- a/apps/worker/src/jobs/rollup.ts
+++ b/apps/worker/src/jobs/rollup.ts
@@ -1,4 +1,5 @@
 import { sql, type Database } from "@snapurl/database";
+import { addHashed, createSketch, deserialize, estimate, merge, serialize } from "@snapurl/domain";
 
 /* ============================================================
    Turning raw clicks into the numbers the dashboards read.
@@ -42,16 +43,6 @@ export async function rollupClicks(db: Database, batchSize = 50_000): Promise<Ro
     const [{ n }] = (await tx.execute(sql`select count(*)::int as n from rollup_batch`)) as unknown as [{ n: number }];
     if (!n) return { events: 0, days: 0 };
 
-    // Distinct visitors per link per day, kept separately so retention can
-    // drop the raw events while the uniques number stays correct.
-    await tx.execute(sql`
-      insert into daily_visitors (link_id, day, visitor_hash)
-      select link_id, (occurred_at at time zone 'UTC')::date, visitor_hash
-      from rollup_batch
-      where is_bot = false and blocked_reason is null
-      on conflict do nothing
-    `);
-
     await tx.execute(sql`
       insert into click_daily (link_id, workspace_id, day, clicks, uniques, scans, blocked)
       select
@@ -70,19 +61,83 @@ export async function rollupClicks(db: Database, batchSize = 50_000): Promise<Ro
         blocked = click_daily.blocked + excluded.blocked
     `);
 
-    /* Uniques are recomputed from daily_visitors rather than added to.
-       Adding would double-count a visitor who clicked twice in one day across
-       two different batches — the exact bug that makes uniques exceed clicks. */
-    await tx.execute(sql`
-      update click_daily cd set uniques = v.n
-      from (
-        select link_id, day, count(*)::int as n
-        from daily_visitors
-        where (link_id, day) in (select distinct link_id, (occurred_at at time zone 'UTC')::date from rollup_batch)
-        group by link_id, day
-      ) v
-      where cd.link_id = v.link_id and cd.day = v.day
-    `);
+    /* Uniques, as an approximate HyperLogLog sketch merged register-wise.
+
+       daily_visitors used to hold one row per (link, day, visitor) and uniques
+       was a COUNT(DISTINCT) over it. That is exact but does not survive this
+       product's load - ~2 billion rows in a btree at retention. So the durable
+       uniques record is now a fixed-size sketch per (link, day) in
+       click_daily_uniques, and click_daily.uniques is derived from it.
+
+       There is no pure-SQL way to build the sketch without the postgresql-hll
+       extension, which we deliberately do not depend on, so the sketch is built
+       in Node here (inside the same transaction) from the batch's non-bot,
+       non-blocked visitor hashes.
+
+       The register-wise-max merge is what keeps a re-run harmless. Merging is
+       idempotent (max(a, a) = a) and commutative, so folding the same batch
+       into the same stored sketch is a no-op: recomputing a day cannot inflate
+       its uniques, which is exactly the property the old recompute-not-increment
+       code protected against a visitor being counted twice across batches. */
+    const visitorRows = (await tx.execute(sql`
+      select
+        link_id as "linkId",
+        (occurred_at at time zone 'UTC')::date::text as day,
+        visitor_hash as "visitorHash"
+      from rollup_batch
+      where is_bot = false and blocked_reason is null
+    `)) as unknown as Array<{ linkId: string; day: string; visitorHash: string }>;
+
+    if (visitorRows.length > 0) {
+      /* Group the batch into one incoming sketch per (link, day). The key is a
+         string join of the two parts, kept alongside its components so the
+         upsert below has them without re-parsing. */
+      const groups = new Map<string, { linkId: string; day: string; sketch: Uint8Array }>();
+      for (const row of visitorRows) {
+        const key = `${row.linkId}|${row.day}`;
+        let group = groups.get(key);
+        if (!group) {
+          group = { linkId: row.linkId, day: row.day, sketch: createSketch() };
+          groups.set(key, group);
+        }
+        addHashed(group.sketch, row.visitorHash);
+      }
+
+      for (const group of groups.values()) {
+        /* Merge the incoming sketch with whatever is already stored for the
+           key, then write the merged bytes back. Reading and merging in TS
+           keeps every bit of sketch logic in @snapurl/domain rather than half
+           of it in a bytea expression. The postgres driver returns bytea as a
+           Buffer, which deserialize copies into a fresh sketch. */
+        const existing = (await tx.execute(sql`
+          select sketch from click_daily_uniques
+          where link_id = ${group.linkId}::uuid and day = ${group.day}::date
+        `)) as unknown as Array<{ sketch: Buffer }>;
+
+        const merged = existing[0]
+          ? merge(deserialize(existing[0].sketch), group.sketch)
+          : group.sketch;
+        const bytes = serialize(merged);
+
+        /* on conflict do update set sketch = excluded.sketch is safe because
+           excluded already carries the merge - two workers cannot lose an
+           update, the loser just re-merges on its next pass. */
+        await tx.execute(sql`
+          insert into click_daily_uniques (link_id, day, sketch)
+          values (${group.linkId}::uuid, ${group.day}::date, ${bytes})
+          on conflict (link_id, day) do update set sketch = excluded.sketch
+        `);
+
+        /* Derive click_daily.uniques from the merged sketch. Recomputed from
+           the sketch, never incremented, for the same reason the merge is a
+           max: a re-run must land on the same number. */
+        const uniques = estimate(merged);
+        await tx.execute(sql`
+          update click_daily set uniques = ${uniques}
+          where link_id = ${group.linkId}::uuid and day = ${group.day}::date
+        `);
+      }
+    }
 
     // One table serves countries, devices, browsers and referrers because the
     // dashboard renders them identically.
@@ -342,17 +397,6 @@ export async function rotateSalts(db: Database): Promise<number> {
   const result = await db.execute(sql`
     with dropped as (
       delete from daily_salts where day < (current_date - interval '1 day') returning 1
-    )
-    select count(*)::int as n from dropped
-  `);
-  return (result as unknown as [{ n: number }])[0]?.n ?? 0;
-}
-
-/** daily_visitors only has to survive long enough for its day to close. */
-export async function pruneVisitors(db: Database): Promise<number> {
-  const result = await db.execute(sql`
-    with dropped as (
-      delete from daily_visitors where day < (current_date - interval '45 days') returning 1
     )
     select count(*)::int as n from dropped
   `);

--- a/apps/worker/src/jobs/rollup.ts
+++ b/apps/worker/src/jobs/rollup.ts
@@ -78,7 +78,12 @@ export async function rollupClicks(db: Database, batchSize = 50_000): Promise<Ro
        idempotent (max(a, a) = a) and commutative, so folding the same batch
        into the same stored sketch is a no-op: recomputing a day cannot inflate
        its uniques, which is exactly the property the old recompute-not-increment
-       code protected against a visitor being counted twice across batches. */
+       code protected against a visitor being counted twice across batches.
+
+       The merge below is made convergent under concurrent workers by locking
+       the sketch row before merging (see the per-group loop), so it re-merges
+       against the current committed value rather than blindly overwriting a
+       snapshot. */
     const visitorRows = (await tx.execute(sql`
       select
         link_id as "linkId",
@@ -108,24 +113,50 @@ export async function rollupClicks(db: Database, batchSize = 50_000): Promise<Ro
            key, then write the merged bytes back. Reading and merging in TS
            keeps every bit of sketch logic in @snapurl/domain rather than half
            of it in a bytea expression. The postgres driver returns bytea as a
-           Buffer, which deserialize copies into a fresh sketch. */
-        const existing = (await tx.execute(sql`
+           Buffer, which deserialize copies into a fresh sketch.
+
+           The read-merge-write has to be convergent even if two workers ever
+           process overlapping (link, day) rows at once. A plain "select then
+           insert ... on conflict do update set sketch = excluded.sketch" is
+           not: both workers read the same stored sketch, each merges its own
+           batch against that snapshot, and the second commit overwrites the
+           first, dropping the first batch's registers. The old daily_visitors
+           path ("insert ... on conflict do nothing") converged, so an overwrite
+           here would be a behavioral regression - the shipped single-instance
+           everyN loop never overlaps its own ticks and so cannot hit it, but we
+           do not want correctness to depend on that.
+
+           So serialize concurrent mergers on the row itself. First guarantee a
+           row exists with "insert ... on conflict do nothing" (a no-op for a
+           losing first-inserter), then "select ... for update" to take a row
+           lock: a second worker blocks there until the first commits, then
+           reads the first's already-merged sketch and merges on top of it. No
+           registers are lost regardless of writer topology, and because the
+           merge is register-wise max it stays idempotent - re-folding the same
+           batch is max(a, a) = a. */
+        await tx.execute(sql`
+          insert into click_daily_uniques (link_id, day, sketch)
+          values (${group.linkId}::uuid, ${group.day}::date, ${serialize(createSketch())})
+          on conflict (link_id, day) do nothing
+        `);
+
+        const locked = (await tx.execute(sql`
           select sketch from click_daily_uniques
           where link_id = ${group.linkId}::uuid and day = ${group.day}::date
+          for update
         `)) as unknown as Array<{ sketch: Buffer }>;
 
-        const merged = existing[0]
-          ? merge(deserialize(existing[0].sketch), group.sketch)
+        /* The row is guaranteed to exist and be locked by the insert above, so
+           locked[0] is always present; the fallback keeps this total in the
+           face of an unexpected driver shape rather than throwing. */
+        const merged = locked[0]
+          ? merge(deserialize(locked[0].sketch), group.sketch)
           : group.sketch;
         const bytes = serialize(merged);
 
-        /* on conflict do update set sketch = excluded.sketch is safe because
-           excluded already carries the merge - two workers cannot lose an
-           update, the loser just re-merges on its next pass. */
         await tx.execute(sql`
-          insert into click_daily_uniques (link_id, day, sketch)
-          values (${group.linkId}::uuid, ${group.day}::date, ${bytes})
-          on conflict (link_id, day) do update set sketch = excluded.sketch
+          update click_daily_uniques set sketch = ${bytes}
+          where link_id = ${group.linkId}::uuid and day = ${group.day}::date
         `);
 
         /* Derive click_daily.uniques from the merged sketch. Recomputed from

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,6 +1,6 @@
 import pino from "pino";
 import { createDatabase, type Database } from "@snapurl/database";
-import { ensureClickPartitions, pruneRetention, pruneVisitors, rollupClicks, rotateSalts } from "./jobs/rollup.js";
+import { ensureClickPartitions, pruneRetention, rollupClicks, rotateSalts } from "./jobs/rollup.js";
 import { NoProjection, drainOutbox, pruneOutbox, stuckProjections, sweepExpired } from "./jobs/outbox.js";
 import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
 
@@ -69,7 +69,6 @@ export async function runMaintenance(database: Database) {
   const expired = await sweepExpired(database);
   const salts = await rotateSalts(database);
   const pruned = await pruneRetention(database);
-  const visitors = await pruneVisitors(database);
   const outbox = await pruneOutbox(database);
   const deliveries = await pruneDeliveries(database);
   const stuck = await stuckProjections(database);
@@ -85,7 +84,6 @@ export async function runMaintenance(database: Database) {
          using mixed retention settings, which is supported but not free. */
       clickPartitionsDropped: pruned.partitionsDropped,
       clickRowsDeleted: pruned.rowsDeleted,
-      visitorsPruned: visitors,
       outboxPruned: outbox,
       deliveriesPruned: deliveries,
     },
@@ -99,7 +97,7 @@ export async function runMaintenance(database: Database) {
     log.error({ stuck }, "projection rows have exhausted their retries — the edge may be serving stale link config");
   }
 
-  return { partitions, expired, salts, pruned, visitors, outbox, deliveries, stuck };
+  return { partitions, expired, salts, pruned, outbox, deliveries, stuck };
 }
 
 /** Guard against a slow pass overlapping the next tick. */

--- a/packages/database/drizzle/0008_hll_uniques.sql
+++ b/packages/database/drizzle/0008_hll_uniques.sql
@@ -1,0 +1,43 @@
+/* ============================================================
+   Uniques stop being exact rows and become a HyperLogLog sketch.
+
+   Why: daily_visitors stored one row per (link_id, day,
+   visitor_hash). At 1,000 clicks/second with half the traffic
+   unique that is ~43M rows a day, and 45 days of retention put
+   ~2 billion rows in a btree. That is a hard scale ceiling, not a
+   tuning problem, and no index budget makes a COUNT(DISTINCT) over
+   it cheap.
+
+   The fix is a fixed-size (~16 KiB) HLL sketch per (link_id, day)
+   in a bytea column, merged register-wise during rollup. The sketch
+   is implemented in @snapurl/domain in pure TypeScript rather than
+   via the postgresql-hll extension on purpose: an extension adds a
+   dependency to the "docker compose up" promise the single-node
+   profile is built on, and it does not port to ClickHouse or Redis,
+   so a sketch we own is the only one that works on vanilla Postgres,
+   any managed Postgres and behind any future analytics adapter
+   unchanged.
+
+   click_daily_uniques is a separate companion table, not a column on
+   click_daily, so click_daily stays a thin all-integer counter row
+   the dashboard sums cheaply; a 16 KiB blob on every one of those
+   rows would bloat every dashboard scan. It also preserves the
+   separation daily_visitors gave us: the sketch is the durable
+   uniques record independent of the raw click_events, so retention
+   can drop raw events while uniques stay correct.
+
+   This is a pre-deployment schema change, not a backfill: nothing is
+   in production, so daily_visitors is simply dropped rather than
+   converted. The constraint names below are drizzle's own, so a
+   future `drizzle-kit generate` sees no drift.
+   ============================================================ */
+
+CREATE TABLE "click_daily_uniques" (
+	"link_id" uuid NOT NULL,
+	"day" date NOT NULL,
+	"sketch" "bytea" NOT NULL,
+	CONSTRAINT "click_daily_uniques_link_id_day_pk" PRIMARY KEY("link_id","day")
+);
+--> statement-breakpoint
+DROP TABLE "daily_visitors" CASCADE;--> statement-breakpoint
+ALTER TABLE "click_daily_uniques" ADD CONSTRAINT "click_daily_uniques_link_id_links_id_fk" FOREIGN KEY ("link_id") REFERENCES "public"."links"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/database/drizzle/meta/0008_snapshot.json
+++ b/packages/database/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,3025 @@
+{
+  "id": "d3137cf2-6ba6-45d8-a0e8-80d44c10a311",
+  "prevId": "a87d29dc-c55b-48cd-aa2f-fd271b6a8924",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invite_token_hash": {
+          "name": "invite_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_workspace_email_key": {
+          "name": "memberships_workspace_email_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_identities": {
+      "name": "oauth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_identities_provider_subject_key": {
+          "name": "oauth_identities_provider_subject_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_identities_user_id_users_id_fk": {
+          "name": "oauth_identities_user_id_users_id_fk",
+          "tableFrom": "oauth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recovery_codes": {
+      "name": "recovery_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recovery_codes_user_idx": {
+          "name": "recovery_codes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_user_id_users_id_fk": {
+          "name": "recovery_codes_user_id_users_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_hash_key": {
+          "name": "refresh_tokens_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_family_idx": {
+          "name": "refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled_at": {
+          "name": "totp_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Free'"
+        },
+        "default_domain_id": {
+          "name": "default_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_redirect": {
+          "name": "default_redirect",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "clicks_included": {
+          "name": "clicks_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000000
+        },
+        "retention_years": {
+          "name": "retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cookieless_analytics": {
+          "name": "cookieless_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scan_on_create": {
+          "name": "scan_on_create",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_previews": {
+          "name": "public_previews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_key": {
+          "name": "workspaces_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verifying'"
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ssl_renews_at": {
+          "name": "ssl_renews_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_redirect": {
+          "name": "root_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_redirect": {
+          "name": "not_found_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domains_domain_key": {
+          "name": "domains_domain_key",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domains_workspace_idx": {
+          "name": "domains_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_workspace_id_workspaces_id_fk": {
+          "name": "domains_workspace_id_workspaces_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_to": {
+          "name": "expires_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activates_at": {
+          "name": "activates_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_to": {
+          "name": "scheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_limit": {
+          "name": "click_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forward_query": {
+          "name": "forward_query",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_referrer": {
+          "name": "hide_referrer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_preview": {
+          "name": "public_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cloaked": {
+          "name": "cloaked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safe_browsing_status": {
+          "name": "safe_browsing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "safe_browsing_checked_at": {
+          "name": "safe_browsing_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_clicks": {
+          "name": "unique_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "links_domain_slug_key": {
+          "name": "links_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_created_idx": {
+          "name": "links_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_tags_idx": {
+          "name": "links_workspace_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "links_expires_idx": {
+          "name": "links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_activates_idx": {
+          "name": "links_activates_idx",
+          "columns": [
+            {
+              "expression": "activates_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"activates_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "links_workspace_id_workspaces_id_fk": {
+          "name": "links_workspace_id_workspaces_id_fk",
+          "tableFrom": "links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "links_domain_id_domains_id_fk": {
+          "name": "links_domain_id_domains_id_fk",
+          "tableFrom": "links",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "links_created_by_users_id_fk": {
+          "name": "links_created_by_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projection_outbox": {
+      "name": "projection_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projection_outbox_pending_idx": {
+          "name": "projection_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"projection_outbox\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_rules": {
+      "name": "routing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "when_country": {
+          "name": "when_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_device": {
+          "name": "when_device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_language": {
+          "name": "when_language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "then": {
+          "name": "then",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_rules_link_position_key": {
+          "name": "routing_rules_link_position_key",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_rules_link_id_links_id_fk": {
+          "name": "routing_rules_link_id_links_id_fk",
+          "tableFrom": "routing_rules",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.breakdown_daily": {
+      "name": "breakdown_daily",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "breakdown_daily_key": {
+          "name": "breakdown_daily_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"link_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "breakdown_daily_lookup_idx": {
+          "name": "breakdown_daily_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "breakdown_daily_workspace_id_workspaces_id_fk": {
+          "name": "breakdown_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "breakdown_daily_link_id_links_id_fk": {
+          "name": "breakdown_daily_link_id_links_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily": {
+      "name": "click_daily",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scans": {
+          "name": "scans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "click_daily_workspace_day_idx": {
+          "name": "click_daily_workspace_day_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_daily_link_id_links_id_fk": {
+          "name": "click_daily_link_id_links_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_daily_workspace_id_workspaces_id_fk": {
+          "name": "click_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_link_id_day_pk": {
+          "name": "click_daily_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily_uniques": {
+      "name": "click_daily_uniques",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sketch": {
+          "name": "sketch",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "click_daily_uniques_link_id_links_id_fk": {
+          "name": "click_daily_uniques_link_id_links_id_fk",
+          "tableFrom": "click_daily_uniques",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_uniques_link_id_day_pk": {
+          "name": "click_daily_uniques_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_events": {
+      "name": "click_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_host": {
+          "name": "referrer_host",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_qr": {
+          "name": "is_qr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_rule_id": {
+          "name": "matched_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_up_at": {
+          "name": "rolled_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "click_events_link_time_idx": {
+          "name": "click_events_link_time_idx",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_workspace_time_idx": {
+          "name": "click_events_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_pending_idx": {
+          "name": "click_events_pending_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"click_events\".\"rolled_up_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_events_link_id_links_id_fk": {
+          "name": "click_events_link_id_links_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_events_workspace_id_workspaces_id_fk": {
+          "name": "click_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_events_id_occurred_at_pk": {
+          "name": "click_events_id_occurred_at_pk",
+          "columns": [
+            "id",
+            "occurred_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversions": {
+      "name": "conversions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "value_minor": {
+          "name": "value_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversions_workspace_time_idx": {
+          "name": "conversions_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversions_external_key": {
+          "name": "conversions_external_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversions\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversions_workspace_id_workspaces_id_fk": {
+          "name": "conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversions_link_id_links_id_fk": {
+          "name": "conversions_link_id_links_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_salts": {
+      "name": "daily_salts",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_last4": {
+          "name": "key_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_hash_key": {
+          "name": "api_keys_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_workspace_idx": {
+          "name": "api_keys_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_time_idx": {
+          "name": "audit_log_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_workspace_id_workspaces_id_fk": {
+          "name": "audit_log_workspace_id_workspaces_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_blocks": {
+      "name": "bio_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "bio_page_id": {
+          "name": "bio_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked": {
+          "name": "locked",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::jsonb"
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "bio_blocks_page_position_key": {
+          "name": "bio_blocks_page_position_key",
+          "columns": [
+            {
+              "expression": "bio_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_blocks_bio_page_id_bio_pages_id_fk": {
+          "name": "bio_blocks_bio_page_id_bio_pages_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "bio_pages",
+          "columnsFrom": [
+            "bio_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_blocks_link_id_links_id_fk": {
+          "name": "bio_blocks_link_id_links_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_pages": {
+      "name": "bio_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "profile_name": {
+          "name": "profile_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_bio": {
+          "name": "profile_bio",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bio_pages_domain_slug_key": {
+          "name": "bio_pages_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_pages_workspace_id_workspaces_id_fk": {
+          "name": "bio_pages_workspace_id_workspaces_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_pages_domain_id_domains_id_fk": {
+          "name": "bio_pages_domain_id_domains_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_responses": {
+      "name": "form_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "form_responses_form_idx": {
+          "name": "form_responses_form_idx",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_responses_form_id_forms_id_fk": {
+          "name": "form_responses_form_id_forms_id_fk",
+          "tableFrom": "form_responses",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_responses_workspace_id_workspaces_id_fk": {
+          "name": "form_responses_workspace_id_workspaces_id_fk",
+          "tableFrom": "form_responses",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "response_count": {
+          "name": "response_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forms_slug_key": {
+          "name": "forms_slug_key",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_workspace_id_workspaces_id_fk": {
+          "name": "forms_workspace_id_workspaces_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_webhook_idx": {
+          "name": "webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_workspace_idx": {
+          "name": "webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_workspace_id_workspaces_id_fk": {
+          "name": "webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788019377532,
       "tag": "0007_partition_click_events",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788029831657,
+      "tag": "0008_hll_uniques",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/analytics.ts
+++ b/packages/database/src/schema/analytics.ts
@@ -1,6 +1,7 @@
 import {
   bigint,
   boolean,
+  customType,
   date,
   index,
   integer,
@@ -124,6 +125,9 @@ export const clickDaily = pgTable(
       .references(() => workspaces.id, { onDelete: "cascade" }),
     day: date("day").notNull(),
     clicks: integer("clicks").notNull().default(0),
+    /** Approximate distinct visitors, derived from the click_daily_uniques HLL
+     *  sketch during rollup (see that table). An integer here so the dashboard
+     *  and API keep summing it cheaply; the sketch stays out of this hot row. */
     uniques: integer("uniques").notNull().default(0),
     scans: integer("scans").notNull().default(0),
     blocked: integer("blocked").notNull().default(0),
@@ -161,20 +165,44 @@ export const breakdownDaily = pgTable(
   ],
 );
 
-/** Counting distinct visitors per day needs the set of hashes seen that day.
- *  Kept separately from click_events so retention can drop the raw events
- *  while the uniques number stays correct. Pruned aggressively — it only has
- *  to survive long enough for the day to close. */
-export const dailyVisitors = pgTable(
-  "daily_visitors",
+/** A raw Postgres bytea, mapped to a Node Buffer both ways. The postgres
+ *  driver already returns bytea values as Buffer, so the fromDriver side is a
+ *  pass-through; the toDriver side accepts the Buffer that domain.serialize
+ *  produces. Kept generic (Buffer) rather than tied to the sketch so any
+ *  future binary column can reuse it. */
+const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType() {
+    return "bytea";
+  },
+});
+
+/** The HyperLogLog uniques sketch, one fixed-size (~16 KiB) blob per
+ *  (link_id, day).
+ *
+ *  This is the durable record distinct-visitor counts are derived from, and it
+ *  lives in its own table rather than as a column on click_daily on purpose:
+ *
+ *  - click_daily stays a thin all-integer counter row. The dashboard and API
+ *    sum click_daily on every load; a 16 KiB bytea on each of those rows would
+ *    bloat every one of those scans for a value they never read.
+ *  - the sketch is the uniques source independent of the raw click_events,
+ *    which is exactly the separation the old daily_visitors table provided:
+ *    retention can drop raw events while uniques stay correct.
+ *
+ *  rollupClicks merges the day's incoming sketch into the stored one by taking
+ *  the register-wise maximum (see @snapurl/domain merge), which is idempotent
+ *  and commutative, so recomputing a day never inflates its uniques.
+ *  click_daily.uniques is then re-derived from this sketch via estimate. */
+export const clickDailyUniques = pgTable(
+  "click_daily_uniques",
   {
     linkId: uuid("link_id")
       .notNull()
       .references(() => links.id, { onDelete: "cascade" }),
     day: date("day").notNull(),
-    visitorHash: varchar("visitor_hash", { length: 32 }).notNull(),
+    sketch: bytea("sketch").notNull(),
   },
-  (t) => [primaryKey({ columns: [t.linkId, t.day, t.visitorHash] })],
+  (t) => [primaryKey({ columns: [t.linkId, t.day] })],
 );
 
 /** The rotating salt behind every visitor hash. Yesterday's row is deleted,

--- a/packages/domain/src/hll.test.ts
+++ b/packages/domain/src/hll.test.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  HLL_BYTE_SIZE,
+  HLL_PRECISION,
+  HLL_REGISTER_COUNT,
+  addHashed,
+  createSketch,
+  deserialize,
+  estimate,
+  merge,
+  serialize,
+} from "./hll.js";
+
+/* Uniques at this product's scale are approximate on purpose: the exact
+   row-per-visitor table is a hard scale ceiling. These tests are the proof
+   that the sketch we own is actually a HyperLogLog and not a stub - that its
+   estimate tracks true cardinality within HLL's known error band, and that
+   merge is the register-wise max that makes re-running a rollup safe. They
+   run with no database and no network. */
+
+/** Deterministic, reproducible synthetic visitor hashes (32 hex chars). */
+const hashOf = (input: string): string =>
+  createHash("sha256").update(input).digest("hex").slice(0, 32);
+
+const sketchOf = (inputs: Iterable<string>): Uint8Array => {
+  const s = createSketch();
+  for (const input of inputs) addHashed(s, hashOf(input));
+  return s;
+};
+
+const range = (start: number, end: number): string[] => {
+  const out: string[] = [];
+  for (let i = start; i < end; i++) out.push(`item-${i}`);
+  return out;
+};
+
+describe("hll constants", () => {
+  it("uses precision 14 with a fixed 16384-byte layout", () => {
+    expect(HLL_PRECISION).toBe(14);
+    expect(HLL_REGISTER_COUNT).toBe(16384);
+    expect(HLL_BYTE_SIZE).toBe(16384);
+  });
+});
+
+describe("createSketch", () => {
+  it("is empty and estimates zero", () => {
+    const s = createSketch();
+    expect(s.length).toBe(HLL_BYTE_SIZE);
+    expect(estimate(s)).toBe(0);
+  });
+});
+
+describe("estimate accuracy", () => {
+  // Linear counting dominates at small N, so allow it more headroom than the
+  // 0.81% theoretical standard error; the raw estimator range must be tight.
+  const cases: Array<{ n: number; tolerance: number }> = [
+    { n: 100, tolerance: 0.1 },
+    { n: 1000, tolerance: 0.05 },
+    { n: 10000, tolerance: 0.03 },
+    { n: 100000, tolerance: 0.03 },
+  ];
+
+  for (const { n, tolerance } of cases) {
+    it(`estimates ${n} distinct items within ${tolerance * 100}%`, () => {
+      const s = sketchOf(range(0, n));
+      const est = estimate(s);
+      const relativeError = Math.abs(est - n) / n;
+      expect(relativeError).toBeLessThan(tolerance);
+    });
+  }
+
+  it("estimates a handful of items close to the true small count", () => {
+    const s = sketchOf(range(0, 7));
+    // In the linear-counting range a small count should be near-exact.
+    expect(estimate(s)).toBeGreaterThanOrEqual(6);
+    expect(estimate(s)).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("addHashed", () => {
+  it("is idempotent: adding the same hash many times does not inflate", () => {
+    const s = createSketch();
+    const h = hashOf("solo-visitor");
+    for (let i = 0; i < 1000; i++) addHashed(s, h);
+    expect(estimate(s)).toBeLessThanOrEqual(2);
+  });
+
+  it("rejects a hash that is not 32 hex chars", () => {
+    const s = createSketch();
+    expect(() => addHashed(s, "abc")).toThrow();
+    expect(() => addHashed(s, "z".repeat(32))).toThrow();
+  });
+
+  it("rejects a wrong-size sketch", () => {
+    expect(() => addHashed(new Uint8Array(10), hashOf("x"))).toThrow();
+  });
+});
+
+describe("merge", () => {
+  it("is register-wise max", () => {
+    const a = createSketch();
+    const b = createSketch();
+    a[0] = 5;
+    a[1] = 2;
+    b[0] = 3;
+    b[1] = 9;
+    const m = merge(a, b);
+    expect(m[0]).toBe(5);
+    expect(m[1]).toBe(9);
+  });
+
+  it("is commutative register-for-register", () => {
+    const a = sketchOf(range(0, 5000));
+    const b = sketchOf(range(2500, 7500));
+    const ab = merge(a, b);
+    const ba = merge(b, a);
+    expect(Array.from(ab)).toEqual(Array.from(ba));
+  });
+
+  it("is idempotent: merge(a, a) equals a", () => {
+    const a = sketchOf(range(0, 5000));
+    const aa = merge(a, a);
+    expect(Array.from(aa)).toEqual(Array.from(a));
+  });
+
+  it("approximates the union cardinality of disjoint sets", () => {
+    const a = sketchOf(range(0, 20000));
+    const b = sketchOf(range(20000, 40000));
+    const est = estimate(merge(a, b));
+    // 40000 is a mid-range cardinality; a broken merge would be off by tens of
+    // percent, so this band is tight enough to catch that while leaving room
+    // above the 0.81% theoretical error for this fixed sample.
+    expect(Math.abs(est - 40000) / 40000).toBeLessThan(0.04);
+  });
+
+  it("approximates the union cardinality of overlapping sets", () => {
+    // Union of [0,30000) and [10000,40000) is [0,40000) = 40000 distinct.
+    const a = sketchOf(range(0, 30000));
+    const b = sketchOf(range(10000, 40000));
+    const est = estimate(merge(a, b));
+    expect(Math.abs(est - 40000) / 40000).toBeLessThan(0.04);
+  });
+
+  it("matches directly building the union sketch", () => {
+    const a = sketchOf(range(0, 5000));
+    const b = sketchOf(range(3000, 9000));
+    const merged = merge(a, b);
+    const direct = sketchOf(range(0, 9000));
+    // Register-wise max of the two halves must equal the sketch built from
+    // the union directly - the property the rollup depends on.
+    expect(Array.from(merged)).toEqual(Array.from(direct));
+  });
+
+  it("rejects mismatched sizes", () => {
+    expect(() => merge(createSketch(), new Uint8Array(10))).toThrow();
+    expect(() => merge(new Uint8Array(10), createSketch())).toThrow();
+  });
+});
+
+describe("serialize / deserialize", () => {
+  it("round-trips to an identical sketch", () => {
+    const s = sketchOf(range(0, 12345));
+    const bytes = serialize(s);
+    expect(bytes.length).toBe(HLL_BYTE_SIZE);
+    const back = deserialize(bytes);
+    expect(Array.from(back)).toEqual(Array.from(s));
+    expect(estimate(back)).toBe(estimate(s));
+  });
+
+  it("produces a buffer independent of the source sketch", () => {
+    const s = createSketch();
+    const bytes = serialize(s);
+    s[0] = 42;
+    // Mutating the source after serialize must not change the serialized copy.
+    expect(bytes[0]).toBe(0);
+  });
+
+  it("deserialize copies so the result is independent of input bytes", () => {
+    const s = sketchOf(range(0, 100));
+    const bytes = serialize(s);
+    const back = deserialize(bytes);
+    bytes[0] = 99;
+    expect(back[0]).not.toBe(99);
+  });
+
+  it("rejects wrong-length input", () => {
+    expect(() => deserialize(new Uint8Array(HLL_BYTE_SIZE - 1))).toThrow();
+    expect(() => deserialize(new Uint8Array(HLL_BYTE_SIZE + 1))).toThrow();
+    expect(() => serialize(new Uint8Array(10))).toThrow();
+  });
+});

--- a/packages/domain/src/hll.ts
+++ b/packages/domain/src/hll.ts
@@ -1,0 +1,234 @@
+import { createHash } from "node:crypto";
+
+/* ============================================================
+   Approximate uniques: a HyperLogLog sketch we own.
+
+   The obvious way to count unique visitors is one row per
+   (link, day, visitor) and a COUNT(DISTINCT). At this product's
+   target load that is billions of rows in a btree, which is a hard
+   scale ceiling, not a tuning problem. The obvious fix is the
+   postgresql-hll extension, and it is the wrong one here: it adds
+   an extension to the "docker compose up" promise the single-node
+   profile is built on, and it does not port to ClickHouse or Redis,
+   so every future analytics adapter would need its own uniques
+   implementation.
+
+   So the sketch lives here, in pure TypeScript with no I/O. A sketch
+   we own runs on vanilla Postgres, any managed Postgres, and behind
+   any future analytics adapter unchanged. It is stored as a fixed
+   16 KiB blob per (link, day) in a bytea column and merged during
+   rollup by taking the register-wise maximum, which is what makes a
+   rollup safe to re-run: merging is idempotent and commutative, so
+   recomputing a day never inflates its uniques.
+
+   The cost, which the UI must state plainly: uniques become
+   approximate. At precision p=14 the standard error is
+   1.04 / sqrt(16384) = 0.8125%, roughly 0.8%. Every analytics
+   product at this scale reports approximate uniques; a hybrid
+   "exact below a threshold, sketch above" design was considered and
+   rejected because two code paths produce two numbers that disagree
+   at the boundary, which is worse than being consistently
+   approximate.
+   ============================================================ */
+
+/**
+ * Precision. The register index is the top HLL_PRECISION bits of the
+ * hashed value, so m = 2^p registers. p=14 is the sweet spot for this
+ * product: ~0.81% error at a fixed 16 KiB per (link, day), which is
+ * cheap enough to keep 45 days of history per link without a ceiling.
+ */
+export const HLL_PRECISION = 14;
+
+/** m = 2^p = 16384 registers. */
+export const HLL_REGISTER_COUNT = 1 << HLL_PRECISION;
+
+/**
+ * One byte per register. A register holds a "rank" (position of the
+ * leftmost 1-bit) which for a 32-bit tail never exceeds ~33, so a
+ * single byte is ample. This gives a fixed 16384-byte layout that maps
+ * 1:1 to a Postgres bytea column and can be merged in a future
+ * ClickHouse or Redis adapter without reinterpretation.
+ */
+export const HLL_BYTE_SIZE = HLL_REGISTER_COUNT;
+
+/**
+ * alpha_m bias-correction constant for the raw estimator. The general
+ * form is 0.7213 / (1 + 1.079/m) for m >= 128, which m=16384 satisfies.
+ */
+const ALPHA_M = 0.7213 / (1 + 1.079 / HLL_REGISTER_COUNT);
+
+/** 2^32, used by the large-range correction threshold and formula. */
+const TWO_POW_32 = 2 ** 32;
+
+/** A fresh, empty sketch: every register at rank 0. */
+export function createSketch(): Uint8Array {
+  return new Uint8Array(HLL_REGISTER_COUNT);
+}
+
+/**
+ * Reduce the 32-hex-char (128-bit) visitorHash from visitor.ts to a
+ * single 32-bit unsigned value that the HLL bit-extraction operates on.
+ *
+ * The visitorHash is an HMAC-SHA256 digest truncated to 128 bits, so it
+ * is already a uniform, well-distributed digest. We fold it to 32 bits by
+ * XORing its four 32-bit words. XOR of independent uniform words is still
+ * uniform, which is all HLL needs, and it keeps the whole path allocation
+ * free. Non-hex or wrong-length input would silently produce NaN words, so
+ * we validate the shape and reject it loudly instead.
+ */
+function hashHexTo32Bit(hashHex: string): number {
+  if (hashHex.length !== 32 || !/^[0-9a-fA-F]{32}$/.test(hashHex)) {
+    throw new Error(
+      `hll: expected a 32-hex-char visitorHash, got ${JSON.stringify(hashHex)}`,
+    );
+  }
+  let x = 0;
+  for (let word = 0; word < 4; word++) {
+    const offset = word * 8;
+    // parseInt on an 8-hex-char slice yields a full 32-bit word.
+    const value = parseInt(hashHex.slice(offset, offset + 8), 16);
+    x = (x ^ value) >>> 0;
+  }
+  return x >>> 0;
+}
+
+/**
+ * The core register update, shared by addHashed and the test path.
+ *
+ * Split the 32-bit value into:
+ *  - index: the top HLL_PRECISION bits, selecting one of m registers;
+ *  - tail:  the remaining (32 - HLL_PRECISION) bits, whose leftmost
+ *           1-bit position (leading zeros + 1) is the register rank.
+ *
+ * If the tail is all zeros the rank is (32 - HLL_PRECISION) + 1, the
+ * largest value the tail can justify. Each register keeps the maximum
+ * rank it has ever seen, which is what makes repeated adds of the same
+ * visitor idempotent.
+ */
+function addValue(sketch: Uint8Array, x: number): void {
+  const index = x >>> (32 - HLL_PRECISION);
+  const tailBits = 32 - HLL_PRECISION;
+  // Shift the index bits off the top, keeping only the tail in a 32-bit slot.
+  const tail = (x << HLL_PRECISION) >>> 0;
+  // rank = position of the leftmost 1-bit within the tail, counting from 1.
+  // Math.clz32 counts leading zeros of the full 32-bit word; the tail's own
+  // leading zeros are that minus the HLL_PRECISION index bits we shifted in.
+  const rank = tail === 0 ? tailBits + 1 : Math.clz32(tail) + 1;
+  if (rank > sketch[index]!) {
+    sketch[index] = rank;
+  }
+}
+
+/**
+ * Add one visitor to the sketch, in place, given the 32-hex-char
+ * visitorHash produced by visitor.ts. Adding the same hash again is a
+ * no-op on the estimate: the register can only stay at its current max.
+ */
+export function addHashed(sketch: Uint8Array, hashHex: string): void {
+  if (sketch.length !== HLL_BYTE_SIZE) {
+    throw new Error(
+      `hll: sketch must be ${HLL_BYTE_SIZE} bytes, got ${sketch.length}`,
+    );
+  }
+  addValue(sketch, hashHexTo32Bit(hashHex));
+}
+
+/**
+ * Estimate the cardinality of the sketch using the standard HLL estimator
+ * with the two canonical corrections.
+ *
+ *  - Raw estimate E = alpha_m * m^2 / sum(2^-register).
+ *  - Small range: when E <= 2.5*m and some registers are still zero, the
+ *    raw estimator is biased, so use linear counting m * ln(m / V) where V
+ *    is the count of zero registers.
+ *  - Large range: when E > 2^32 / 30, correct for 32-bit hash saturation
+ *    with -2^32 * ln(1 - E/2^32).
+ */
+export function estimate(sketch: Uint8Array): number {
+  if (sketch.length !== HLL_BYTE_SIZE) {
+    throw new Error(
+      `hll: sketch must be ${HLL_BYTE_SIZE} bytes, got ${sketch.length}`,
+    );
+  }
+  const m = HLL_REGISTER_COUNT;
+  let sum = 0;
+  let zeros = 0;
+  for (let i = 0; i < m; i++) {
+    const rank = sketch[i]!;
+    sum += 2 ** -rank;
+    if (rank === 0) zeros++;
+  }
+
+  let e = (ALPHA_M * m * m) / sum;
+
+  if (e <= 2.5 * m && zeros > 0) {
+    // Linear counting is more accurate than the raw estimator in this range.
+    e = m * Math.log(m / zeros);
+  } else if (e > TWO_POW_32 / 30) {
+    // Undo the collision bias of a 32-bit hash space near saturation.
+    e = -TWO_POW_32 * Math.log(1 - e / TWO_POW_32);
+  }
+
+  return Math.max(0, Math.round(e));
+}
+
+/**
+ * Merge two sketches into a new one by taking the element-wise maximum of
+ * their registers. This is the operation the rollup relies on. Because max
+ * is idempotent (max(a,a)=a) and commutative (max(a,b)=max(b,a)), re-running
+ * a rollup over the same day can never change the uniques figure, which is
+ * the invariant the old row-counting code protected with its
+ * recompute-not-increment comment.
+ */
+export function merge(a: Uint8Array, b: Uint8Array): Uint8Array {
+  if (a.length !== HLL_BYTE_SIZE || b.length !== HLL_BYTE_SIZE) {
+    throw new Error(
+      `hll: merge expects two ${HLL_BYTE_SIZE}-byte sketches, got ${a.length} and ${b.length}`,
+    );
+  }
+  const out = new Uint8Array(HLL_REGISTER_COUNT);
+  for (let i = 0; i < HLL_REGISTER_COUNT; i++) {
+    const av = a[i]!;
+    const bv = b[i]!;
+    out[i] = av > bv ? av : bv;
+  }
+  return out;
+}
+
+/**
+ * Serialize a sketch to a Buffer for storage in a Postgres bytea column.
+ * The layout is raw and dense (no compression) so it round-trips exactly
+ * and can be merged in SQL or a future adapter without reinterpretation.
+ */
+export function serialize(sketch: Uint8Array): Buffer {
+  if (sketch.length !== HLL_BYTE_SIZE) {
+    throw new Error(
+      `hll: cannot serialize a ${sketch.length}-byte sketch, expected ${HLL_BYTE_SIZE}`,
+    );
+  }
+  return Buffer.from(sketch);
+}
+
+/**
+ * Deserialize bytes read back from a bytea column into a sketch. Validates
+ * the length so a truncated or foreign blob fails loudly rather than
+ * producing silent nonsense. Copies into a fresh Uint8Array so the returned
+ * sketch is independent of the caller's buffer.
+ */
+export function deserialize(bytes: Uint8Array | Buffer): Uint8Array {
+  if (bytes.length !== HLL_BYTE_SIZE) {
+    throw new Error(
+      `hll: cannot deserialize ${bytes.length} bytes, expected ${HLL_BYTE_SIZE}`,
+    );
+  }
+  return new Uint8Array(bytes);
+}
+
+/**
+ * A deterministic 32-hex-char hash for a given input, matching the shape of
+ * visitor.ts output. Kept here so both callers and tests can generate valid
+ * synthetic hashes without reaching for crypto directly.
+ */
+export function hashForTesting(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 32);
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -4,3 +4,4 @@ export * from "./slug.js";
 export * from "./destination.js";
 export * from "./deep-link.js";
 export * from "./form.js";
+export * from "./hll.js";

--- a/web/src/app/(app)/analytics/page.tsx
+++ b/web/src/app/(app)/analytics/page.tsx
@@ -55,7 +55,10 @@ export default function AnalyticsPage() {
             <Tile label="Clicks" value={full(data.totals.clicks)} delta={`▲ ${pct(data.deltas.clicks)}`} deltaTone="up">
               <Sparkline values={data.series.map((s) => s.clicks)} width={160} height={26} />
             </Tile>
-            <Tile label="Unique visitors" value={full(data.totals.unique)} delta={`▲ ${pct(data.deltas.unique)}`} deltaTone="up">
+            {/* Uniques are an approximate HyperLogLog estimate (about 0.8% error),
+                not an exact distinct count - the label says so rather than
+                implying a precision the number does not have. */}
+            <Tile label="Unique visitors (approx.)" value={full(data.totals.unique)} delta={`▲ ${pct(data.deltas.unique)}`} deltaTone="up">
               <Sparkline values={data.series.map((s) => s.unique)} width={160} height={26} />
             </Tile>
             <Tile label="QR scans" value={full(data.totals.scans)} delta={`▲ ${pct(data.deltas.scans)}`} deltaTone="up">

--- a/web/src/app/(app)/links/[id]/page.tsx
+++ b/web/src/app/(app)/links/[id]/page.tsx
@@ -169,7 +169,9 @@ export default function LinkDetailPage() {
         <Tile label="Total clicks" value={full(l.clicks)} {...deltaFor(a?.deltas.clicks, range)}>
           <Sparkline values={clickSeries} width={160} height={26} />
         </Tile>
-        <Tile label="Unique visitors" value={full(l.uniqueClicks ?? 0)} {...deltaFor(a?.deltas.unique, range)}>
+        {/* Approximate: uniques come from a HyperLogLog sketch (about 0.8%
+            error), so the label signals that rather than implying an exact count. */}
+        <Tile label="Unique visitors (approx.)" value={full(l.uniqueClicks ?? 0)} {...deltaFor(a?.deltas.unique, range)}>
           {/* The real per-day uniques, not the click sparkline scaled by 0.72. */}
           {uniqueSeries ? <Sparkline values={uniqueSeries} width={160} height={26} /> : null}
         </Tile>

--- a/web/src/components/charts/index.tsx
+++ b/web/src/components/charts/index.tsx
@@ -56,7 +56,10 @@ export function TrafficChart({
   series?: SeriesKey[];
   height?: number;
 }) {
-  const labels: Record<SeriesKey, string> = { clicks: "Clicks", unique: "Unique", scans: "QR scans" };
+  // "Unique" carries the same "(approx.)" caveat as the KPI tiles: the figure
+  // is a HyperLogLog estimate, not an exact distinct count, and the legend must
+  // not imply otherwise.
+  const labels: Record<SeriesKey, string> = { clicks: "Clicks", unique: "Unique (approx.)", scans: "QR scans" };
   // Primary series takes the brand accent; the comparison stays neutral so
   // the pairing survives whichever accent the viewer picked.
   const colors: Record<SeriesKey, string> = {


### PR DESCRIPTION
Closes #269. Phase 1 of epic #267.

## The problem
`daily_visitors` stored one row per `(link_id, day, visitor_hash)`. At 1,000 req/s with half the traffic unique that is ~43M rows/day, ~2 billion rows in a btree over the 45-day window. Unworkable at any budget.

## Approach
- **New pure-TypeScript HyperLogLog sketch in `@snapurl/domain`** (`packages/domain/src/hll.ts`), NOT the `postgresql-hll` extension — so `docker compose up` stays dependency-free and the sketch ports unchanged to future ClickHouse/Redis `AnalyticsReader` adapters and any managed Postgres.
- **Precision p=14 → 16384 registers, 1 byte each → a fixed 16 KiB `bytea` per (link, day).** Standard error 1.04/√16384 = **~0.81%**, matching the issue's target. Stored in a new `click_daily_uniques` table keyed by (link_id, day); `click_daily.uniques` is now *derived* from the sketch.
- `rollupClicks` builds per-(link,day) sketches from each batch, merges them register-wise (max) into the stored sketch, and sets `uniques = estimate(merged)`.
- `daily_visitors` and `pruneVisitors` removed (table + prune job + main.ts wiring). Retention still drops raw `click_events` while the sketch keeps uniques correct — same separation the old table provided.
- **Idempotency:** HLL merge is register-wise max, which is idempotent (max(a,a)=a) and commutative, so re-running a rollup can't move uniques — preserving the old recompute-not-increment invariant. The upsert does `INSERT … ON CONFLICT DO NOTHING` → `SELECT … FOR UPDATE` → merge in Node → `UPDATE`, so concurrent workers on the same (link, day) serialize on the row and converge (hardened after a semantic-review flag).
- **UI copy:** uniques are now labelled **approximate** everywhere they surface — the 'Unique visitors (approx.)' KPI on the analytics dashboard and link-detail page, and 'Unique (approx.)' in the traffic-chart legend. No hybrid exact-below-threshold path (explicitly rejected by the epic).

Migration is **0008** (sits on top of the 0007 partition migration now in main).

## How to test
From repo root:
1. `rm -rf web/.next` (clears stale generated route types) then `pnpm type-check` → green (verified).
2. `pnpm --filter @snapurl/domain test` → 113 pass incl. the 21-test HLL suite (large-N accuracy <3% actual / ~0.8% expected error, merge=register-wise-max idempotent+commutative, serialize/deserialize round-trip, validation). Verified.
3. `NEXT_PUBLIC_API_URL=https://api.example.com/api/v1 pnpm build` → green (web prod build requires that env var — pre-existing precondition, not from this change).
4. `pnpm --filter @snapurl/database generate` → expect 'No schema changes' (confirms migration 0008 matches schema, no drift).
5. `grep -rn 'daily_visitors|dailyVisitors|pruneVisitors' packages/*/src apps/*/src` → only intentional historical comments remain.
6. DB-gated rollup tests: run with a real Postgres 18 (`pnpm db:up && pnpm db:migrate && pnpm --filter @snapurl/worker test`). They assert uniques are stable on a re-run and equal the union under a simulated concurrent writer.

**What to look for in review:** `rollupClicks` merges sketches (not row counts) and derives `click_daily.uniques` via `estimate`; the sketch column is a fixed-size bytea; `daily_visitors`/`pruneVisitors` are gone.

## Environment note
DB-dependent tests could not run in-sandbox (podman/crun cgroup error prevents starting postgres:18-alpine); they skip cleanly here and run in CI with `DATABASE_URL`. Type-check, build, and the pure HLL unit tests were executed and are green.