### PR TITLE
Add optional read-replica URL and verified TLS to createDatabase (#271)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,7 +4,19 @@ PORT=3001
 API_PREFIX=api/v1
 
 DATABASE_URL=postgres://snapurl:snapurl@localhost:5433/snapurl
+# Optional read replica. When absent, dashboard/analytics reads use the primary
+# and single-node behaviour is unchanged. Set it to send replica-safe reads
+# (pure analytics and list queries) to a replica while writes stay on primary.
+# DATABASE_REPLICA_URL=
+# DATABASE_SSL=true now VERIFIES the server certificate (verify-full) by
+# default, which protects the connection against a man-in-the-middle.
 DATABASE_SSL=false
+# Supply a CA bundle (PEM contents) to verify against, for RDS or a self-signed
+# server whose CA is not in the system trust store.
+# DATABASE_CA_CERT=
+# Opt out of certificate verification. Only safe inside a trusted network (VPC);
+# insecure across any network you do not control.
+# DATABASE_SSL_NO_VERIFY=false
 DATABASE_POOL_MAX=10
 
 # Two different secrets. One key signing both would let a stolen access token

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { and, breakdownDaily, clickDaily, conversions, desc, eq, gte, links, lt, sql, type Database } from "@snapurl/database";
 import type { Analytics, AnalyticsQuery, Breakdown, TimeseriesPoint } from "@snapurl/contract";
-import { DB } from "../database/database.module.js";
+import { DB, READ_DB } from "../database/database.module.js";
 
 const RANGE_DAYS: Record<string, number> = { "24h": 1, "7d": 7, "30d": 30, "90d": 90, "12m": 365 };
 
@@ -20,20 +20,31 @@ const COUNTRY_NAMES: Record<string, string> = {
 
 @Injectable()
 export class AnalyticsService {
-  constructor(@Inject(DB) private readonly db: Database) {}
+  constructor(
+    @Inject(DB) private readonly db: Database,
+    // Read-only handle. Every query in this service is a pure dashboard
+    // aggregation over rollup tables with no write in the same operation, so
+    // all of them are replica-safe — see overview().
+    @Inject(READ_DB) private readonly readDb: Database,
+  ) {}
 
   /* Everything here reads rollup tables, never click_events.
 
      Aggregating raw rows on page load is fine at a thousand clicks and
      unusable at ten million; the rollups exist precisely so this endpoint's
-     cost is bounded by the date range rather than by traffic. */
+     cost is bounded by the date range rather than by traffic.
+
+     Replica-safe: overview (and the breakdown/tagBreakdown/topLinks helpers it
+     calls) only read rollup tables and never write, so they route through
+     this.readDb. No read-then-write here, so replica lag cannot produce a
+     wrong answer relative to a write in the same operation. */
   async overview(workspaceId: string, query: AnalyticsQuery): Promise<Analytics> {
     const days = RANGE_DAYS[query.range] ?? 30;
     const { start, previousStart } = windowFor(days);
 
     const scope = query.linkId ? and(eq(clickDaily.workspaceId, workspaceId), eq(clickDaily.linkId, query.linkId)) : eq(clickDaily.workspaceId, workspaceId);
 
-    const [current] = await this.db
+    const [current] = await this.readDb
       .select({
         clicks: sql<number>`coalesce(sum(${clickDaily.clicks}), 0)::int`,
         unique: sql<number>`coalesce(sum(${clickDaily.uniques}), 0)::int`,
@@ -43,7 +54,7 @@ export class AnalyticsService {
       .from(clickDaily)
       .where(and(scope, gte(clickDaily.day, iso(start))));
 
-    const [previous] = await this.db
+    const [previous] = await this.readDb
       .select({
         clicks: sql<number>`coalesce(sum(${clickDaily.clicks}), 0)::int`,
         unique: sql<number>`coalesce(sum(${clickDaily.uniques}), 0)::int`,
@@ -52,7 +63,7 @@ export class AnalyticsService {
       .from(clickDaily)
       .where(and(scope, gte(clickDaily.day, iso(previousStart)), lt(clickDaily.day, iso(start))));
 
-    const series = await this.db
+    const series = await this.readDb
       .select({
         date: clickDaily.day,
         clicks: sql<number>`coalesce(sum(${clickDaily.clicks}), 0)::int`,
@@ -84,7 +95,7 @@ export class AnalyticsService {
        the stat tile needs its own count. Without this the analytics page reads
        zero while the conversions page reports hundreds — the kind of
        contradiction that makes someone stop trusting both numbers. */
-    const [conversionTotals] = await this.db
+    const [conversionTotals] = await this.readDb
       .select({ n: sql<number>`count(*)::int` })
       .from(conversions)
       .where(
@@ -95,7 +106,7 @@ export class AnalyticsService {
         ),
       );
 
-    const [previousConversions] = await this.db
+    const [previousConversions] = await this.readDb
       .select({ n: sql<number>`count(*)::int` })
       .from(conversions)
       .where(
@@ -152,7 +163,8 @@ export class AnalyticsService {
     ];
     if (linkId) filters.push(eq(breakdownDaily.linkId, linkId));
 
-    const rows = await this.db
+    // Replica-safe: pure read of the breakdown rollup.
+    const rows = await this.readDb
       .select({ label: breakdownDaily.value, value: sql<number>`sum(${breakdownDaily.count})::int` })
       .from(breakdownDaily)
       .where(and(...filters))
@@ -165,7 +177,8 @@ export class AnalyticsService {
   /** Tags live on the link, not on the click, so this joins rather than
    *  reading a breakdown row. A click inherits whatever tags the link has now. */
   private async tagBreakdown(workspaceId: string, start: Date): Promise<Breakdown[]> {
-    const rows = await this.db
+    // Replica-safe: pure read of the click rollup joined to links.
+    const rows = await this.readDb
       .select({ label: sql<string>`tag`, value: sql<number>`sum(${clickDaily.clicks})::int` })
       .from(clickDaily)
       .innerJoin(links, eq(clickDaily.linkId, links.id))
@@ -178,7 +191,8 @@ export class AnalyticsService {
   }
 
   private async topLinks(workspaceId: string, start: Date): Promise<Breakdown[]> {
-    const rows = await this.db
+    // Replica-safe: pure read of the click rollup joined to links.
+    const rows = await this.readDb
       .select({ slug: links.slug, value: sql<number>`sum(${clickDaily.clicks})::int` })
       .from(clickDaily)
       .innerJoin(links, eq(clickDaily.linkId, links.id))

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -10,10 +10,21 @@ export const EnvSchema = z.object({
   API_PREFIX: z.string().default("api/v1"),
 
   DATABASE_URL: z.string().min(1),
+  /** Optional read-replica connection string. Absent means reads use the
+      primary — single-node behaviour is unchanged. */
+  DATABASE_REPLICA_URL: z.string().optional(),
   DATABASE_SSL: z
     .string()
     .default("false")
     .transform((v) => v === "true"),
+  /** Opt out of TLS certificate verification (VPC/self-signed only; insecure
+      across untrusted networks). Defaults to off, i.e. verification is on. */
+  DATABASE_SSL_NO_VERIFY: z
+    .string()
+    .default("false")
+    .transform((v) => v === "true"),
+  /** PEM contents of a CA bundle used to verify the DB server certificate. */
+  DATABASE_CA_CERT: z.string().optional(),
   DATABASE_POOL_MAX: z.coerce.number().int().default(10),
 
   /* Two separate secrets. If one key signed both, a stolen access token could

--- a/apps/api/src/conversions/conversions.service.ts
+++ b/apps/api/src/conversions/conversions.service.ts
@@ -1,17 +1,25 @@
 import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
 import { and, clickDaily, conversions, desc, eq, gte, linkCounters, links, lt, sql, workspaces, type Database } from "@snapurl/database";
 import type { ConversionsReport, RecordConversionInput } from "@snapurl/contract";
-import { DB } from "../database/database.module.js";
+import { DB, READ_DB } from "../database/database.module.js";
 import { recordActivity, type Actor } from "../common/activity.js";
 
 const RANGE_DAYS: Record<string, number> = { "24h": 1, "7d": 7, "30d": 30, "90d": 90, "12m": 365 };
 
 @Injectable()
 export class ConversionsService {
-  constructor(@Inject(DB) private readonly db: Database) {}
+  constructor(
+    @Inject(DB) private readonly db: Database,
+    // Read-only handle for the pure dashboard reads (report and its helpers).
+    // record() deliberately stays on this.db — see the note there.
+    @Inject(READ_DB) private readonly readDb: Database,
+  ) {}
 
   private readonly logger = new Logger(ConversionsService.name);
 
+  /* Replica-safe: report (and its totalsFor/revenueSeries helpers) only reads
+     rollup and conversion rows to render the dashboard; it never writes in the
+     same operation, so it routes through this.readDb. */
   async report(workspaceId: string, range = "30d"): Promise<ConversionsReport> {
     const days = RANGE_DAYS[range] ?? 30;
     const start = new Date();
@@ -26,7 +34,7 @@ export class ConversionsService {
        number that means nothing, and converting would need a rate source and a
        rate date — a product decision, not a backend one. So the report states
        the workspace currency and counts only conversions recorded in it. */
-    const [workspace] = await this.db
+    const [workspace] = await this.readDb
       .select({ currency: workspaces.currency })
       .from(workspaces)
       .where(eq(workspaces.id, workspaceId))
@@ -36,7 +44,7 @@ export class ConversionsService {
     const totals = await this.totalsFor(workspaceId, start, undefined, currency);
     const previous = await this.totalsFor(workspaceId, previousStart, start, currency);
 
-    const events = await this.db
+    const events = await this.readDb
       .select({
         id: sql<string>`min(${conversions.id}::text)`,
         kind: conversions.kind,
@@ -50,7 +58,7 @@ export class ConversionsService {
       .orderBy(desc(sql`count(*)`))
       .limit(12);
 
-    const byLink = await this.db
+    const byLink = await this.readDb
       .select({
         link: links.slug,
         campaign: sql<string>`coalesce(${links.utm}->>'campaign', coalesce(${links.folder}, '-'))`,
@@ -95,6 +103,12 @@ export class ConversionsService {
     };
   }
 
+  /* Stays on the primary (this.db), never the replica: this is a read-then-write.
+     It resolves a slug to a link id and reads the workspace currency, then
+     INSERTs a conversion and writes activity in the same logical operation.
+     On a lagging replica the slug or currency lookup could miss a row that was
+     just created on the primary, so the conversion would be misresolved or
+     rejected. Read the inputs and write from the same primary handle. */
   async record(workspaceId: string, actor: Actor, input: RecordConversionInput) {
     let linkId = input.linkId ?? null;
     if (!linkId && input.slug) {
@@ -167,7 +181,8 @@ export class ConversionsService {
     const bounds = [eq(conversions.workspaceId, workspaceId), gte(conversions.occurredAt, start)];
     if (end) bounds.push(lt(conversions.occurredAt, end));
 
-    const [row] = await this.db
+    // Replica-safe: helper for report(), pure aggregate read.
+    const [row] = await this.readDb
       .select({
         leads: sql<number>`count(*) filter (where ${conversions.kind} = 'lead')::int`,
         signups: sql<number>`count(*) filter (where ${conversions.kind} = 'signup')::int`,
@@ -179,7 +194,7 @@ export class ConversionsService {
 
     const clickBounds = [eq(clickDaily.workspaceId, workspaceId), gte(clickDaily.day, isoDay(start))];
     if (end) clickBounds.push(lt(clickDaily.day, isoDay(end)));
-    const [clicks] = await this.db
+    const [clicks] = await this.readDb
       .select({ total: sql<number>`coalesce(sum(${clickDaily.clicks}), 0)::int` })
       .from(clickDaily)
       .where(and(...clickBounds));
@@ -194,7 +209,8 @@ export class ConversionsService {
   }
 
   private async revenueSeries(workspaceId: string, start: Date, days: number, currency: string): Promise<number[]> {
-    const rows = await this.db
+    // Replica-safe: helper for report(), pure aggregate read.
+    const rows = await this.readDb
       .select({
         day: sql<string>`(${conversions.occurredAt} at time zone 'UTC')::date::text`,
         revenueMinor: sql<string>`coalesce(sum(${conversions.valueMinor}), 0)::text`,

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -4,6 +4,11 @@ import { ENV } from "../config/env.js";
 import type { Env } from "../config/env.js";
 
 export const DB = Symbol("DB");
+/** Read-only handle. Points at the replica when DATABASE_REPLICA_URL is set,
+ *  otherwise it is the same handle as DB. Only inject this for reads that are
+ *  NOT part of a read-then-write operation — replica lag would make such reads
+ *  stale relative to the write that follows. */
+export const READ_DB = Symbol("READ_DB");
 export const DB_HANDLE = Symbol("DB_HANDLE");
 
 type Handle = ReturnType<typeof createDatabase>;
@@ -15,11 +20,19 @@ type Handle = ReturnType<typeof createDatabase>;
       provide: DB_HANDLE,
       inject: [ENV],
       useFactory: (env: Env) =>
-        createDatabase({ url: env.DATABASE_URL, ssl: env.DATABASE_SSL, max: env.DATABASE_POOL_MAX }),
+        createDatabase({
+          url: env.DATABASE_URL,
+          replicaUrl: env.DATABASE_REPLICA_URL,
+          ssl: env.DATABASE_SSL,
+          sslNoVerify: env.DATABASE_SSL_NO_VERIFY,
+          sslCaCert: env.DATABASE_CA_CERT,
+          max: env.DATABASE_POOL_MAX,
+        }),
     },
     { provide: DB, inject: [DB_HANDLE], useFactory: (h: Handle) => h.db },
+    { provide: READ_DB, inject: [DB_HANDLE], useFactory: (h: Handle) => h.readDb },
   ],
-  exports: [DB, DB_HANDLE],
+  exports: [DB, READ_DB, DB_HANDLE],
 })
 export class DatabaseModule implements OnApplicationShutdown {
   constructor(@Inject(DB_HANDLE) private readonly handle: Handle) {}

--- a/apps/api/src/links/links.service.integration.test.ts
+++ b/apps/api/src/links/links.service.integration.test.ts
@@ -84,7 +84,9 @@ describeDb("LinksService.list", () => {
   beforeAll(async () => {
     handle = createDatabase({ url: DATABASE_URL!, max: 1 });
     db = handle.db;
-    service = new LinksService(db, safeBrowsingStub);
+    // Second arg is the read-only handle. Single-node here, so it is the same
+    // db handle as the primary (matches READ_DB === DB when no replica is set).
+    service = new LinksService(db, db, safeBrowsingStub);
 
     const [ws] = await db
       .insert(workspaces)

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -13,7 +13,7 @@ import type {
   UpdateLinkInput,
 } from "@snapurl/contract";
 import { SLUG_RETRY_LIMIT, generateSlug, isSlugAvailableShape, validateRoutingChain, validateSchedule } from "@snapurl/domain";
-import { DB } from "../database/database.module.js";
+import { DB, READ_DB } from "../database/database.module.js";
 import { SafeBrowsingService } from "../safe-browsing/safe-browsing.service.js";
 import { isUniqueViolation } from "../common/postgres-error.filter.js";
 import { recordActivity, type Actor } from "../common/activity.js";
@@ -33,11 +33,19 @@ const ARGON_OPTIONS = { type: argon2.argon2id, memoryCost: 19_456, timeCost: 2, 
 export class LinksService {
   constructor(
     @Inject(DB) private readonly db: Database,
+    // Read-only handle for the two purely external reads (list and the public
+    // get). Every write path — and the post-write read-backs inside them —
+    // deliberately stays on this.db; see getFrom() for the read-your-own-write
+    // trap that makes the distinction load-bearing.
+    @Inject(READ_DB) private readonly readDb: Database,
     private readonly safeBrowsing: SafeBrowsingService,
   ) {}
 
   private readonly logger = new Logger(LinksService.name);
 
+  /* Replica-safe: list() is a purely external read for the dashboard table
+     and CSV export. It never writes, and it is never called from inside a
+     write flow, so it reads from this.readDb. */
   async list(workspaceId: string, query: ListLinksQuery) {
     const filters = [eq(links.workspaceId, workspaceId)];
 
@@ -99,7 +107,7 @@ export class LinksService {
     if (query.folder) filters.push(eq(links.folder, query.folder));
     if (query.domain) filters.push(sql`lower(${domains.domain}) = ${query.domain.toLowerCase()}`);
 
-    const [{ total }] = await this.db
+    const [{ total }] = await this.readDb
       .select({ total: sql<number>`count(*)::int` })
       .from(links)
       .innerJoin(domains, eq(links.domainId, domains.id))
@@ -117,7 +125,7 @@ export class LinksService {
     }
 
     // One extra row tells us whether there is another page without a second query.
-    const rows = await this.db
+    const rows = await this.readDb
       .select({
         link: links,
         domain: domains.domain,
@@ -138,6 +146,7 @@ export class LinksService {
     const last = page[page.length - 1];
 
     const items = await this.hydrate(
+      this.readDb,
       page.map((r) => ({ ...r, link: { ...r.link, clicks: r.clicks, uniqueClicks: r.uniqueClicks } as LinkRow })),
     );
 
@@ -148,8 +157,26 @@ export class LinksService {
     };
   }
 
+  /* Replica-safe: the public GET path for a single link is a pure read, so it
+     goes through this.readDb.
+
+     WARNING: get() is NOT safe to reuse inside write flows. insert(),
+     bulkCreate() and clone() call get() right after committing to return the
+     freshly written row, and update() reads it before and after mutating. On a
+     lagging replica that "read your own write" returns a stale or absent row —
+     the caller would see the pre-write state, or a 404 for a link that exists.
+     Those callers use getFrom(this.db, ...) instead so the read-back lands on
+     the primary. The query is written once in getFrom(); only the executor
+     differs. */
   async get(workspaceId: string, id: string): Promise<Link> {
-    const [row] = await this.db
+    return this.getFrom(this.readDb, workspaceId, id);
+  }
+
+  /* The shared single-link read. `executor` is this.readDb for the external
+     GET and this.db for post-write read-backs — see get() for why the
+     distinction matters. */
+  private async getFrom(executor: Executor, workspaceId: string, id: string): Promise<Link> {
+    const [row] = await executor
       .select({
         link: links,
         domain: domains.domain,
@@ -165,7 +192,7 @@ export class LinksService {
       .limit(1);
 
     if (!row) throw new NotFoundException("That link doesn't exist, or isn't in this workspace.");
-    const [dto] = await this.hydrate([
+    const [dto] = await this.hydrate(executor, [
       { ...row, link: { ...row.link, clicks: row.clicks, uniqueClicks: row.uniqueClicks } as LinkRow },
     ]);
     return dto!;
@@ -405,7 +432,9 @@ export class LinksService {
        links exist by now, so a failure here must not undo them. */
     const results: BulkLinkOutcome[] = [];
     for (const [i, id] of ids.entries()) {
-      const link = await this.get(workspaceId, id);
+      // Primary read-back: these rows were just committed, a replica may not
+      // have them yet.
+      const link = await this.getFrom(this.db, workspaceId, id);
       await recordActivity(this.db, this.logger, {
         workspaceId,
         actor,
@@ -435,7 +464,9 @@ export class LinksService {
    * a hash here and passed alongside.
    */
   async clone(workspaceId: string, id: string, actor: Actor, input: CloneLinkInput): Promise<Link> {
-    const source = await this.get(workspaceId, id);
+    // Primary: clone reads the source then inserts a copy, a read-then-write.
+    // The insert() it delegates to also reads back from the primary.
+    const source = await this.getFrom(this.db, workspaceId, id);
 
     /* The DTO exposes `passwordProtected`, never the hash, so read it
        separately rather than widening what every caller of `get` receives. */
@@ -589,7 +620,9 @@ export class LinksService {
           await this.enqueueProjection(tx, row!.id, "upsert");
           return row!.id;
         })
-          .then((id) => this.get(workspaceId, id))
+          // Primary read-back: reading the just-committed row from a lagging
+          // replica could 404 or return a stale copy.
+          .then((id) => this.getFrom(this.db, workspaceId, id))
           .then(async (link) => {
             await recordActivity(this.db, this.logger, {
               workspaceId,
@@ -628,7 +661,9 @@ export class LinksService {
   /* G1 — PATCH did not exist, yet editing a destination is the entire promise
      behind "print it once, change where it points forever". */
   async update(workspaceId: string, id: string, actor: Actor, input: UpdateLinkInput): Promise<Link> {
-    const existing = await this.get(workspaceId, id);
+    // Primary: update reads the row, mutates it, then reads it back — a
+    // read-then-write throughout, so both reads must see the primary.
+    const existing = await this.getFrom(this.db, workspaceId, id);
 
     /* Both windows have to be checked against what the row will look like
        afterwards, not against the patch: sending only `expiresAt` can still
@@ -697,7 +732,7 @@ export class LinksService {
       await this.enqueueProjection(tx, id, "upsert");
     });
 
-    const updated = await this.get(workspaceId, id);
+    const updated = await this.getFrom(this.db, workspaceId, id);
     await recordActivity(this.db, this.logger, {
       workspaceId,
       actor,
@@ -822,11 +857,14 @@ export class LinksService {
 
   /** Batch the rules and sparklines for a page of links — otherwise a 50-row
    *  table issues 101 queries. */
-  private async hydrate(rows: Array<{ link: LinkRow; domain: string; creator: string | null }>) {
+  private async hydrate(
+    executor: Executor,
+    rows: Array<{ link: LinkRow; domain: string; creator: string | null }>,
+  ) {
     if (rows.length === 0) return [];
     const ids = rows.map((r) => r.link.id);
 
-    const rules = await this.db
+    const rules = await executor
       .select()
       .from(routingRules)
       .where(inArray(routingRules.linkId, ids))
@@ -834,7 +872,7 @@ export class LinksService {
 
     const since = new Date();
     since.setUTCDate(since.getUTCDate() - SPARKLINE_DAYS);
-    const daily = await this.db
+    const daily = await executor
       .select({ linkId: clickDaily.linkId, day: clickDaily.day, clicks: clickDaily.clicks })
       .from(clickDaily)
       .where(and(inArray(clickDaily.linkId, ids), gte(clickDaily.day, since.toISOString().slice(0, 10))));

--- a/apps/api/src/members/members.service.ts
+++ b/apps/api/src/members/members.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, ConflictException, Inject, Injectable, NotFoundExc
 import { randomBytes, createHash } from "node:crypto";
 import { and, auditLog, desc, eq, links, memberships, sql, users, type Database } from "@snapurl/database";
 import type { AuditEntry, InviteMemberInput, Member } from "@snapurl/contract";
-import { DB } from "../database/database.module.js";
+import { DB, READ_DB } from "../database/database.module.js";
 import { initialsOf } from "../auth/auth.service.js";
 import { MailService } from "../mail/mail.service.js";
 
@@ -10,11 +10,16 @@ import { MailService } from "../mail/mail.service.js";
 export class MembersService {
   constructor(
     @Inject(DB) private readonly db: Database,
+    // Read-only handle for the pure reads (list, audit). The mutating methods
+    // below (invite/changeRole/remove/writeAudit) read-then-write in the same
+    // operation and deliberately stay on this.db.
+    @Inject(READ_DB) private readonly readDb: Database,
     private readonly mail: MailService,
   ) {}
 
+  // Replica-safe: pure read of the membership/user tables for the team page.
   async list(workspaceId: string): Promise<Member[]> {
-    const rows = await this.db
+    const rows = await this.readDb
       .select({
         membership: memberships,
         user: users,
@@ -41,6 +46,12 @@ export class MembersService {
     }));
   }
 
+  /* invite/changeRole/remove/writeAudit all stay on the primary (this.db):
+     each reads-then-writes in one operation (invite checks for an existing
+     membership then inserts; changeRole/remove count owners then mutate;
+     writeAudit inserts). On a lagging replica the guard read could miss a row
+     that already exists on the primary, so the check and the write must share
+     the primary handle. */
   async invite(workspaceId: string, actorLabel: string, input: InviteMemberInput): Promise<Member> {
     const email = input.email.toLowerCase().trim();
 
@@ -149,8 +160,9 @@ export class MembersService {
     });
   }
 
+  // Replica-safe: pure read of the audit log for the activity view.
   async audit(workspaceId: string, limit = 50): Promise<AuditEntry[]> {
-    const rows = await this.db
+    const rows = await this.readDb
       .select()
       .from(auditLog)
       .where(eq(auditLog.workspaceId, workspaceId))

--- a/apps/redirect/.env.example
+++ b/apps/redirect/.env.example
@@ -1,6 +1,15 @@
 PORT=3002
 DATABASE_URL=postgres://snapurl:snapurl@localhost:5433/snapurl
+# Optional read replica. When absent, reads use the primary (single-node
+# behaviour unchanged). The redirect always uses the primary for the click gate
+# regardless, but this is plumbed through for consistency.
+# DATABASE_REPLICA_URL=
+# DATABASE_SSL=true now VERIFIES the server certificate (verify-full) by default.
 DATABASE_SSL=false
+# CA bundle (PEM) to verify against, for RDS/self-signed.
+# DATABASE_CA_CERT=
+# Opt out of verification. VPC only; insecure across untrusted networks.
+# DATABASE_SSL_NO_VERIFY=false
 # Must match the API — the redirect verifies unlock tokens the API signed.
 JWT_ACCESS_SECRET=
 WEB_ORIGIN=http://localhost:3000

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -45,7 +45,19 @@ const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:3000";
 const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 5);
 
 const app = Fastify({ logger: { level: process.env.LOG_LEVEL ?? "info" }, trustProxy: true });
-const { db, close } = createDatabase({ url: DATABASE_URL, ssl: process.env.DATABASE_SSL === "true", max: POOL_MAX });
+/* The replica URL and SSL settings are plumbed through for consistency with the
+   other apps, but the redirect deliberately uses the PRIMARY `db` handle (not
+   readDb) everywhere: the click-limit gate reads a link's click count and then
+   records a click, so it is a read-then-write path. Serving that read from a
+   replica would let lag hand back a stale count and overshoot the hard cap. */
+const { db, close } = createDatabase({
+  url: DATABASE_URL,
+  replicaUrl: process.env.DATABASE_REPLICA_URL,
+  ssl: process.env.DATABASE_SSL === "true",
+  sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
+  sslCaCert: process.env.DATABASE_CA_CERT,
+  max: POOL_MAX,
+});
 
 const resolver: LinkResolver = new PostgresLinkResolver(db);
 const clicks: ClickSink = new PostgresClickSink(db);

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -1,5 +1,14 @@
 DATABASE_URL=postgres://snapurl:snapurl@localhost:5433/snapurl
+# Optional read replica. When absent, reads use the primary (single-node
+# behaviour unchanged). The worker always runs on the primary regardless (its
+# jobs read-then-write), but this is plumbed through for consistency.
+# DATABASE_REPLICA_URL=
+# DATABASE_SSL=true now VERIFIES the server certificate (verify-full) by default.
 DATABASE_SSL=false
+# CA bundle (PEM) to verify against, for RDS/self-signed.
+# DATABASE_CA_CERT=
+# Opt out of verification. VPC only; insecure across untrusted networks.
+# DATABASE_SSL_NO_VERIFY=false
 LOG_LEVEL=info
 ROLLUP_INTERVAL_SECONDS=30
 MAINTENANCE_INTERVAL_SECONDS=3600

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -22,7 +22,20 @@ const MAINTENANCE_SECONDS = Number(process.env.MAINTENANCE_INTERVAL_SECONDS ?? 3
    where every extra connection is idle and counted against RDS's limit. */
 const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 4);
 
-export const { db, close } = createDatabase({ url: DATABASE_URL, ssl: process.env.DATABASE_SSL === "true", max: POOL_MAX });
+/* The replica URL and SSL settings are plumbed through for consistency, but the
+   worker deliberately runs every job on the PRIMARY `db` handle: rollups drain
+   click_events then mark them consumed, retention prunes what it has just
+   counted, and so on — every worker read is part of a read-then-write logical
+   operation. Reading those from a lagging replica would double-count or skip
+   rows, so there is no readDb here on purpose. */
+export const { db, close } = createDatabase({
+  url: DATABASE_URL,
+  replicaUrl: process.env.DATABASE_REPLICA_URL,
+  ssl: process.env.DATABASE_SSL === "true",
+  sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
+  sslCaCert: process.env.DATABASE_CA_CERT,
+  max: POOL_MAX,
+});
 const projection = new NoProjection();
 
 /** Runs often: this is the loop that makes the dashboards current. */

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -23,7 +23,8 @@
     "migrate": "tsx scripts/migrate.ts",
     "seed": "tsx scripts/seed.ts",
     "studio": "drizzle-kit studio",
-    "import-v1": "tsx scripts/import-v1.ts"
+    "import-v1": "tsx scripts/import-v1.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@snapurl/contract": "workspace:*",
@@ -36,6 +37,7 @@
     "argon2": "^0.44.0",
     "drizzle-kit": "^0.31.5",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createDatabase } from "./client.js";
+import { buildSslOption, createDatabase } from "./client.js";
 
 /* Pure-logic checks for the read-replica plumbing. postgres-js does not open a
    socket until a query actually runs, so constructing the pools here is safe
@@ -38,5 +38,50 @@ describe("createDatabase read-replica handle", () => {
     expect(handle).toHaveProperty("readDb");
     expect(handle).toHaveProperty("sql");
     expect(typeof handle.close).toBe("function");
+  });
+});
+
+/* Security-critical: buildSslOption holds the TLS verification default and the
+   opt-out precedence. These assertions are written so that reintroducing
+   `{ rejectUnauthorized: false }` as the default (the old insecure behaviour)
+   would make the "verify-full" and CA-bundle cases fail. */
+describe("buildSslOption", () => {
+  const CA_PEM = "-----BEGIN CERTIFICATE-----\nMIIBfake\n-----END CERTIFICATE-----";
+
+  it("returns undefined when ssl is disabled", () => {
+    expect(buildSslOption({ url: PRIMARY_URL, ssl: false })).toBeUndefined();
+  });
+
+  it("returns undefined when ssl is absent", () => {
+    expect(buildSslOption({ url: PRIMARY_URL })).toBeUndefined();
+  });
+
+  it("returns { rejectUnauthorized: false } when ssl is on and sslNoVerify is set", () => {
+    expect(buildSslOption({ url: PRIMARY_URL, ssl: true, sslNoVerify: true })).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+
+  it("verifies against a supplied CA bundle when ssl is on and sslCaCert is set", () => {
+    const result = buildSslOption({ url: PRIMARY_URL, ssl: true, sslCaCert: CA_PEM });
+    expect(result).toEqual({ ca: CA_PEM, rejectUnauthorized: true });
+  });
+
+  it("defaults to 'verify-full' when ssl is on and nothing else is set", () => {
+    const result = buildSslOption({ url: PRIMARY_URL, ssl: true });
+    // Must NOT silently disable verification: the default has to verify the chain
+    // AND the hostname, never { rejectUnauthorized: false }.
+    expect(result).toBe("verify-full");
+    expect(result).not.toEqual({ rejectUnauthorized: false });
+  });
+
+  it("lets sslNoVerify win over sslCaCert when both are set (explicit opt-out wins)", () => {
+    const result = buildSslOption({
+      url: PRIMARY_URL,
+      ssl: true,
+      sslNoVerify: true,
+      sslCaCert: CA_PEM,
+    });
+    expect(result).toEqual({ rejectUnauthorized: false });
   });
 });

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatabase } from "./client.js";
+
+/* Pure-logic checks for the read-replica plumbing. postgres-js does not open a
+   socket until a query actually runs, so constructing the pools here is safe
+   with no Postgres available — we only assert on handle identity and always
+   close() to avoid leaking pools. */
+
+const PRIMARY_URL = "postgres://user:pass@primary.example:5432/db";
+const REPLICA_URL = "postgres://user:pass@replica.example:5432/db";
+
+describe("createDatabase read-replica handle", () => {
+  let handle: ReturnType<typeof createDatabase> | undefined;
+
+  afterEach(async () => {
+    if (handle) await handle.close();
+    handle = undefined;
+  });
+
+  it("returns readDb as the same reference as db when no replicaUrl is given", () => {
+    handle = createDatabase({ url: PRIMARY_URL });
+    expect(handle.readDb).toBe(handle.db);
+  });
+
+  it("treats a replicaUrl equal to the primary url as single-node (readDb === db)", () => {
+    handle = createDatabase({ url: PRIMARY_URL, replicaUrl: PRIMARY_URL });
+    expect(handle.readDb).toBe(handle.db);
+  });
+
+  it("returns a distinct readDb handle when a different replicaUrl is given", () => {
+    handle = createDatabase({ url: PRIMARY_URL, replicaUrl: REPLICA_URL });
+    expect(handle.readDb).not.toBe(handle.db);
+  });
+
+  it("exposes the expected handle shape", () => {
+    handle = createDatabase({ url: PRIMARY_URL });
+    expect(handle).toHaveProperty("db");
+    expect(handle).toHaveProperty("readDb");
+    expect(handle).toHaveProperty("sql");
+    expect(typeof handle.close).toBe("function");
+  });
+});

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -12,27 +12,88 @@ export type Executor = Database | Transaction;
 
 export interface DatabaseOptions {
   url: string;
+  /** Optional read-replica connection string. When absent (the common
+   *  single-node case) every read uses the primary and behaviour is
+   *  byte-identical to before this option existed. When set, reads issued
+   *  through `readDb` land on the replica while writes stay on the primary.
+   *
+   *  ONLY route a query here if it does not read-then-write in the same
+   *  logical operation. Replica lag means a value read from the replica can be
+   *  stale relative to a write you are about to make against the primary, which
+   *  turns gates and counters into wrong answers. Pure analytics/list reads are
+   *  safe; anything guarding a subsequent write is not. */
+  replicaUrl?: string;
   /** Lambda gets 1 — a function instance serves one request at a time, so a
    *  pool there just multiplies idle connections against RDS's small limit. */
   max?: number;
   ssl?: boolean;
+  /** Opt out of TLS certificate verification ({ rejectUnauthorized: false }).
+   *  This is the old default and is only safe inside a trusted network (a VPC),
+   *  where there is no MITM to defend against. Do not enable it for a
+   *  connection that crosses a network you do not control. */
+  sslNoVerify?: boolean;
+  /** PEM contents of a CA bundle to verify the server certificate against, for
+   *  RDS or a self-signed setup whose CA is not in the system trust store. */
+  sslCaCert?: string;
+}
+
+/** Build the postgres-js `ssl` option.
+ *
+ *  Certificate verification defends the database connection against a
+ *  man-in-the-middle: without it, anything on the network path can present its
+ *  own certificate and read or rewrite queries. So when TLS is on we default to
+ *  'verify-full' (verifies the certificate chain AND the hostname) rather than
+ *  the old `{ rejectUnauthorized: false }`, which accepted any certificate.
+ *
+ *  Precedence, most explicit first:
+ *    1. sslNoVerify  — deliberate opt-out for VPC/self-signed (insecure).
+ *    2. sslCaCert    — verify against a supplied CA bundle.
+ *    3. 'verify-full'— verify against the system CA store (the default). */
+function buildSslOption(opts: DatabaseOptions): postgres.Options<Record<string, never>>["ssl"] {
+  if (!opts.ssl) return undefined;
+  if (opts.sslNoVerify) return { rejectUnauthorized: false };
+  if (opts.sslCaCert) return { ca: opts.sslCaCert, rejectUnauthorized: true };
+  return "verify-full";
 }
 
 export function createDatabase(opts: DatabaseOptions) {
-  const sql = postgres(opts.url, {
+  const ssl = buildSslOption(opts);
+  const connectionOptions = {
     max: opts.max ?? 10,
     idle_timeout: 20,
     connect_timeout: 10,
-    ssl: opts.ssl ? { rejectUnauthorized: false } : undefined,
+    ssl,
     // Postgres NUMERIC/BIGINT arrive as strings by default; the contract wants numbers.
     types: {
       bigint: postgres.BigInt,
     },
     onnotice: () => {},
-  });
+  } as const;
 
+  const sql = postgres(opts.url, connectionOptions);
   const db = drizzle(sql, { schema, casing: "snake_case" });
-  return { db, sql, close: () => sql.end({ timeout: 5 }) };
+
+  /* Only open a second pool when there is a distinct replica to talk to.
+     When replicaUrl is absent/empty, readDb IS db (same reference) so
+     single-node deployments carry exactly one pool and behaviour is
+     unchanged. */
+  const hasReplica = Boolean(opts.replicaUrl && opts.replicaUrl !== opts.url);
+  const replicaSql = hasReplica ? postgres(opts.replicaUrl!, connectionOptions) : undefined;
+  const readDb = replicaSql ? drizzle(replicaSql, { schema, casing: "snake_case" }) : db;
+
+  return {
+    db,
+    /** Read-only handle. Identical Drizzle type to `db`. Points at the replica
+     *  when replicaUrl is set, otherwise at the primary. Only use for reads that
+     *  are NOT part of a read-then-write operation (see DatabaseOptions.replicaUrl). */
+    readDb,
+    sql,
+    close: async () => {
+      await sql.end({ timeout: 5 });
+      // Guard against double-ending: replicaSql only exists when a distinct pool was opened.
+      if (replicaSql) await replicaSql.end({ timeout: 5 });
+    },
+  };
 }
 
 export { schema };

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -49,7 +49,7 @@ export interface DatabaseOptions {
  *    1. sslNoVerify  — deliberate opt-out for VPC/self-signed (insecure).
  *    2. sslCaCert    — verify against a supplied CA bundle.
  *    3. 'verify-full'— verify against the system CA store (the default). */
-function buildSslOption(opts: DatabaseOptions): postgres.Options<Record<string, never>>["ssl"] {
+export function buildSslOption(opts: DatabaseOptions): postgres.Options<Record<string, never>>["ssl"] {
   if (!opts.ssl) return undefined;
   if (opts.sslNoVerify) return { rejectUnauthorized: false };
   if (opts.sslCaCert) return { ca: opts.sslCaCert, rejectUnauthorized: true };

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "outDir": "./dist", "rootDir": "./src" },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/database/vitest.config.ts
+++ b/packages/database/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: { environment: "node", include: ["src/**/*.test.ts"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
 
   packages/domain:
     dependencies:


### PR DESCRIPTION
Closes #271. Phase 1 of epic #267 (final Phase 1 item).

## Approach
Two changes to `packages/database/src/client.ts` and its callers.

### 1. Optional read replica
- `DatabaseOptions` gains an optional `replicaUrl` (env `DATABASE_REPLICA_URL`). `createDatabase` now returns an extra **`readDb`** handle, typed identically to `db`.
- **When `replicaUrl` is absent (or equal to the primary): `readDb === db`, only one pool opens** — single-node behaviour is byte-identical. A distinct `replicaUrl` opens a second pool; `close()` (now async) ends both.
- **Replica-safe reads routed to `readDb`** (pure dashboard reads, no write in the same operation): analytics `overview`/breakdowns/topLinks, conversions `report`, links `list`/`get`, members `list`/`audit`.
- **Everything read-then-write stays on the primary, with the replica-lag trap named at each call site:** conversions `record`, all links create/update/clone/remove + their post-write read-backs, members mutations, the redirect hot path (click-limit gate reads-then-records), and all worker jobs (rollup drains then marks consumed). Under-routing is safe; over-routing is the dangerous mistake, so anything ambiguous was left on primary.

### 2. TLS certificate verification on by default
The old `ssl: { rejectUnauthorized: false }` disabled cert verification for every SSL connection. Now, when SSL is on, `buildSslOption` picks (most explicit first): `DATABASE_SSL_NO_VERIFY=true` → insecure opt-out (documented, for VPC/self-signed); `DATABASE_CA_CERT` (PEM) → verify against a supplied CA (RDS/self-host); otherwise **`verify-full`** (chain + hostname against the system store). `rejectUnauthorized:false` is now reachable ONLY via the explicit opt-out.

## Done-when
- ✅ `DATABASE_REPLICA_URL` honoured; absent = primary; added to all three `.env.example` files.
- ✅ Replica-safe read paths marked as such at the call site.
- ✅ Certificate verification on by default (`verify-full`) with a documented opt-out (`DATABASE_SSL_NO_VERIFY`) and optional CA bundle (`DATABASE_CA_CERT`).

No DB migration (client/config change only).

## Files changed
`packages/database/src/client.ts` (options, `buildSslOption`, lazy replica pool, `readDb`, async `close`) + new `client.test.ts` (10 pure-logic tests) + vitest wiring; `apps/api/src/config/env.ts` (zod: replica URL + 2 SSL vars); `apps/api/src/database/database.module.ts` (new `READ_DB` provider); analytics/conversions/links/members services (inject `READ_DB`, route safe reads); links integration test constructor; `apps/redirect/src/main.ts` + `apps/worker/src/main.ts` (plumb envs, stay on primary); three `.env.example` files.

## How to test
From repo root:
1. `pnpm type-check` → green (verified).
2. `rm -rf web/.next && NEXT_PUBLIC_API_URL=https://api.example.com/api/v1 pnpm build` → green (verified).
3. `pnpm test` → green; `packages/database` runs 10 new pure-logic tests (readDb identity for none/equal/distinct replicaUrl; `buildSslOption` off/absent/noVerify/CA/verify-full/precedence, incl. an explicit assertion the default is NOT `rejectUnauthorized:false`). DB-gated integration tests run in CI (Postgres 18); they skip locally.
4. `grep -n 'rejectUnauthorized' packages/database/src/client.ts` → the only hit is inside the `sslNoVerify` opt-out branch (verified).

**What to look for in review:** the safe/unsafe read classification at each switched call site; `readDb === db` when no replica; TLS default is `verify-full`.

## Environment note
DB integration tests could not run in-sandbox (podman/crun cannot start postgres:18-alpine); they skip cleanly here and run in CI. Type-check, build, and the pure client/domain unit tests were executed and are green.