### PR TITLE
Await click writes in the redirect so they survive Lambda freeze (#277)

### DIFF
--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -90,7 +90,7 @@ app.get<{ Params: { slug: string } }>("/:slug", async (request, reply) => {
   if (blocked) {
     // Blocked clicks are still recorded — "how many people hit an expired
     // link" is exactly the number that tells someone to go renew it.
-    void record(link, request, userAgent, blocked, null, null);
+    await record(link, request, userAgent, blocked, null, null);
 
     if (blocked === "expired" && link.expiresTo) return reply.redirect(link.expiresTo, 302);
     if (blocked === "scheduled" && link.scheduledTo) return reply.redirect(link.scheduledTo, 302);
@@ -154,7 +154,7 @@ app.get<{ Params: { slug: string } }>("/:slug", async (request, reply) => {
      platform fallback to catch the miss, so this is a no-op for most clicks. */
   const target = buildDeepLink(destination, parseDevice(userAgent), link.deepLink);
 
-  void record(link, request, userAgent, null, decision.matchedRuleId, decision.variant, hash);
+  await record(link, request, userAgent, null, decision.matchedRuleId, decision.variant, hash);
 
   for (const [header, value] of Object.entries(cacheHeadersFor(link.redirectType))) {
     void reply.header(header, value);
@@ -204,13 +204,27 @@ function isValidUnlockToken(token: string, linkId: string): boolean {
 }
 
 /**
- * Push the click and do not await it.
+ * Record the click. Awaited by the handler, but never fatal.
  *
- * The redirect must not get slower because analytics is having a bad day. A
- * failure here is logged and dropped — a lost click is a worse outcome than a
- * slow redirect only if you are the one counting clicks, and the visitor is not.
+ * This is awaited so the INSERT completes within the invocation. Under the
+ * Lambda Web Adapter the sandbox freezes the moment Fastify responds, which
+ * suspends any in-flight query: a fire-and-forget write is not just lost, it
+ * pins a Postgres backend the pool cannot reclaim and — with DATABASE_POOL_MAX=1
+ * — the next request on that warm instance queues behind a query that never
+ * finishes, until the function times out. Awaiting the write costs one
+ * same-AZ round trip (single-digit ms) and is vastly cheaper than a deadlocked
+ * instance billing its full timeout.
+ *
+ * It stays non-fatal: the try/catch below logs and swallows every error, so
+ * awaiting this can never throw into the handler. Analytics being down still
+ * cannot break a redirect — a lost click is a worse outcome than a slow
+ * redirect only if you are the one counting clicks, and the visitor is not.
+ *
+ * Phase 7 direction (per the issue): move to the SQS ClickSink adapter the
+ * port was designed for. An HTTP send with a bounded flush survives
+ * freeze/thaw in a way a Postgres INSERT does not.
  */
-function record(
+async function record(
   link: ResolvedLink,
   request: { ip: string; headers: Record<string, unknown> },
   userAgent: string,
@@ -218,40 +232,38 @@ function record(
   matchedRuleId: string | null,
   variant: string | null,
   precomputedHash?: string,
-) {
-  void (async () => {
-    try {
-      const salt = await salts.today();
-      const hash =
-        precomputedHash ?? visitorHash({ dailySalt: salt, ip: request.ip, userAgent, linkId: link.id });
+): Promise<void> {
+  try {
+    const salt = await salts.today();
+    const hash =
+      precomputedHash ?? visitorHash({ dailySalt: salt, ip: request.ip, userAgent, linkId: link.id });
 
-      await clicks.record({
-        linkId: link.id,
-        workspaceId: link.workspaceId,
-        occurredAt: new Date(),
-        visitorHash: hash,
-        country: ((request.headers["cloudfront-viewer-country"] as string) ?? "").toUpperCase().slice(0, 2) || null,
-        /* Deliberately not paired with CloudFront-Viewer-Latitude/Longitude,
-           which the same header family offers: a city is a population, a
-           coordinate is a location. */
-        city: ((request.headers["cloudfront-viewer-city"] as string) ?? "").slice(0, 100) || null,
-        device: parseDevice(userAgent),
-        browser: parseBrowser(userAgent),
-        os: parseOs(userAgent),
-        referrerHost: parseReferrerHost(request.headers.referer as string),
-        // A QR scan arrives with no referrer and a mobile UA. Imperfect, and
-        // the honest alternative — a ?qr marker the printer must remember to
-        // add — is worse because it silently under-counts.
-        isQr: !request.headers.referer && parseDevice(userAgent) !== "desktop",
-        isBot: isBot(userAgent),
-        blockedReason,
-        matchedRuleId,
-        variant,
-      });
-    } catch (err) {
-      app.log.warn({ err, linkId: link.id }, "failed to record click");
-    }
-  })();
+    await clicks.record({
+      linkId: link.id,
+      workspaceId: link.workspaceId,
+      occurredAt: new Date(),
+      visitorHash: hash,
+      country: ((request.headers["cloudfront-viewer-country"] as string) ?? "").toUpperCase().slice(0, 2) || null,
+      /* Deliberately not paired with CloudFront-Viewer-Latitude/Longitude,
+         which the same header family offers: a city is a population, a
+         coordinate is a location. */
+      city: ((request.headers["cloudfront-viewer-city"] as string) ?? "").slice(0, 100) || null,
+      device: parseDevice(userAgent),
+      browser: parseBrowser(userAgent),
+      os: parseOs(userAgent),
+      referrerHost: parseReferrerHost(request.headers.referer as string),
+      // A QR scan arrives with no referrer and a mobile UA. Imperfect, and
+      // the honest alternative — a ?qr marker the printer must remember to
+      // add — is worse because it silently under-counts.
+      isQr: !request.headers.referer && parseDevice(userAgent) !== "desktop",
+      isBot: isBot(userAgent),
+      blockedReason,
+      matchedRuleId,
+      variant,
+    });
+  } catch (err) {
+    app.log.warn({ err, linkId: link.id }, "failed to record click");
+  }
 }
 
 async function main() {

--- a/scripts/integration-assertions.sh
+++ b/scripts/integration-assertions.sh
@@ -80,21 +80,25 @@ else
 fi
 
 echo
-echo "== the click lands in click_events =="
-# The redirect service records clicks asynchronously, so poll rather than
-# assume the row is there the instant the 302 came back. Note: this count is
-# over click_events regardless of is_bot, so it would pass even for a bot UA;
-# the click_daily check below is the one that requires a non-bot UA.
+echo "== the click lands in click_events, exactly once =="
+# The redirect now AWAITS the click write before it sends the 302 (issue #277),
+# so the row exists synchronously by the time the redirect returns. We still
+# poll briefly to absorb commit/visibility lag, but the assertion is now
+# EXACTLY ONE row: this script drives exactly one redirect to this slug, so a
+# single click_events row is the correct count. A count other than 1 means
+# either the write was lost (fire-and-forget regression) or duplicated. Note:
+# this count is over click_events regardless of is_bot, so it holds for a bot
+# UA too; the click_daily check below is the one that requires a non-bot UA.
 EVENTS=0
 for i in $(seq 1 20); do
   EVENTS="$(dbq "select count(*) from click_events where link_id in (select id from links where slug = '$SLUG')" | tr -d '[:space:]')"
   [ "${EVENTS:-0}" -ge 1 ] && break
   sleep 1
 done
-if [ "${EVENTS:-0}" -ge 1 ]; then
-  ok "the redirect recorded a click in click_events ($EVENTS)"
+if [ "${EVENTS:-0}" -eq 1 ]; then
+  ok "the redirect recorded exactly one click in click_events ($EVENTS)"
 else
-  bad "click not recorded in click_events" "count=$EVENTS after 20s"
+  bad "redirect did not record exactly one click in click_events" "expected exactly 1, got count=$EVENTS after 20s"
 fi
 
 echo


### PR DESCRIPTION
Closes #277. Phase 3 of epic #267 (release-blocker).

## The problem (ordinary traffic, no attacker)
The redirect called `void record(...)` — fire-and-forget. Under the Lambda Web Adapter the sandbox **freezes the moment Fastify responds**, suspending the in-flight `INSERT`. Three consequences, the third expensive:
1. Clicks silently lost.
2. The suspended query pins a Postgres backend the server can't reclaim.
3. With `DATABASE_POOL_MAX=1`, postgres.js queues the next request behind that never-completing query until the 10s function timeout — so every warm instance breaks itself after one request and bills 10s instead of ~20ms (a 500x jump on the failure path).

## The fix (Phase 3)
`await` the click write so the INSERT completes within the invocation, before the sandbox freezes. It's one same-AZ round trip (single-digit ms) and vastly cheaper than a deadlocked instance.
- `record(...)` refactored from a non-async double fire-and-forget (`void (async()=>{...})()`) into a plain `async function … : Promise<void>` with the **same try/catch that logs and swallows every error** — so awaiting it can never throw into the handler. The click payload/logic is byte-for-byte identical.
- Both call sites changed `void record(...)` → `await record(...)` (the blocked path before the gated response; the success path before cache headers / the 302).
- **Still non-fatal:** analytics being down cannot break a redirect (errors are caught, logged, dropped). Doc-comment updated; Phase 7 SQS `ClickSink` noted as the future direction (an HTTP send with a bounded flush survives freeze/thaw in a way a Postgres INSERT does not).
- Left unchanged per the issue: `packages/database/src/client.ts` `connect_timeout` (the fuse, not the fix) and `DATABASE_POOL_MAX`.
- Confirmed `record` was the ONLY unawaited DB write across a response boundary; the remaining `void reply.header(...)` calls are synchronous Fastify reply builders.

## Done-when
- ✅ No DB write left unawaited across a response boundary.
- ✅ Integration harness asserts a redirect produces **exactly one** `click_events` row: `scripts/integration-assertions.sh` tightened from `>= 1` to `== 1` (the script drives exactly one redirect to a fresh slug; because the write is now awaited, the row exists synchronously by the time the 302 returns).
- Load-test 'no 10s invocations' is inherently a deployed-Lambda observation (Phase 7), but the mechanism is removed here.

## How to test
- `pnpm --filter @snapurl/redirect type-check` → passes (verified).
- `bash -n scripts/integration-assertions.sh` → OK (verified).
- **The compose `integration` CI job on this PR is the end-to-end arbiter**: it runs integration-assertions.sh against the composed stack (with a real worker), now asserting exactly one click_events row and survival into click_daily. Green = the awaited write lands exactly once.

Files: `apps/redirect/src/main.ts`, `scripts/integration-assertions.sh`.