### PR TITLE
fix: reject dangerous URL schemes and internal hosts in the contract (#280)

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -12,12 +12,15 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
-    "type-check": "tsc -p tsconfig.json --noEmit"
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "typescript": "^5.7.3"
+    "@types/node": "^22.20.1",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/contract/src/http-url.test.ts
+++ b/packages/contract/src/http-url.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { HttpUrl, isDeniedHost } from "./http-url.js";
+import { CreateLinkInput, RoutingRule } from "./link.js";
+import { AddDomainInput, CreateWebhookInput, UpsertBioPageInput } from "./workspace.js";
+
+/* Issue #280: every URL-bearing field goes through HttpUrl, which rejects
+   dangerous schemes and internal hosts before anything can emit them as a
+   Location header or render them as a clickable <a href>. */
+
+describe("HttpUrl — accepted", () => {
+  it.each([
+    "https://example.com",
+    "http://example.com",
+    "https://example.com/path?q=1#frag",
+    "https://sub.example.co.uk/a/b/c",
+    "https://example.com:8443/ok",
+    "https://8.8.8.8/public-dns",
+  ])("accepts %s", (url) => {
+    expect(HttpUrl.safeParse(url).success).toBe(true);
+  });
+});
+
+describe("HttpUrl — rejected schemes", () => {
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html;base64,PHNjcmlwdD4=",
+    "file:///etc/passwd",
+    "ftp://example.com/file",
+    "vbscript:msgbox(1)",
+    "mailto:someone@example.com",
+    "tel:+15555555555",
+    "ws://example.com/socket",
+    "//example.com",
+    "not a url",
+  ])("rejects %s", (url) => {
+    expect(HttpUrl.safeParse(url).success).toBe(false);
+  });
+});
+
+describe("HttpUrl — denylisted host ranges", () => {
+  it.each([
+    ["loopback name", "http://localhost/admin"],
+    ["loopback name subdomain", "http://api.localhost/admin"],
+    ["loopback v4", "http://127.0.0.1/x"],
+    ["loopback v4 (127/8)", "http://127.99.1.2/x"],
+    ["unspecified v4", "http://0.0.0.0/x"],
+    ["private 10/8", "http://10.0.0.5/admin"],
+    ["private 172.16/12", "http://172.16.0.1/x"],
+    ["private 172.31/12", "http://172.31.255.255/x"],
+    ["private 192.168/16", "http://192.168.1.1/x"],
+    ["cgnat 100.64/10", "http://100.64.0.1/x"],
+    ["link-local / metadata", "http://169.254.169.254/latest/meta-data/"],
+    ["link-local range", "http://169.254.1.1/x"],
+    ["ipv6 loopback", "http://[::1]/x"],
+    ["ipv6 unspecified", "http://[::]/x"],
+    ["ipv6 link-local", "http://[fe80::1]/x"],
+    ["ipv6 unique-local", "http://[fd00::1]/x"],
+    ["ipv4-mapped metadata", "http://[::ffff:169.254.169.254]/x"],
+  ])("rejects %s: %s", (_label, url) => {
+    expect(HttpUrl.safeParse(url).success).toBe(false);
+  });
+
+  it("still allows public IPs that only look adjacent to private ranges", () => {
+    expect(HttpUrl.safeParse("http://172.15.0.1/x").success).toBe(true); // just below 172.16/12
+    expect(HttpUrl.safeParse("http://172.32.0.1/x").success).toBe(true); // just above 172.31
+    expect(HttpUrl.safeParse("http://100.63.0.1/x").success).toBe(true); // just below CGNAT
+    expect(HttpUrl.safeParse("http://100.128.0.1/x").success).toBe(true); // just above CGNAT
+  });
+});
+
+describe("isDeniedHost", () => {
+  it("flags internal hosts and clears public ones", () => {
+    expect(isDeniedHost("localhost")).toBe(true);
+    expect(isDeniedHost("169.254.169.254")).toBe(true);
+    expect(isDeniedHost("10.0.0.5")).toBe(true);
+    expect(isDeniedHost("example.com")).toBe(false);
+    expect(isDeniedHost("8.8.8.8")).toBe(false);
+  });
+});
+
+describe("every contract field routes through HttpUrl", () => {
+  const bad = "javascript:alert(1)";
+  const metadata = "http://169.254.169.254/latest/meta-data/";
+  const good = "https://example.com/ok";
+
+  it("CreateLinkInput.destination rejects dangerous URLs", () => {
+    expect(CreateLinkInput.safeParse({ destination: bad, domain: "d" }).success).toBe(false);
+    expect(CreateLinkInput.safeParse({ destination: metadata, domain: "d" }).success).toBe(false);
+    expect(CreateLinkInput.safeParse({ destination: good, domain: "d" }).success).toBe(true);
+  });
+
+  it("CreateLinkInput.social.image rejects dangerous URLs", () => {
+    expect(
+      CreateLinkInput.safeParse({ destination: good, domain: "d", social: { image: bad } }).success,
+    ).toBe(false);
+    expect(
+      CreateLinkInput.safeParse({ destination: good, domain: "d", social: { image: good } }).success,
+    ).toBe(true);
+  });
+
+  it("RoutingRule.then rejects dangerous URLs", () => {
+    const base = { id: "r1", when: {} };
+    expect(RoutingRule.safeParse({ ...base, then: bad }).success).toBe(false);
+    expect(RoutingRule.safeParse({ ...base, then: metadata }).success).toBe(false);
+    expect(RoutingRule.safeParse({ ...base, then: good }).success).toBe(true);
+  });
+
+  it("AddDomainInput.rootRedirect and notFoundRedirect reject dangerous URLs", () => {
+    expect(AddDomainInput.safeParse({ domain: "acme.com", rootRedirect: bad }).success).toBe(false);
+    expect(AddDomainInput.safeParse({ domain: "acme.com", notFoundRedirect: metadata }).success).toBe(false);
+    expect(AddDomainInput.safeParse({ domain: "acme.com", rootRedirect: good }).success).toBe(true);
+    expect(AddDomainInput.safeParse({ domain: "acme.com", rootRedirect: null }).success).toBe(true);
+  });
+
+  it("CreateWebhookInput.endpoint rejects dangerous URLs", () => {
+    expect(CreateWebhookInput.safeParse({ endpoint: bad, events: ["link.created"] }).success).toBe(false);
+    expect(CreateWebhookInput.safeParse({ endpoint: metadata, events: ["link.created"] }).success).toBe(false);
+    expect(CreateWebhookInput.safeParse({ endpoint: good, events: ["link.created"] }).success).toBe(true);
+  });
+
+  it("UpsertBioPageInput block href rejects dangerous URLs", () => {
+    const base = {
+      domain: "d",
+      slug: "me",
+      profile: { name: "Me", bio: "" },
+    };
+    const block = (href: string) => ({ kind: "link" as const, title: "t", href });
+    expect(UpsertBioPageInput.safeParse({ ...base, blocks: [block(bad)] }).success).toBe(false);
+    expect(UpsertBioPageInput.safeParse({ ...base, blocks: [block(metadata)] }).success).toBe(false);
+    expect(UpsertBioPageInput.safeParse({ ...base, blocks: [block(good)] }).success).toBe(true);
+  });
+});

