### PR TITLE
Lock the redirect Function URL behind CloudFront OAC (#276)

### DIFF
--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -275,8 +275,14 @@ export class SnapUrlStack extends Stack {
     });
 
 
+    /* IAM auth, not NONE: a NONE Function URL is reachable by anyone on the
+       public internet, which skips CloudFront entirely and with it the WAF,
+       edge rate limiting, the viewer-country header, and the edge cache — and
+       opens a second uncapped path into the redirect Lambda. With AWS_IAM the
+       URL only answers to a SigV4-signed request; CloudFront signs via the
+       Origin Access Control wired below, and any direct caller gets 403. */
     const redirectUrl = redirectFn.addFunctionUrl({
-      authType: lambda.FunctionUrlAuthType.NONE,
+      authType: lambda.FunctionUrlAuthType.AWS_IAM,
     });
 
     /* The origin is a Lambda Function URL, and a Function URL rejects any
@@ -330,7 +336,19 @@ export class SnapUrlStack extends Stack {
 
     const distribution = new cloudfront.Distribution(this, "RedirectCdn", {
       defaultBehavior: {
-        origin: new origins.FunctionUrlOrigin(redirectUrl),
+        /* Origin Access Control, not a plain FunctionUrlOrigin: this helper
+           creates the OAC, sets signing to SIGV4_ALWAYS, and grants CloudFront
+           permission to invoke the AWS_IAM Function URL — so only CloudFront
+           can reach the origin and direct callers get 403. SigV4 validation
+           requires the signed Host to match the origin's own hostname, so
+           CloudFront must send the origin Host rather than the viewer's. That
+           is exactly what the RedirectOrigReqPolicy below does (Host is not in
+           its allow-list), and the RedirectViewerRequest function (#274) copies
+           the viewer Host into x-forwarded-host for the app to read. That
+           x-forwarded-host function is therefore a prerequisite for this OAC,
+           not a nicety — without it the app could not resolve the viewer's
+           domain once Host is pinned to the origin. */
+        origin: origins.FunctionUrlOrigin.withOriginAccessControl(redirectUrl),
         // Redirects must never be cached at the edge. The product promise is
         // "print it once, change where it points forever" — a cached 302 makes
         // a destination edit invisible to anyone who already clicked.
@@ -389,6 +407,15 @@ export class SnapUrlStack extends Stack {
     new CfnOutput(this, "RedirectDomain", {
       value: `https://${distribution.distributionDomainName}`,
       description: "CNAME your short domain here.",
+    });
+    /* The raw redirect Function URL. It is IAM-signed behind OAC, so a direct
+       (unsigned) request must return 403 while the same path through
+       RedirectDomain succeeds — that is the guarantee #276 is about. Exposed
+       here so the Phase 7 (#289) deployed smoke gate can assert the direct 403;
+       see scripts/smoke-redirect.sh. */
+    new CfnOutput(this, "RedirectFunctionUrl", {
+      value: redirectUrl.url,
+      description: "IAM-signed origin behind CloudFront OAC; a direct request must return 403.",
     });
     new CfnOutput(this, "DatabaseSecretArn", {
       value: database.secret?.secretArn ?? "(none)",

--- a/scripts/smoke-redirect.sh
+++ b/scripts/smoke-redirect.sh
@@ -287,6 +287,15 @@ echo "== deployment showstoppers =="
 #       via the DB in DB-available mode (local/compose/CI, no worker required),
 #       and via the analytics countries[] poll in deployed mode (no DB, but a
 #       worker is running there to roll clicks up). See below.
+#
+# TODO (Phase 7 / #276, #289): once a real deploy exists, add a deployed-only
+# assertion that a DIRECT (unsigned) request to the raw redirect Function URL
+# returns 403 — proof that OAC + AWS_IAM auth keep the origin reachable only
+# through CloudFront. The stack exposes that URL as the RedirectFunctionUrl
+# CfnOutput; wire it in here (e.g. via a FUNCTION_URL env var) and assert 403,
+# while $RD (the CloudFront base) continues to prove the via-CDN 302s above.
+# Not done locally/in compose: there is no Function URL there (compose hits the
+# container directly), so this must stay gated to the deployed target.
 
 # Drive a real redirect through the country-ruled $RUN-geo link with a non-bot
 # browser UA and a CloudFront-Viewer-Country header. This is what populates


### PR DESCRIPTION
Closes #276. Phase 3 of epic #267 (aws/security release-blocker). Prerequisite #274 (the x-forwarded-host CloudFront Function) is already merged.

## The problem
The redirect origin was created with `addFunctionUrl({ authType: NONE })` — the Lambda Function URL was directly reachable on the public internet, alongside the distribution. Anyone who found it could skip CloudFront and everything attached to it (a future WAF, edge rate limiting, the country header, the edge cache) — and it's a second uncapped path into the timeout amplifier from #278.

## The fix
- Function URL auth `NONE` → **`AWS_IAM`**.
- Origin `new FunctionUrlOrigin(redirectUrl)` → **`FunctionUrlOrigin.withOriginAccessControl(redirectUrl)`** — CloudFront signs origin requests with SigV4 (OAC, signing mode SIGV4_ALWAYS), so **direct callers get 403** while requests through CloudFront succeed. The helper also auto-grants CloudFront permission to invoke the IAM-authed Function URL.
- Added a `RedirectFunctionUrl` CfnOutput so a future deployed smoke run can read the raw URL to assert the 403.

**API/version:** used the built-in CDK helper `FunctionUrlOrigin.withOriginAccessControl` — **no aws-cdk-lib bump needed** (repo has 2.266.0; the helper landed ~2.157.0). Signature verified in node_modules. No package.json/lockfile change.

**Why Host-matching is fine (the #274 prerequisite):** SigV4/OAC requires the signed Host to match the origin's own hostname. The custom origin request policy already **excludes Host** (CloudFront sends the origin Host), and the #274 viewer-request function copies the viewer Host into `x-forwarded-host`, which the app reads to resolve the link's domain. So OAC signing validates AND the app still resolves the viewer's domain.

## Done-when
- ✅ (in code) A direct request to the Function URL is rejected — enforced by AWS_IAM + OAC.
- ✅ (in code) The same request through CloudFront succeeds — CloudFront signs; invoke permission auto-granted.
- Deployed smoke assertion for the direct-403 is **Phase-7-gated** (no Function URL exists locally/in compose; compose hits the container directly). Added a light TODO in `scripts/smoke-redirect.sh` describing the deployed-only assertion reading the `RedirectFunctionUrl` output, so #288/#289 can wire it.

## How to test
- `corepack pnpm --filter @snapurl/infra type-check` and repo-wide `corepack pnpm type-check` → pass (verified). CI re-runs type-check (includes infra).
- `cdk synth` / end-to-end (direct 403 vs via-CloudFront 200) is deferred to a Phase 7 deploy (no AWS creds/Docker in sandbox).

Files: `infra/lib/snapurl-stack.ts`, `scripts/smoke-redirect.sh`.