--- a/packages/contract/src/http-url.ts
+++ b/packages/contract/src/http-url.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+
+/* ============================================================
+   The one URL schema every URL-bearing field in the contract uses.
+
+   Why this exists (issue #280): a bare `z.string().url()` only asserts that
+   `new URL()` did not throw. That happily accepts `javascript:alert(1)`,
+   `data:text/html;base64,…`, `file:///etc/passwd`, and links to internal
+   hosts like `http://169.254.169.254/…` (the cloud metadata endpoint) or
+   `http://10.0.0.5/admin`. Every one of those either leaves as a `Location`
+   header from the redirect service (apps/redirect/src/main.ts) or is rendered
+   as a clickable `<a href>` on the public trust page (web .../p/[slug]), so a
+   shortener that accepts them is phishing / SSRF infrastructure by default.
+
+   Keeping it in ONE place means a URL field added to the contract later cannot
+   quietly skip the check: it imports `HttpUrl` like every other field.
+   ============================================================ */
+
+/**
+ * Hosts that must never be a redirect or webhook destination.
+ *
+ * The ranges below are the ones an attacker reaches for: the loopback and
+ * unspecified addresses, RFC 1918 private space, the 100.64/10 carrier-grade
+ * NAT range, and — the one that matters most in a cloud deployment — the
+ * 169.254.0.0/16 link-local block that carries the instance metadata service
+ * at 169.254.169.254. With no NAT the reachable SSRF surface here is intra-VPC
+ * (RDS is what is in there), but "different threat model" is not "no threat".
+ */
+const isDeniedIpv4 = (host: string): boolean => {
+  const parts = host.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map((p) => Number(p));
+  if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) return false;
+  const [a, b] = octets as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8 "this network"
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  return false;
+};
+
+const isDeniedIpv6 = (raw: string): boolean => {
+  // URL hostnames wrap IPv6 in brackets; strip them and any zone id.
+  const host = raw.replace(/^\[/, "").replace(/\]$/, "").split("%")[0]!.toLowerCase();
+  if (host === "::" || host === "::1") return true; // unspecified / loopback
+  if (host.startsWith("fe80")) return true; // link-local
+  if (host.startsWith("fc") || host.startsWith("fd")) return true; // fc00::/7 unique-local
+  // IPv4-mapped addresses. `new URL()` compresses ::ffff:169.254.169.254 to
+  // ::ffff:a9fe:a9fe, so match on the ::ffff: prefix and rebuild the v4 tail
+  // from either dotted-quad or the two hex groups, then reuse the v4 rules.
+  const mapped = host.match(/^::ffff:(.+)$/);
+  if (mapped) {
+    const tail = mapped[1]!;
+    if (tail.includes(".")) {
+      if (isDeniedIpv4(tail)) return true;
+    } else {
+      const groups = tail.split(":");
+      if (groups.length === 2) {
+        const [hi, lo] = groups.map((g) => parseInt(g, 16)) as [number, number];
+        if (Number.isInteger(hi) && Number.isInteger(lo)) {
+          const dotted = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+          if (isDeniedIpv4(dotted)) return true;
+        }
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * True when `host` is a name or address we refuse to point users at.
+ *
+ * `host` is the `hostname` from a parsed `URL`: lower-cased, no port, IPv6 in
+ * brackets. Exported so callers that hold a raw host (not a full URL) can run
+ * the same check.
+ */
+export const isDeniedHost = (host: string): boolean => {
+  const h = host.toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h.includes(":")) return isDeniedIpv6(h);
+  return isDeniedIpv4(h);
+};
+
+/**
+ * The shared schema: an absolute http(s) URL whose host is not private,
+ * loopback or link-local. Use this for every URL field in the contract.
+ *
+ * `z.url({ protocol })` (zod 4) rejects non-http(s) schemes such as
+ * `javascript:`, `data:`, `file:` and `ftp:` before the host check ever runs.
+ */
+export const HttpUrl = z
+  .url({ protocol: /^https?$/, error: "Enter an absolute http(s) URL" })
+  .refine(
+    (value) => {
+      let host: string;
+      try {
+        host = new URL(value).hostname;
+      } catch {
+        return false;
+      }
+      return !isDeniedHost(host);
+    },
+    { error: "That host isn't allowed (private, loopback or link-local address)" },
+  );
+export type HttpUrl = z.infer<typeof HttpUrl>;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -4,6 +4,7 @@
  * change it here — tsc then points at every call site that needs updating,
  * which is the whole reason this package exists.
  */
+export * from "./http-url.js";
 export * from "./link.js";
 export * from "./analytics.js";
 export * from "./workspace.js";

--- a/packages/contract/src/link.ts
+++ b/packages/contract/src/link.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { HttpUrl } from "./http-url.js";
 
 /* ============================================================
    Links, routing rules, and the inputs that create and edit them.
@@ -25,7 +26,7 @@ export const RoutingRule = z.object({
     device: DeviceType.nullable().optional(),
     language: z.string().nullable().optional(),
   }),
-  then: z.string().url(),
+  then: HttpUrl,
   weight: z.number().min(0).max(100).nullable().optional(),
 });
 export type RoutingRule = z.infer<typeof RoutingRule>;
@@ -92,7 +93,8 @@ export const Link = z.object({
     .object({
       title: z.string().nullable().optional(),
       description: z.string().nullable().optional(),
-      image: z.string().nullable().optional(),
+      /** Lands in an og:image; must be a real http(s) URL, never javascript:/data:. */
+      image: HttpUrl.nullable().optional(),
     })
     .nullable()
     .optional(),
@@ -104,7 +106,7 @@ export const Link = z.object({
 export type Link = z.infer<typeof Link>;
 
 export const CreateLinkInput = z.object({
-  destination: z.string().min(1, "Where should this link go?").url("That doesn't look like a URL — include https://"),
+  destination: z.string().min(1, "Where should this link go?").pipe(HttpUrl),
   domain: z.string().min(1),
   slug: z
     .string()
@@ -138,7 +140,8 @@ export const CreateLinkInput = z.object({
     .object({
       title: z.string().optional(),
       description: z.string().optional(),
-      image: z.string().optional(),
+      /** Lands in an og:image; must be a real http(s) URL, never javascript:/data:. */
+      image: HttpUrl.optional(),
     })
     .optional(),
 });

--- a/packages/contract/src/workspace.ts
+++ b/packages/contract/src/workspace.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { HttpUrl } from "./http-url.js";
 import { RedirectType } from "./link.js";
 import { CurrencyCode } from "./analytics.js";
 
@@ -62,8 +63,8 @@ export const AddDomainInput = z.object({
     .string()
     .min(3)
     .regex(/^[a-z0-9.-]+\.[a-z]{2,}$/i, "That doesn't look like a domain name"),
-  rootRedirect: z.string().url().nullable().optional(),
-  notFoundRedirect: z.string().url().nullable().optional(),
+  rootRedirect: HttpUrl.nullable().optional(),
+  notFoundRedirect: HttpUrl.nullable().optional(),
 });
 export type AddDomainInput = z.infer<typeof AddDomainInput>;
 
@@ -141,7 +142,7 @@ export const Webhook = z.object({
 export type Webhook = z.infer<typeof Webhook>;
 
 export const CreateWebhookInput = z.object({
-  endpoint: z.string().url("Webhook endpoints must be absolute https URLs"),
+  endpoint: HttpUrl,
   events: z.array(z.enum(WEBHOOK_EVENTS)).min(1),
 });
 export type CreateWebhookInput = z.infer<typeof CreateWebhookInput>;
@@ -186,7 +187,7 @@ export const UpsertBioPageInput = z.object({
     .array(
       BioBlock.omit({ id: true }).extend({
         id: z.string().optional(),
-        href: z.string().url().optional(),
+        href: HttpUrl.optional(),
       }),
     )
     .default([]),

--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/contract/vitest.config.ts
+++ b/packages/contract/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: { environment: "node", include: ["src/**/*.test.ts"] },
+});

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -24,6 +24,7 @@
     "seed": "tsx scripts/seed.ts",
     "studio": "drizzle-kit studio",
     "import-v1": "tsx scripts/import-v1.ts",
+    "audit-urls": "tsx scripts/audit-urls.ts",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/database/scripts/audit-urls.ts
+++ b/packages/database/scripts/audit-urls.ts
@@ -1,0 +1,98 @@
+import postgres from "postgres";
+import { HttpUrl } from "@snapurl/contract";
+
+/* Issue #280: the contract now rejects javascript:/data:/file: schemes and
+   private / loopback / link-local hosts at every URL-bearing field. Rows that
+   were written before that check exists can still hold such a value and would
+   be emitted as a Location header or rendered as a clickable <a href>.
+
+   This read-only script lists every existing row whose URL would now be
+   rejected, so an operator can see the blast radius before enforcing. It never
+   writes: it is a report, not a migration.
+
+     DATABASE_URL=… pnpm --filter @snapurl/database audit-urls
+
+   Exit code is non-zero when offending rows are found, so it can gate a deploy. */
+
+interface Offender {
+  table: string;
+  column: string;
+  id: string;
+  value: string;
+}
+
+const bad = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0 && !HttpUrl.safeParse(value).success;
+
+async function main() {
+  const url = process.env.DATABASE_URL ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
+  const sql = postgres(url, { max: 1 });
+  const offenders: Offender[] = [];
+
+  try {
+    const links = await sql<{ id: string; destination: string; social: unknown }[]>`
+      SELECT id, destination, social FROM links`;
+    for (const row of links) {
+      if (bad(row.destination)) {
+        offenders.push({ table: "links", column: "destination", id: row.id, value: row.destination });
+      }
+      const image = (row.social as { image?: unknown } | null)?.image;
+      if (bad(image)) {
+        offenders.push({ table: "links", column: "social.image", id: row.id, value: image });
+      }
+    }
+
+    const rules = await sql<{ id: string; then: string }[]>`
+      SELECT id, "then" FROM routing_rules`;
+    for (const row of rules) {
+      if (bad(row.then)) {
+        offenders.push({ table: "routing_rules", column: "then", id: row.id, value: row.then });
+      }
+    }
+
+    const domains = await sql<{ id: string; root_redirect: string | null; not_found_redirect: string | null }[]>`
+      SELECT id, root_redirect, not_found_redirect FROM domains`;
+    for (const row of domains) {
+      if (bad(row.root_redirect)) {
+        offenders.push({ table: "domains", column: "root_redirect", id: row.id, value: row.root_redirect! });
+      }
+      if (bad(row.not_found_redirect)) {
+        offenders.push({ table: "domains", column: "not_found_redirect", id: row.id, value: row.not_found_redirect! });
+      }
+    }
+
+    const webhooks = await sql<{ id: string; endpoint: string }[]>`
+      SELECT id, endpoint FROM webhooks`;
+    for (const row of webhooks) {
+      if (bad(row.endpoint)) {
+        offenders.push({ table: "webhooks", column: "endpoint", id: row.id, value: row.endpoint });
+      }
+    }
+
+    const blocks = await sql<{ id: string; href: string | null }[]>`
+      SELECT id, href FROM bio_blocks`;
+    for (const row of blocks) {
+      if (bad(row.href)) {
+        offenders.push({ table: "bio_blocks", column: "href", id: row.id, value: row.href! });
+      }
+    }
+  } finally {
+    await sql.end();
+  }
+
+  if (offenders.length === 0) {
+    console.log("audit-urls: no rows would be rejected by the new HttpUrl schema.");
+    return;
+  }
+
+  console.error(`audit-urls: ${offenders.length} row(s) hold a URL the contract now rejects:`);
+  for (const o of offenders) {
+    console.error(`  ${o.table}.${o.column} id=${o.id} => ${JSON.stringify(o.value)}`);
+  }
+  process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,9 +180,15 @@ importers:
         specifier: ^4.1.12
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
 
   packages/database:
     dependencies:


### PR DESCRIPTION
Closes #280. Phase 3 of the architecture epic (#267).

## Problem

The contract used bare `z.string().url()`, which only checks that `new URL()` did not throw. That accepts `javascript:alert(1)`, `data:text/html;base64,…`, `file:///etc/passwd`, `http://169.254.169.254/latest/meta-data/…` (cloud metadata) and `http://10.0.0.5/admin`. These values reach a `Location` header from the redirect service and a clickable `<a href>` on the public trust page — phishing / SSRF surface by default.

## Fix

One shared `HttpUrl` schema in `@snapurl/contract` (`packages/contract/src/http-url.ts`), used at **every** URL-bearing input field so a field added later cannot skip the check:

- `z.url({ protocol: /^https?$/ })` base — rejects `javascript:`, `data:`, `file:`, `ftp:`, `ws:`, `mailto:`, `tel:`, protocol-relative `//host`, etc.
- A private / loopback / link-local host denylist applied before insert: `0/8`, `10/8`, `127/8`, `169.254/16` (incl. the `169.254.169.254` metadata endpoint), `172.16/12`, `192.168/16`, `100.64/10` CGNAT, `localhost`/`*.localhost`, and the IPv6 loopback/unspecified/link-local/unique-local ranges plus IPv4-mapped forms.

Applied at all seven sites from the issue: `CreateLinkInput.destination`, `Link`/`CreateLinkInput` `social.image` (previously **no** URL validation at all), `RoutingRule.then`, `AddDomainInput.rootRedirect`/`notFoundRedirect`, `CreateWebhookInput.endpoint`, and the bio-page block `href`.

Read-back schemas (`Link.destination`, `Domain.rootRedirect`, …) stay `z.string()` on purpose so historical rows can still be served; enforcement is on input.

## Done when

- ✅ No URL-bearing input field uses bare `z.string().url()` (verified: no `.url(` calls remain outside the explanatory comment).
- ✅ A test asserts each rejected scheme and each denylisted host range, plus a per-field test that every contract input routes through `HttpUrl` (`packages/contract/src/http-url.test.ts`, 41 cases).
- ✅ Existing rows are auditable: read-only `packages/database/scripts/audit-urls.ts` (`pnpm --filter @snapurl/database audit-urls`) lists every existing row the new schema would reject and exits non-zero so it can gate a deploy. Uses `HttpUrl.safeParse`, so it can never drift from enforcement.

## Verification

- `pnpm build:packages` — clean
- `pnpm -r type-check` — clean across all 8 projects (web, api, redirect, worker included; no downstream breakage from the `HttpUrl` type)
- `pnpm -r test` — all pass (contract 41, domain 122, database 10, api 89, redirect 3, worker 5)