### PR TITLE
Abuse reporting path + honest Report button (#291)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { BioPagesModule } from "./bio-pages/bio-pages.module.js";
 import { PublicModule } from "./public/public.module.js";
 import { HealthController } from "./common/health.controller.js";
 import { FormsModule } from "./forms/forms.module.js";
+import { ReportsModule } from "./reports/reports.module.js";
 import { PostgresErrorFilter } from "./common/postgres-error.filter.js";
 import { ProxyAwareThrottlerGuard } from "./common/proxy-aware-throttler.guard.js";
 
@@ -68,6 +69,7 @@ import { ProxyAwareThrottlerGuard } from "./common/proxy-aware-throttler.guard.j
     DevelopersModule,
     BioPagesModule,
     FormsModule,
+    ReportsModule,
     PublicModule,
   ],
   controllers: [HealthController],

--- a/apps/api/src/public/public.controller.ts
+++ b/apps/api/src/public/public.controller.ts
@@ -1,10 +1,11 @@
 import { Body, Controller, Get, HttpCode, Param, Post, Query } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
-import { SubmitFormInput, UnlockLinkInput } from "@snapurl/contract";
+import { SubmitFormInput, SubmitReportInput, UnlockLinkInput } from "@snapurl/contract";
 import { zodBody } from "../common/zod.pipe.js";
 import { Public } from "../auth/auth.guard.js";
 import { PublicService } from "./public.service.js";
 import { FormsService } from "../forms/forms.service.js";
+import { ReportsService } from "../reports/reports.service.js";
 
 /* Every route here is unauthenticated, and each one says so individually.
    @Public() on the controller would mean one forgotten decorator on a future
@@ -14,6 +15,7 @@ export class PublicController {
   constructor(
     private readonly publicService: PublicService,
     private readonly forms: FormsService,
+    private readonly reports: ReportsService,
   ) {}
 
   @Public()
@@ -73,5 +75,27 @@ export class PublicController {
   @HttpCode(200)
   submit(@Param("slug") slug: string, @Body(zodBody(SubmitFormInput)) input: SubmitFormInput) {
     return this.forms.submit(slug, input);
+  }
+
+  /* Abuse reports (#291). Unauthenticated — the whole point is that a victim
+     who never signed up can flag a phishing link.
+
+     10/min per trustworthy client IP, the same bound as the form submit above
+     and looser than unlock's 5/min. Unlock runs argon2id on every call, so it
+     is a CPU-burn and a password-guessing oracle if left open; a report is a
+     cheap single INSERT with none of that. But it is still an unauthenticated
+     write, so an unlimited path is a spam-and-DB-bloat vector. Ten a minute is
+     far more than any human filing a report and far less than a script is worth
+     writing — a floor, not a substitute for a honeypot if it is ever abused in
+     earnest.
+
+     Always returns { ok:true }; see ReportsService.submitReport for why it must
+     not vary by whether the slug exists. */
+  @Public()
+  @Throttle({ default: { limit: 10, ttl: 60_000 } })
+  @Post("links/:slug/report")
+  @HttpCode(200)
+  report(@Param("slug") slug: string, @Body(zodBody(SubmitReportInput)) input: SubmitReportInput) {
+    return this.reports.submitReport(slug, input);
   }
 }

--- a/apps/api/src/public/public.module.ts
+++ b/apps/api/src/public/public.module.ts
@@ -2,8 +2,14 @@ import { Module } from "@nestjs/common";
 import { PublicController } from "./public.controller.js";
 import { PublicService } from "./public.service.js";
 import { FormsModule } from "../forms/forms.module.js";
+import { ReportsModule } from "../reports/reports.module.js";
 
-/* FormsModule imported rather than the service re-provided, so the public
-   form routes and the dashboard's share one instance and one set of rules. */
-@Module({ imports: [FormsModule], controllers: [PublicController], providers: [PublicService] })
+/* FormsModule and ReportsModule are imported rather than their services
+   re-provided, so the public routes and the dashboard's share one instance and
+   one set of rules. */
+@Module({
+  imports: [FormsModule, ReportsModule],
+  controllers: [PublicController],
+  providers: [PublicService],
+})
 export class PublicModule {}

--- a/apps/api/src/reports/reports.controller.test.ts
+++ b/apps/api/src/reports/reports.controller.test.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { SubmitReportInput } from "@snapurl/contract";
+import { PublicController } from "../public/public.controller.js";
+
+/* The abuse-report intake is an unauthenticated write, so its per-route rate
+   limit is not optional decoration — it is the only thing bounding spam and DB
+   bloat (#291). @nestjs/throttler stores the limit as metadata on the method
+   under 'THROTTLER:LIMIT' + '<name>'. Removing the @Throttle would silently
+   fall back to the global budget; this asserts it is present and bounded. */
+describe("PublicController.report throttle", () => {
+  it("carries a bounded per-minute @Throttle on the report route", () => {
+    const method = PublicController.prototype.report;
+    const limit = Reflect.getMetadata("THROTTLER:LIMIT" + "default", method);
+    const ttl = Reflect.getMetadata("THROTTLER:TTL" + "default", method);
+
+    expect(limit).toBe(10);
+    expect(ttl).toBe(60_000);
+  });
+});
+
+/* A plain validation check so the shared body shape is exercised without a DB. */
+describe("SubmitReportInput at the intake", () => {
+  it("accepts a real report and rejects an empty reason", () => {
+    expect(SubmitReportInput.safeParse({ reason: "This link is a phishing page." }).success).toBe(true);
+    expect(SubmitReportInput.safeParse({ reason: "" }).success).toBe(false);
+  });
+});

--- a/apps/api/src/reports/reports.controller.ts
+++ b/apps/api/src/reports/reports.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Param, Patch } from "@nestjs/common";
+import { UpdateAbuseReportInput } from "@snapurl/contract";
+import { zodBody } from "../common/zod.pipe.js";
+import { Actor, Roles, Scope, type RequestActor } from "../auth/auth.guard.js";
+import { toActor } from "../common/activity.js";
+import { ReportsService } from "./reports.service.js";
+
+/* ============================================================
+   Operator-side abuse-report review — #291 (FEAT-003).
+
+   These routes are AUTHENTICATED and workspace-scoped: an operator sees and
+   acts on reports whose slug resolved to a link in their own workspace. The
+   unauthenticated intake route (@Public) deliberately lives on
+   PublicController, matching the repo convention that every /public route is
+   declared there; this controller carries only the authed surface.
+   ============================================================ */
+@Controller("reports")
+export class ReportsController {
+  constructor(private readonly reports: ReportsService) {}
+
+  @Get()
+  @Scope("links:read")
+  list(@Actor() actor: RequestActor) {
+    return this.reports.list(actor.workspaceId);
+  }
+
+  @Patch(":id")
+  @Roles("editor")
+  @Scope("links:write")
+  update(
+    @Actor() actor: RequestActor,
+    @Param("id") id: string,
+    @Body(zodBody(UpdateAbuseReportInput)) input: UpdateAbuseReportInput,
+  ) {
+    return this.reports.review(actor.workspaceId, id, toActor(actor), input);
+  }
+}

--- a/apps/api/src/reports/reports.module.ts
+++ b/apps/api/src/reports/reports.module.ts
@@ -1,11 +1,14 @@
 import { Module } from "@nestjs/common";
+import { ReportsController } from "./reports.controller.js";
 import { ReportsService } from "./reports.service.js";
 
 /* The unauth intake route lives on PublicController (mirroring the convention
-   that every /public route is declared there), so this module only provides the
-   service and exports it for PublicModule to share one instance. FEAT-003 adds
-   the operator-side controller here. */
+   that every /public route is declared there), so this module provides the
+   service and exports it for PublicModule to share one instance. The
+   operator-side authed surface (FEAT-003) is declared by ReportsController; it
+   flags links via a direct scoped db.update, so no LinksModule import is needed. */
 @Module({
+  controllers: [ReportsController],
   providers: [ReportsService],
   exports: [ReportsService],
 })

--- a/apps/api/src/reports/reports.module.ts
+++ b/apps/api/src/reports/reports.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { ReportsService } from "./reports.service.js";
+
+/* The unauth intake route lives on PublicController (mirroring the convention
+   that every /public route is declared there), so this module only provides the
+   service and exports it for PublicModule to share one instance. FEAT-003 adds
+   the operator-side controller here. */
+@Module({
+  providers: [ReportsService],
+  exports: [ReportsService],
+})
+export class ReportsModule {}

--- a/apps/api/src/reports/reports.service.integration.test.ts
+++ b/apps/api/src/reports/reports.service.integration.test.ts
@@ -86,3 +86,153 @@ describeDb("ReportsService.submitReport", () => {
     expect(withoutContact!.reporterContact).toBeNull();
   });
 });
+
+/* ============================================================
+   ReportsService.list / review — operator side (#291, FEAT-003).
+
+   These prove the invariants only a real DB can: the operator sees only their
+   own workspace's reports (never another workspace's, never a null-workspace
+   one), flagging a link writes the exact 'flagged' value the redirect gate
+   reads, a status-only update leaves the link untouched, and a report in
+   another workspace is NotFound. Test (2) is the one that must fail if the flag
+   write were reverted.
+   ============================================================ */
+import { NotFoundException } from "@nestjs/common";
+import { toActor } from "../common/activity.js";
+
+const reviewer = toActor({ userId: null, label: "operator@test", workspaceId: "", role: "editor", email: "" });
+
+describeDb("ReportsService.list / review", () => {
+  let handle: ReturnType<typeof createDatabase>;
+  let db: Database;
+  let service: ReportsService;
+
+  const stamp = Date.now();
+  let wsA: string;
+  let wsB: string;
+  let linkA: string;
+  let reportOnLinkA: string;
+  let reportOnLinkA2: string;
+  let reportInWsB: string;
+  let reportNullWorkspace: string;
+
+  beforeAll(async () => {
+    handle = createDatabase({ url: DATABASE_URL!, max: 1 });
+    db = handle.db;
+    service = new ReportsService(db);
+
+    // Two independent workspaces, each with a domain and a link.
+    const [a] = await db
+      .insert(workspaces)
+      .values({ name: "ws A", slug: `rev-a-${stamp}` })
+      .returning({ id: workspaces.id });
+    wsA = a!.id;
+    const [b] = await db
+      .insert(workspaces)
+      .values({ name: "ws B", slug: `rev-b-${stamp}` })
+      .returning({ id: workspaces.id });
+    wsB = b!.id;
+
+    const [domA] = await db
+      .insert(domains)
+      .values({ workspaceId: wsA, domain: `rev-a-${stamp}.test` })
+      .returning({ id: domains.id });
+    const [domB] = await db
+      .insert(domains)
+      .values({ workspaceId: wsB, domain: `rev-b-${stamp}.test` })
+      .returning({ id: domains.id });
+
+    const [lA] = await db
+      .insert(links)
+      .values({ workspaceId: wsA, domainId: domA!.id, slug: `rev-a-${stamp}`, destination: "https://example.com/a" })
+      .returning({ id: links.id });
+    linkA = lA!.id;
+    const [lB] = await db
+      .insert(links)
+      .values({ workspaceId: wsB, domainId: domB!.id, slug: `rev-b-${stamp}`, destination: "https://example.com/b" })
+      .returning({ id: links.id });
+
+    // Two reports for workspace A's link, one for B's link, one that never
+    // resolved (null workspace).
+    const [r1] = await db
+      .insert(abuseReports)
+      .values({ slug: `rev-a-${stamp}`, linkId: linkA, workspaceId: wsA, reason: "phishing on A", status: "open" })
+      .returning({ id: abuseReports.id });
+    reportOnLinkA = r1!.id;
+    const [r2] = await db
+      .insert(abuseReports)
+      .values({ slug: `rev-a-${stamp}`, linkId: linkA, workspaceId: wsA, reason: "malware on A", status: "open" })
+      .returning({ id: abuseReports.id });
+    reportOnLinkA2 = r2!.id;
+    const [r3] = await db
+      .insert(abuseReports)
+      .values({ slug: `rev-b-${stamp}`, linkId: lB!.id, workspaceId: wsB, reason: "phishing on B", status: "open" })
+      .returning({ id: abuseReports.id });
+    reportInWsB = r3!.id;
+    const [r4] = await db
+      .insert(abuseReports)
+      .values({ slug: `rev-nowhere-${stamp}`, linkId: null, workspaceId: null, reason: "unresolved", status: "open" })
+      .returning({ id: abuseReports.id });
+    reportNullWorkspace = r4!.id;
+  });
+
+  afterAll(async () => {
+    if (wsA) await db.delete(workspaces).where(eq(workspaces.id, wsA));
+    if (wsB) await db.delete(workspaces).where(eq(workspaces.id, wsB));
+    await db.delete(abuseReports).where(eq(abuseReports.id, reportNullWorkspace));
+    await handle?.close();
+  });
+
+  it("lists only the caller workspace's reports — not another workspace's, not null-workspace ones", async () => {
+    const list = await service.list(wsA);
+    const ids = list.map((r) => r.id);
+    expect(ids).toContain(reportOnLinkA);
+    expect(ids).toContain(reportOnLinkA2);
+    expect(ids).not.toContain(reportInWsB);
+    expect(ids).not.toContain(reportNullWorkspace);
+    // Every returned report genuinely belongs to A.
+    expect(list.every((r) => ids.includes(r.id))).toBe(true);
+    expect(list.length).toBe(2);
+  });
+
+  it("flags the resolved link and marks the report 'actioned' when flagLink is true", async () => {
+    const dto = await service.review(wsA, reportOnLinkA, reviewer, { flagLink: true });
+    expect(dto.status).toBe("actioned");
+
+    // The enforcement invariant: this is the exact value gateFor blocks on. If
+    // the flag write in review() were reverted, this assertion fails.
+    const [row] = await db
+      .select({ status: links.safeBrowsingStatus, checkedAt: links.safeBrowsingCheckedAt })
+      .from(links)
+      .where(eq(links.id, linkA))
+      .limit(1);
+    expect(row!.status).toBe("flagged");
+    expect(row!.checkedAt).not.toBeNull();
+  });
+
+  it("updates status without touching safeBrowsingStatus for a status-only review", async () => {
+    // A second, still-pending link report in workspace A.
+    const before = await db
+      .select({ status: links.safeBrowsingStatus })
+      .from(links)
+      .where(eq(links.id, linkA))
+      .limit(1);
+
+    const dto = await service.review(wsA, reportOnLinkA2, reviewer, { status: "dismissed" });
+    expect(dto.status).toBe("dismissed");
+
+    const after = await db
+      .select({ status: links.safeBrowsingStatus })
+      .from(links)
+      .where(eq(links.id, linkA))
+      .limit(1);
+    // Whatever the link's status was, a status-only review does not change it.
+    expect(after[0]!.status).toBe(before[0]!.status);
+  });
+
+  it("throws NotFound for a report outside the caller's workspace", async () => {
+    await expect(service.review(wsA, reportInWsB, reviewer, { status: "dismissed" })).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+});

--- a/apps/api/src/reports/reports.service.integration.test.ts
+++ b/apps/api/src/reports/reports.service.integration.test.ts
@@ -111,10 +111,15 @@ describeDb("ReportsService.list / review", () => {
   let wsA: string;
   let wsB: string;
   let linkA: string;
+  let linkB: string;
   let reportOnLinkA: string;
   let reportOnLinkA2: string;
   let reportInWsB: string;
   let reportNullWorkspace: string;
+  // A report owned by workspace A whose linkId points at workspace B's link —
+  // as if the link moved workspaces after intake. getOwned finds it under wsA,
+  // but the flag write (scoped to links.workspaceId = wsA) matches zero rows.
+  let reportMovedLink: string;
 
   beforeAll(async () => {
     handle = createDatabase({ url: DATABASE_URL!, max: 1 });
@@ -151,6 +156,7 @@ describeDb("ReportsService.list / review", () => {
       .insert(links)
       .values({ workspaceId: wsB, domainId: domB!.id, slug: `rev-b-${stamp}`, destination: "https://example.com/b" })
       .returning({ id: links.id });
+    linkB = lB!.id;
 
     // Two reports for workspace A's link, one for B's link, one that never
     // resolved (null workspace).
@@ -174,6 +180,14 @@ describeDb("ReportsService.list / review", () => {
       .values({ slug: `rev-nowhere-${stamp}`, linkId: null, workspaceId: null, reason: "unresolved", status: "open" })
       .returning({ id: abuseReports.id });
     reportNullWorkspace = r4!.id;
+
+    // Owned by wsA, but its linkId names wsB's link — a link that moved
+    // workspaces after the report was filed.
+    const [r5] = await db
+      .insert(abuseReports)
+      .values({ slug: `rev-a-${stamp}`, linkId: linkB, workspaceId: wsA, reason: "moved link on A", status: "open" })
+      .returning({ id: abuseReports.id });
+    reportMovedLink = r5!.id;
   });
 
   afterAll(async () => {
@@ -188,11 +202,12 @@ describeDb("ReportsService.list / review", () => {
     const ids = list.map((r) => r.id);
     expect(ids).toContain(reportOnLinkA);
     expect(ids).toContain(reportOnLinkA2);
+    expect(ids).toContain(reportMovedLink);
     expect(ids).not.toContain(reportInWsB);
     expect(ids).not.toContain(reportNullWorkspace);
     // Every returned report genuinely belongs to A.
     expect(list.every((r) => ids.includes(r.id))).toBe(true);
-    expect(list.length).toBe(2);
+    expect(list.length).toBe(3);
   });
 
   it("flags the resolved link and marks the report 'actioned' when flagLink is true", async () => {
@@ -234,5 +249,23 @@ describeDb("ReportsService.list / review", () => {
     await expect(service.review(wsA, reportInWsB, reviewer, { status: "dismissed" })).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+
+  it("does not flag or mark 'actioned' when the link has moved out of the workspace", async () => {
+    // The report is owned by wsA, but its linkId names wsB's link. The flag
+    // UPDATE is scoped to links.workspaceId = wsA, so it matches zero rows. The
+    // report must NOT be marked 'actioned' and wsB's link must NOT be flagged —
+    // otherwise the report claims an enforcement that never happened.
+    const dto = await service.review(wsA, reportMovedLink, reviewer, { flagLink: true });
+    expect(dto.status).not.toBe("actioned");
+    expect(dto.status).toBe("open");
+
+    // wsB's link is untouched: no cross-workspace enforcement leaked through.
+    const [row] = await db
+      .select({ status: links.safeBrowsingStatus })
+      .from(links)
+      .where(eq(links.id, linkB))
+      .limit(1);
+    expect(row!.status).not.toBe("flagged");
   });
 });

--- a/apps/api/src/reports/reports.service.integration.test.ts
+++ b/apps/api/src/reports/reports.service.integration.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { abuseReports, createDatabase, domains, eq, links, workspaces, type Database } from "@snapurl/database";
+import { ReportsService } from "./reports.service.js";
+
+/* ============================================================
+   ReportsService.submitReport against a real Postgres (#291).
+
+   The invariants that only a real DB can prove: a report resolves the slug to
+   its link and workspace when it can, stores null when it cannot, and answers
+   identically either way so the endpoint is not an enumeration oracle.
+
+   Runs only when DATABASE_URL is set — see the note in rollup.test.ts.
+   ============================================================ */
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeDb = DATABASE_URL ? describe : describe.skip;
+
+describeDb("ReportsService.submitReport", () => {
+  let handle: ReturnType<typeof createDatabase>;
+  let db: Database;
+  let service: ReportsService;
+  let workspaceId: string;
+  let linkId: string;
+
+  const stamp = Date.now();
+  const slug = `r${stamp}-real`;
+
+  beforeAll(async () => {
+    handle = createDatabase({ url: DATABASE_URL!, max: 1 });
+    db = handle.db;
+    service = new ReportsService(db);
+
+    const [ws] = await db
+      .insert(workspaces)
+      .values({ name: "reports test", slug: `reports-${stamp}` })
+      .returning({ id: workspaces.id });
+    workspaceId = ws!.id;
+
+    const [dom] = await db
+      .insert(domains)
+      .values({ workspaceId, domain: `reports-${stamp}.test` })
+      .returning({ id: domains.id });
+
+    const [link] = await db
+      .insert(links)
+      .values({ workspaceId, domainId: dom!.id, slug, destination: "https://example.com/phish" })
+      .returning({ id: links.id });
+    linkId = link!.id;
+  });
+
+  afterAll(async () => {
+    if (workspaceId) await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    // The report for the non-existent slug has no workspace to cascade from.
+    await db.delete(abuseReports).where(eq(abuseReports.slug, `${slug}-missing`));
+    await handle?.close();
+  });
+
+  it("resolves the link and workspace for an existing slug", async () => {
+    const result = await service.submitReport(slug, { reason: "This is a phishing page." });
+    expect(result).toEqual({ ok: true });
+
+    const [row] = await db.select().from(abuseReports).where(eq(abuseReports.linkId, linkId)).limit(1);
+    expect(row).toBeDefined();
+    expect(row!.slug).toBe(slug);
+    expect(row!.status).toBe("open");
+    expect(row!.linkId).toBe(linkId);
+    expect(row!.workspaceId).toBe(workspaceId);
+  });
+
+  it("returns ok:true and stores null link/workspace for a non-existent slug (no enumeration)", async () => {
+    const missing = `${slug}-missing`;
+    const result = await service.submitReport(missing, { reason: "Reporting a link that isn't here." });
+    expect(result).toEqual({ ok: true });
+
+    const [row] = await db.select().from(abuseReports).where(eq(abuseReports.slug, missing)).limit(1);
+    expect(row).toBeDefined();
+    expect(row!.linkId).toBeNull();
+    expect(row!.workspaceId).toBeNull();
+  });
+
+  it("stores null when reporterContact is empty or omitted", async () => {
+    await service.submitReport(slug, { reason: "No contact given.", reporterContact: "" });
+    const rows = await db.select().from(abuseReports).where(eq(abuseReports.linkId, linkId));
+    const withoutContact = rows.find((r) => r.reason === "No contact given.");
+    expect(withoutContact).toBeDefined();
+    expect(withoutContact!.reporterContact).toBeNull();
+  });
+});

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -84,6 +84,15 @@ export class ReportsService {
    * When flagLink flips a link and the caller passed no explicit status, the
    * report is defaulted to 'actioned' — flagging a link IS the action, and a
    * report left 'open' after enforcement would misrepresent the queue.
+   *
+   * The recorded outcome (status + audit entry) reflects the ACTUAL result of
+   * the links UPDATE, not the report's intake-time linkId. The flag write is
+   * scoped to links.workspaceId, so a link that has since moved to another
+   * workspace (or been otherwise removed from this one) matches zero rows even
+   * though report.linkId still names it. In that case we do NOT default the
+   * report to 'actioned' and do NOT write a 'link.flagged' audit entry — a
+   * moved/deleted link must never let a report claim an enforcement that did
+   * not occur (review issue #2, #291).
    */
   async review(workspaceId: string, id: string, actor: Actor, input: UpdateAbuseReportInput): Promise<AbuseReport> {
     if (input.status === undefined && input.flagLink === undefined) {
@@ -92,13 +101,31 @@ export class ReportsService {
 
     const report = await this.getOwned(workspaceId, id);
 
-    // Only flag when there is a resolved link in this workspace to flag.
-    const willFlag = input.flagLink === true && report.linkId !== null;
-    // Flagging a link is itself the action, so default to 'actioned' when the
-    // caller did not state a status of their own.
-    const nextStatus = input.status ?? (willFlag ? "actioned" : undefined);
+    // We only attempt to flag when there is a resolved link on the report; but
+    // whether the flag actually took effect is decided by the UPDATE below, not
+    // by the intake-time linkId.
+    const attemptFlag = input.flagLink === true && report.linkId !== null;
 
-    await this.db.transaction(async (tx) => {
+    const flagged = await this.db.transaction(async (tx) => {
+      let didFlag = false;
+
+      if (attemptFlag) {
+        // .returning() yields exactly the rows the UPDATE changed. An empty
+        // array means the link no longer matches (id, workspaceId) — it moved
+        // or is gone — so the flag did NOT take effect.
+        const updated = await tx
+          .update(links)
+          .set({ safeBrowsingStatus: "flagged", safeBrowsingCheckedAt: new Date() })
+          .where(and(eq(links.id, report.linkId!), eq(links.workspaceId, workspaceId)))
+          .returning({ id: links.id });
+        didFlag = updated.length > 0;
+      }
+
+      // Flagging a link is itself the action, so default to 'actioned' when the
+      // caller did not state a status of their own — but only if the flag
+      // actually landed. A no-op flag falls back to the reviewed path (or an
+      // explicit input.status, if the caller gave one).
+      const nextStatus = input.status ?? (didFlag ? "actioned" : undefined);
       if (nextStatus !== undefined) {
         await tx
           .update(abuseReports)
@@ -106,22 +133,19 @@ export class ReportsService {
           .where(and(eq(abuseReports.id, id), eq(abuseReports.workspaceId, workspaceId)));
       }
 
-      if (willFlag) {
-        await tx
-          .update(links)
-          .set({ safeBrowsingStatus: "flagged", safeBrowsingCheckedAt: new Date() })
-          .where(and(eq(links.id, report.linkId!), eq(links.workspaceId, workspaceId)));
-      }
+      return didFlag;
     });
 
-    // Audit after the commit, never inside it (see recordActivity's contract).
+    // The audit reflects what actually happened: a 'link.flagged' entry only
+    // when a link row was truly updated, otherwise the plain reviewed entry.
+    const recordedStatus = input.status ?? (flagged ? "actioned" : report.status);
     await recordActivity(this.db, this.logger, {
       workspaceId,
       actor,
-      auditAction: willFlag ? "link.flagged" : "abuse_report.reviewed",
-      targetType: willFlag ? "link" : "abuse_report",
-      targetId: willFlag ? report.linkId! : id,
-      metadata: { reportId: id, slug: report.slug, status: nextStatus ?? report.status, flagged: willFlag },
+      auditAction: flagged ? "link.flagged" : "abuse_report.reviewed",
+      targetType: flagged ? "link" : "abuse_report",
+      targetId: flagged ? report.linkId! : id,
+      metadata: { reportId: id, slug: report.slug, status: recordedStatus, flagged },
     });
 
     return this.get(workspaceId, id);

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -1,11 +1,15 @@
-import { Inject, Injectable } from "@nestjs/common";
-import { abuseReports, links, sql, type Database } from "@snapurl/database";
-import type { SubmitReportInput, SubmitReportResult } from "@snapurl/contract";
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { abuseReports, and, desc, eq, links, sql, type Database } from "@snapurl/database";
+import type { AbuseReport, SubmitReportInput, SubmitReportResult, UpdateAbuseReportInput } from "@snapurl/contract";
 import { DB } from "../database/database.module.js";
+import { recordActivity, type Actor } from "../common/activity.js";
+
+type AbuseReportRow = typeof abuseReports.$inferSelect;
 
 @Injectable()
 export class ReportsService {
   constructor(@Inject(DB) private readonly db: Database) {}
+  private readonly logger = new Logger(ReportsService.name);
 
   /**
    * Public, unauthenticated intake for abuse reports (#291).
@@ -41,4 +45,112 @@ export class ReportsService {
 
     return { ok: true };
   }
+
+  /* ---------------- operator-side (authed, workspace-scoped) ---------------- */
+
+  /**
+   * List the reports an operator owns (#291, FEAT-003).
+   *
+   * Scoped strictly to reports whose slug resolved to a link in THIS workspace.
+   * Reports with a null workspaceId (an unresolved slug — a typo, or a link
+   * already deleted) are intentionally shown to no workspace here: an
+   * unresolved slug belongs to no one, so no operator owns it. Surfacing those
+   * would leak one workspace's reports to another and has no natural owner to
+   * act on it; a future global/admin view is out of scope for this feature.
+   */
+  async list(workspaceId: string): Promise<AbuseReport[]> {
+    const rows = await this.db
+      .select()
+      .from(abuseReports)
+      .where(eq(abuseReports.workspaceId, workspaceId))
+      .orderBy(desc(abuseReports.createdAt));
+    return rows.map(toDto);
+  }
+
+  /**
+   * Review a report and optionally flag the link behind it (#291, FEAT-003).
+   *
+   * Loads the report scoped by workspaceId (NotFound if missing or owned by
+   * another workspace, mirroring forms.service.get). Then, in a SINGLE
+   * transaction so a report is never marked actioned while its link stayed
+   * unflagged:
+   *   - if `input.status` is set, moves the report to that status;
+   *   - if `input.flagLink` is true AND the report resolved to a link, sets
+   *     links.safeBrowsingStatus = 'flagged' (+ safeBrowsingCheckedAt = now)
+   *     for that link scoped to the workspace. 'flagged' is the exact value the
+   *     redirect gate reads (apps/redirect/src/main.ts gateFor), so this is the
+   *     enforcement path.
+   *
+   * When flagLink flips a link and the caller passed no explicit status, the
+   * report is defaulted to 'actioned' — flagging a link IS the action, and a
+   * report left 'open' after enforcement would misrepresent the queue.
+   */
+  async review(workspaceId: string, id: string, actor: Actor, input: UpdateAbuseReportInput): Promise<AbuseReport> {
+    if (input.status === undefined && input.flagLink === undefined) {
+      throw new BadRequestException("Nothing to update: pass a status, flagLink, or both.");
+    }
+
+    const report = await this.getOwned(workspaceId, id);
+
+    // Only flag when there is a resolved link in this workspace to flag.
+    const willFlag = input.flagLink === true && report.linkId !== null;
+    // Flagging a link is itself the action, so default to 'actioned' when the
+    // caller did not state a status of their own.
+    const nextStatus = input.status ?? (willFlag ? "actioned" : undefined);
+
+    await this.db.transaction(async (tx) => {
+      if (nextStatus !== undefined) {
+        await tx
+          .update(abuseReports)
+          .set({ status: nextStatus, updatedAt: new Date() })
+          .where(and(eq(abuseReports.id, id), eq(abuseReports.workspaceId, workspaceId)));
+      }
+
+      if (willFlag) {
+        await tx
+          .update(links)
+          .set({ safeBrowsingStatus: "flagged", safeBrowsingCheckedAt: new Date() })
+          .where(and(eq(links.id, report.linkId!), eq(links.workspaceId, workspaceId)));
+      }
+    });
+
+    // Audit after the commit, never inside it (see recordActivity's contract).
+    await recordActivity(this.db, this.logger, {
+      workspaceId,
+      actor,
+      auditAction: willFlag ? "link.flagged" : "abuse_report.reviewed",
+      targetType: willFlag ? "link" : "abuse_report",
+      targetId: willFlag ? report.linkId! : id,
+      metadata: { reportId: id, slug: report.slug, status: nextStatus ?? report.status, flagged: willFlag },
+    });
+
+    return this.get(workspaceId, id);
+  }
+
+  private async getOwned(workspaceId: string, id: string): Promise<AbuseReportRow> {
+    const [row] = await this.db
+      .select()
+      .from(abuseReports)
+      .where(and(eq(abuseReports.id, id), eq(abuseReports.workspaceId, workspaceId)))
+      .limit(1);
+    if (!row) throw new NotFoundException("That report doesn't exist, or isn't in this workspace.");
+    return row;
+  }
+
+  private async get(workspaceId: string, id: string): Promise<AbuseReport> {
+    return toDto(await this.getOwned(workspaceId, id));
+  }
+}
+
+function toDto(row: AbuseReportRow): AbuseReport {
+  return {
+    id: row.id,
+    slug: row.slug,
+    reason: row.reason,
+    reporterContact: row.reporterContact,
+    status: row.status as AbuseReport["status"],
+    linkId: row.linkId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
 }

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -1,0 +1,44 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { abuseReports, links, sql, type Database } from "@snapurl/database";
+import type { SubmitReportInput, SubmitReportResult } from "@snapurl/contract";
+import { DB } from "../database/database.module.js";
+
+@Injectable()
+export class ReportsService {
+  constructor(@Inject(DB) private readonly db: Database) {}
+
+  /**
+   * Public, unauthenticated intake for abuse reports (#291).
+   *
+   * The response is { ok: true } UNCONDITIONALLY — it never throws NotFound and
+   * never varies by whether the slug resolves. A victim reporting a phishing
+   * link should not be told "that link doesn't exist"; and just as importantly,
+   * an unauthenticated endpoint that answered differently for a real slug than
+   * for a made-up one would be an enumeration oracle for every short code in
+   * the system. So the raw slug is always stored, and the resolved link and
+   * workspace are best-effort: null when the slug names nothing.
+   */
+  async submitReport(slug: string, input: SubmitReportInput): Promise<SubmitReportResult> {
+    // Best-effort resolution. lower() matching mirrors the preview/unlock path
+    // in public.service.ts — a printed QR read as SNAP.TO/Spring reports the
+    // same link as snap.to/spring.
+    const [link] = await this.db
+      .select({ id: links.id, workspaceId: links.workspaceId })
+      .from(links)
+      .where(sql`lower(${links.slug}) = ${slug.toLowerCase()}`)
+      .limit(1);
+
+    const contact = input.reporterContact?.trim() ? input.reporterContact.trim() : null;
+
+    await this.db.insert(abuseReports).values({
+      slug,
+      linkId: link?.id ?? null,
+      workspaceId: link?.workspaceId ?? null,
+      reason: input.reason,
+      reporterContact: contact,
+      status: "open",
+    });
+
+    return { ok: true };
+  }
+}

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -11,3 +11,4 @@ export * from "./workspace.js";
 export * from "./auth.js";
 export * from "./public.js";
 export * from "./form.js";
+export * from "./report.js";

--- a/packages/contract/src/report.test.ts
+++ b/packages/contract/src/report.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { SubmitReportInput, UpdateAbuseReportInput } from "./report.js";
+
+/* Issue #291: the abuse-report intake is unauthenticated, so the body shape is
+   the only thing standing between a real report and junk. The slug is not in
+   the body — it comes from the route — so these tests only cover reason and
+   reporterContact. */
+
+describe("SubmitReportInput", () => {
+  it("accepts a valid reason", () => {
+    expect(SubmitReportInput.safeParse({ reason: "This is a phishing page." }).success).toBe(true);
+  });
+
+  it("rejects an empty or too-short reason", () => {
+    expect(SubmitReportInput.safeParse({ reason: "" }).success).toBe(false);
+    expect(SubmitReportInput.safeParse({ reason: "ab" }).success).toBe(false);
+  });
+
+  it("accepts a valid reporterContact email", () => {
+    expect(
+      SubmitReportInput.safeParse({ reason: "phishing", reporterContact: "victim@example.com" }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a non-email reporterContact", () => {
+    expect(SubmitReportInput.safeParse({ reason: "phishing", reporterContact: "not-an-email" }).success).toBe(
+      false,
+    );
+  });
+
+  it("allows reporterContact omitted or empty", () => {
+    expect(SubmitReportInput.safeParse({ reason: "phishing" }).success).toBe(true);
+    expect(SubmitReportInput.safeParse({ reason: "phishing", reporterContact: "" }).success).toBe(true);
+  });
+});
+
+describe("UpdateAbuseReportInput", () => {
+  it("accepts a status change", () => {
+    expect(UpdateAbuseReportInput.safeParse({ status: "actioned" }).success).toBe(true);
+  });
+
+  it("accepts a flagLink toggle", () => {
+    expect(UpdateAbuseReportInput.safeParse({ flagLink: true }).success).toBe(true);
+  });
+});

--- a/packages/contract/src/report.ts
+++ b/packages/contract/src/report.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+/* ============================================================
+   Abuse reports — #291.
+
+   The public intake is unauthenticated: anyone can tell an operator that a
+   short link points at phishing or malware. The wire format lives here so the
+   web form and the API validate the exact same shape.
+   ============================================================ */
+
+/* The slug is not in the body — it comes from the route @Param, exactly like
+   the unlock endpoint. A reason has to be non-trivial (a blank box tells the
+   operator nothing) but must not demand an essay; 3 characters is a floor that
+   rejects "" and " " while 2000 is generous enough for a full description. */
+export const SubmitReportInput = z.object({
+  reason: z.string().min(3, "Tell us what's wrong with this link.").max(2000),
+  /* Optional contact so the operator can follow up. Validated as an email when
+     present, but an empty string is allowed and treated as "not provided" —
+     the same forgiving shape CreateFormInput.slug uses. 320 = max email length. */
+  reporterContact: z.string().email().max(320).optional().or(z.literal("")),
+});
+export type SubmitReportInput = z.infer<typeof SubmitReportInput>;
+
+/* A deliberately opaque acknowledgement. The endpoint always answers { ok:true }
+   whether or not the slug resolves, so it cannot be used to enumerate which
+   slugs exist — see the reasoning in ReportsService.submitReport. */
+export const SubmitReportResult = z.object({ ok: z.boolean() });
+export type SubmitReportResult = z.infer<typeof SubmitReportResult>;
+
+/* ---- operator-side shapes (used by FEAT-003) ---- */
+
+export const AbuseReportStatus = z.enum(["open", "reviewed", "dismissed", "actioned"]);
+export type AbuseReportStatus = z.infer<typeof AbuseReportStatus>;
+
+export const AbuseReport = z.object({
+  id: z.string(),
+  slug: z.string(),
+  reason: z.string(),
+  reporterContact: z.string().nullable(),
+  status: AbuseReportStatus,
+  linkId: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type AbuseReport = z.infer<typeof AbuseReport>;
+
+/* An operator can move a report through its status and/or flag the underlying
+   link in a single call. Both fields are optional, but a request with neither
+   is a no-op the service should reject. */
+export const UpdateAbuseReportInput = z.object({
+  status: AbuseReportStatus.optional(),
+  flagLink: z.boolean().optional(),
+});
+export type UpdateAbuseReportInput = z.infer<typeof UpdateAbuseReportInput>;

--- a/packages/database/drizzle/0010_ambitious_talos.sql
+++ b/packages/database/drizzle/0010_ambitious_talos.sql
@@ -1,0 +1,35 @@
+/* ============================================================
+   Abuse reports (#291).
+
+   The only way a victim can tell an operator that a short link points at
+   phishing or malware. The intake is unauthenticated, so the table is
+   deliberately forgiving about what it can resolve.
+
+   `slug` is stored raw and is NOT a foreign key: a report may name a slug that
+   never existed (a typo) or one whose link is already deleted, and losing that
+   report would defeat the endpoint. `link_id` and `workspace_id` are
+   best-effort resolutions kept nullable — set null when the slug names nothing.
+   `link_id` is ON DELETE set null so a report outlives the link it was about;
+   `workspace_id` cascades because a deleted workspace has nobody left to action
+   anything.
+
+   Indexed on status (the operator queue), lower(slug) (grouping reports about
+   the same link), and workspace_id (scoping the operator listing in FEAT-003).
+   ============================================================ */
+CREATE TABLE "abuse_reports" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"slug" varchar(64) NOT NULL,
+	"link_id" uuid,
+	"workspace_id" uuid,
+	"reason" text NOT NULL,
+	"reporter_contact" varchar(320),
+	"status" varchar(20) DEFAULT 'open' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "abuse_reports" ADD CONSTRAINT "abuse_reports_link_id_links_id_fk" FOREIGN KEY ("link_id") REFERENCES "public"."links"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "abuse_reports" ADD CONSTRAINT "abuse_reports_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "abuse_reports_status_idx" ON "abuse_reports" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "abuse_reports_slug_idx" ON "abuse_reports" USING btree (lower("slug"));--> statement-breakpoint
+CREATE INDEX "abuse_reports_workspace_idx" ON "abuse_reports" USING btree ("workspace_id");

--- a/packages/database/drizzle/meta/0010_snapshot.json
+++ b/packages/database/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,3202 @@
+{
+  "id": "de645c6c-161b-4c00-ac10-4376444e17b9",
+  "prevId": "1323a41a-1be9-4db0-a3c6-dd17911ee976",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invite_token_hash": {
+          "name": "invite_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_workspace_email_key": {
+          "name": "memberships_workspace_email_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_identities": {
+      "name": "oauth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_identities_provider_subject_key": {
+          "name": "oauth_identities_provider_subject_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_identities_user_id_users_id_fk": {
+          "name": "oauth_identities_user_id_users_id_fk",
+          "tableFrom": "oauth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recovery_codes": {
+      "name": "recovery_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recovery_codes_user_idx": {
+          "name": "recovery_codes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_user_id_users_id_fk": {
+          "name": "recovery_codes_user_id_users_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_hash_key": {
+          "name": "refresh_tokens_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_family_idx": {
+          "name": "refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled_at": {
+          "name": "totp_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Free'"
+        },
+        "default_domain_id": {
+          "name": "default_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_redirect": {
+          "name": "default_redirect",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "clicks_included": {
+          "name": "clicks_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000000
+        },
+        "retention_years": {
+          "name": "retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cookieless_analytics": {
+          "name": "cookieless_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scan_on_create": {
+          "name": "scan_on_create",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_previews": {
+          "name": "public_previews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_key": {
+          "name": "workspaces_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verifying'"
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ssl_renews_at": {
+          "name": "ssl_renews_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_redirect": {
+          "name": "root_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_redirect": {
+          "name": "not_found_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domains_domain_key": {
+          "name": "domains_domain_key",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domains_workspace_idx": {
+          "name": "domains_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_workspace_id_workspaces_id_fk": {
+          "name": "domains_workspace_id_workspaces_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.link_counters": {
+      "name": "link_counters",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_clicks": {
+          "name": "unique_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "link_counters_link_id_links_id_fk": {
+          "name": "link_counters_link_id_links_id_fk",
+          "tableFrom": "link_counters",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_to": {
+          "name": "expires_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activates_at": {
+          "name": "activates_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_to": {
+          "name": "scheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_limit": {
+          "name": "click_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forward_query": {
+          "name": "forward_query",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_referrer": {
+          "name": "hide_referrer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_preview": {
+          "name": "public_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cloaked": {
+          "name": "cloaked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safe_browsing_status": {
+          "name": "safe_browsing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "safe_browsing_checked_at": {
+          "name": "safe_browsing_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "links_domain_slug_key": {
+          "name": "links_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_created_idx": {
+          "name": "links_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_tags_idx": {
+          "name": "links_workspace_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "links_expires_idx": {
+          "name": "links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_activates_idx": {
+          "name": "links_activates_idx",
+          "columns": [
+            {
+              "expression": "activates_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"activates_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "links_workspace_id_workspaces_id_fk": {
+          "name": "links_workspace_id_workspaces_id_fk",
+          "tableFrom": "links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "links_domain_id_domains_id_fk": {
+          "name": "links_domain_id_domains_id_fk",
+          "tableFrom": "links",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "links_created_by_users_id_fk": {
+          "name": "links_created_by_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projection_outbox": {
+      "name": "projection_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projection_outbox_pending_idx": {
+          "name": "projection_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"projection_outbox\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_rules": {
+      "name": "routing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "when_country": {
+          "name": "when_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_device": {
+          "name": "when_device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_language": {
+          "name": "when_language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "then": {
+          "name": "then",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_rules_link_position_key": {
+          "name": "routing_rules_link_position_key",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_rules_link_id_links_id_fk": {
+          "name": "routing_rules_link_id_links_id_fk",
+          "tableFrom": "routing_rules",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.breakdown_daily": {
+      "name": "breakdown_daily",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "breakdown_daily_key": {
+          "name": "breakdown_daily_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"link_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "breakdown_daily_lookup_idx": {
+          "name": "breakdown_daily_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "breakdown_daily_workspace_id_workspaces_id_fk": {
+          "name": "breakdown_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "breakdown_daily_link_id_links_id_fk": {
+          "name": "breakdown_daily_link_id_links_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily": {
+      "name": "click_daily",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scans": {
+          "name": "scans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "click_daily_workspace_day_idx": {
+          "name": "click_daily_workspace_day_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_daily_link_id_links_id_fk": {
+          "name": "click_daily_link_id_links_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_daily_workspace_id_workspaces_id_fk": {
+          "name": "click_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_link_id_day_pk": {
+          "name": "click_daily_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily_uniques": {
+      "name": "click_daily_uniques",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sketch": {
+          "name": "sketch",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "click_daily_uniques_link_id_links_id_fk": {
+          "name": "click_daily_uniques_link_id_links_id_fk",
+          "tableFrom": "click_daily_uniques",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_uniques_link_id_day_pk": {
+          "name": "click_daily_uniques_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_events": {
+      "name": "click_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_host": {
+          "name": "referrer_host",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_qr": {
+          "name": "is_qr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_rule_id": {
+          "name": "matched_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_up_at": {
+          "name": "rolled_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "click_events_link_time_idx": {
+          "name": "click_events_link_time_idx",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_workspace_time_idx": {
+          "name": "click_events_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_pending_idx": {
+          "name": "click_events_pending_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"click_events\".\"rolled_up_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_events_link_id_links_id_fk": {
+          "name": "click_events_link_id_links_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_events_workspace_id_workspaces_id_fk": {
+          "name": "click_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_events_id_occurred_at_pk": {
+          "name": "click_events_id_occurred_at_pk",
+          "columns": [
+            "id",
+            "occurred_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversions": {
+      "name": "conversions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "value_minor": {
+          "name": "value_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversions_workspace_time_idx": {
+          "name": "conversions_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversions_external_key": {
+          "name": "conversions_external_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversions\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversions_workspace_id_workspaces_id_fk": {
+          "name": "conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversions_link_id_links_id_fk": {
+          "name": "conversions_link_id_links_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_salts": {
+      "name": "daily_salts",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_last4": {
+          "name": "key_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_hash_key": {
+          "name": "api_keys_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_workspace_idx": {
+          "name": "api_keys_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_time_idx": {
+          "name": "audit_log_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_workspace_id_workspaces_id_fk": {
+          "name": "audit_log_workspace_id_workspaces_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_blocks": {
+      "name": "bio_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "bio_page_id": {
+          "name": "bio_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked": {
+          "name": "locked",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::jsonb"
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "bio_blocks_page_position_key": {
+          "name": "bio_blocks_page_position_key",
+          "columns": [
+            {
+              "expression": "bio_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_blocks_bio_page_id_bio_pages_id_fk": {
+          "name": "bio_blocks_bio_page_id_bio_pages_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "bio_pages",
+          "columnsFrom": [
+            "bio_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_blocks_link_id_links_id_fk": {
+          "name": "bio_blocks_link_id_links_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_pages": {
+      "name": "bio_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "profile_name": {
+          "name": "profile_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_bio": {
+          "name": "profile_bio",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bio_pages_domain_slug_key": {
+          "name": "bio_pages_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_pages_workspace_id_workspaces_id_fk": {
+          "name": "bio_pages_workspace_id_workspaces_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_pages_domain_id_domains_id_fk": {
+          "name": "bio_pages_domain_id_domains_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_responses": {
+      "name": "form_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "form_responses_form_idx": {
+          "name": "form_responses_form_idx",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_responses_form_id_forms_id_fk": {
+          "name": "form_responses_form_id_forms_id_fk",
+          "tableFrom": "form_responses",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_responses_workspace_id_workspaces_id_fk": {
+          "name": "form_responses_workspace_id_workspaces_id_fk",
+          "tableFrom": "form_responses",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "response_count": {
+          "name": "response_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forms_slug_key": {
+          "name": "forms_slug_key",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_workspace_id_workspaces_id_fk": {
+          "name": "forms_workspace_id_workspaces_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_webhook_idx": {
+          "name": "webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_workspace_idx": {
+          "name": "webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_workspace_id_workspaces_id_fk": {
+          "name": "webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.abuse_reports": {
+      "name": "abuse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_contact": {
+          "name": "reporter_contact",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abuse_reports_status_idx": {
+          "name": "abuse_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abuse_reports_slug_idx": {
+          "name": "abuse_reports_slug_idx",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abuse_reports_workspace_idx": {
+          "name": "abuse_reports_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "abuse_reports_link_id_links_id_fk": {
+          "name": "abuse_reports_link_id_links_id_fk",
+          "tableFrom": "abuse_reports",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "abuse_reports_workspace_id_workspaces_id_fk": {
+          "name": "abuse_reports_workspace_id_workspaces_id_fk",
+          "tableFrom": "abuse_reports",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1788032631179,
       "tag": "0009_third_kang",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788067972592,
+      "tag": "0010_ambitious_talos",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/abuse.ts
+++ b/packages/database/src/schema/abuse.ts
@@ -1,0 +1,63 @@
+import { index, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { workspaces } from "./identity.js";
+import { links } from "./links.js";
+
+const id = () => uuid("id").primaryKey().default(sql`uuidv7()`);
+
+/* ============================================================
+   Abuse reports — #291.
+
+   The only way a victim can tell the operator that a link is a phishing page.
+   The intake is unauthenticated, so the row is deliberately forgiving about
+   what it can resolve: a report may name a slug that does not exist (a typo, or
+   a link already deleted), and it must survive being filed anyway. That is why
+   `slug` is stored raw and is NOT a foreign key, while `linkId` and
+   `workspaceId` are best-effort resolutions kept nullable.
+
+   FEAT-003 adds the operator-side review/flag surface that reads these rows,
+   scoped by `workspaceId`, and flips links.safeBrowsingStatus to 'flagged'.
+   ============================================================ */
+export const abuseReports = pgTable(
+  "abuse_reports",
+  {
+    id: id(),
+
+    /* The reported slug exactly as it was typed — not a foreign key, because a
+       report may name a slug that does not resolve, and losing that report just
+       because the link is gone would defeat the point of the endpoint. */
+    slug: varchar("slug", { length: 64 }).notNull(),
+
+    /* Best-effort resolution of the slug. Nullable and `set null` on delete so
+       a report outlives the link it was about — the operator still needs to see
+       "someone reported this slug" even after the link is removed. */
+    linkId: uuid("link_id").references(() => links.id, { onDelete: "set null" }),
+
+    /* The owning workspace, resolved at intake, used to scope the operator
+       listing in FEAT-003. Cascades: if the workspace is gone there is nobody
+       left to action the report. */
+    workspaceId: uuid("workspace_id").references(() => workspaces.id, { onDelete: "cascade" }),
+
+    reason: text("reason").notNull(),
+
+    /* Optional — a reporter may want to stay anonymous. 320 is the max length
+       of an email address (64 local + @ + 255 domain). */
+    reporterContact: varchar("reporter_contact", { length: 320 }),
+
+    status: varchar("status", { length: 20 }).notNull().default("open"),
+
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // The operator queue filters on status, and lists per workspace.
+    index("abuse_reports_status_idx").on(t.status),
+    index("abuse_reports_slug_idx").on(sql`lower(${t.slug})`),
+    index("abuse_reports_workspace_idx").on(t.workspaceId),
+  ],
+);
+
+export const abuseReportsRelations = relations(abuseReports, ({ one }) => ({
+  link: one(links, { fields: [abuseReports.linkId], references: [links.id] }),
+  workspace: one(workspaces, { fields: [abuseReports.workspaceId], references: [workspaces.id] }),
+}));

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -2,3 +2,4 @@ export * from "./identity.js";
 export * from "./links.js";
 export * from "./analytics.js";
 export * from "./developers.js";
+export * from "./abuse.js";

--- a/web/src/app/(app)/reports/page.tsx
+++ b/web/src/app/(app)/reports/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { PageHead } from "@/components/app-shell";
+import { Button, Card, Chip, EmptyState, ErrorState, Skeleton, Table, TableWrap, Td, Th } from "@/components/ui";
+import { useReports, useReviewReport } from "@/lib/api/hooks";
+import type { AbuseReportStatus } from "@snapurl/contract";
+import { formatDate } from "@/lib/utils";
+
+/* Operator-side abuse-report queue — #291 (FEAT-003). Lists reports filed
+   against this workspace's links and lets an editor move them through their
+   status or flag the underlying link (which blocks the redirect server-side). */
+
+const TONE: Record<AbuseReportStatus, "good" | "warn" | "default" | "bad"> = {
+  open: "warn",
+  reviewed: "default",
+  dismissed: "default",
+  actioned: "bad",
+};
+
+export default function ReportsPage() {
+  const reports = useReports();
+  const review = useReviewReport();
+
+  if (reports.isError) {
+    return (
+      <Card>
+        <ErrorState message={(reports.error as Error).message} onRetry={() => reports.refetch()} />
+      </Card>
+    );
+  }
+
+  const items = reports.data ?? [];
+
+  return (
+    <>
+      <PageHead
+        title="Abuse reports"
+        sub="Reports filed against links in this workspace. Flagging a link blocks its redirect immediately."
+      />
+
+      {reports.isLoading ? (
+        <Skeleton className="h-[220px]" />
+      ) : items.length === 0 ? (
+        <Card>
+          <EmptyState
+            icon="⚑"
+            title="No reports"
+            body="When someone reports one of this workspace's links from its trust page, it shows up here."
+          />
+        </Card>
+      ) : (
+        <Card>
+          <TableWrap>
+            <Table>
+              <thead>
+                <tr>
+                  <Th>Link</Th>
+                  <Th>Reason</Th>
+                  <Th>Reporter</Th>
+                  <Th>Status</Th>
+                  <Th>Filed</Th>
+                  <Th />
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((r) => (
+                  <tr key={r.id}>
+                    <Td className="font-mono text-[12px] text-accent">/{r.slug}</Td>
+                    <Td className="text-ink max-w-[340px] text-[12.5px]">{r.reason}</Td>
+                    <Td className="text-[12px] text-ink-3">
+                      {r.reporterContact ?? <span className="text-ink-3">anonymous</span>}
+                    </Td>
+                    <Td>
+                      <Chip tone={TONE[r.status]} dot>
+                        {r.status[0]!.toUpperCase() + r.status.slice(1)}
+                      </Chip>
+                    </Td>
+                    <Td className="text-[12px] text-ink-3 whitespace-nowrap">{formatDate(r.createdAt)}</Td>
+                    <Td className="text-right whitespace-nowrap">
+                      <div className="inline-flex gap-1.5">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={review.isPending}
+                          onClick={() => review.mutate({ id: r.id, status: "reviewed" })}
+                        >
+                          Reviewed
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={review.isPending}
+                          onClick={() => review.mutate({ id: r.id, status: "dismissed" })}
+                        >
+                          Dismiss
+                        </Button>
+                        <Button
+                          size="sm"
+                          disabled={review.isPending || r.linkId === null}
+                          title={r.linkId === null ? "This report's slug did not resolve to a link" : undefined}
+                          onClick={() => review.mutate({ id: r.id, flagLink: true })}
+                        >
+                          Flag link
+                        </Button>
+                      </div>
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </TableWrap>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/web/src/app/p/[slug]/page.tsx
+++ b/web/src/app/p/[slug]/page.tsx
@@ -3,7 +3,7 @@
 import { useParams, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { Button, Chip, ErrorState, Field, Input, Skeleton } from "@/components/ui";
-import { useLinkPreview, useUnlockLink } from "@/lib/api/hooks";
+import { useLinkPreview, useReportLink, useUnlockLink } from "@/lib/api/hooks";
 import { formatDate, relativeDate } from "@/lib/utils";
 
 /** shortUrl is "domain/slug" with no scheme; localhost is the dev redirect. */
@@ -25,9 +25,20 @@ export default function LinkPreviewPage() {
   const unlockRequested = useSearchParams().get("unlock") === "1";
   const { data, isLoading, isError, error, refetch } = useLinkPreview(slug);
   const unlock = useUnlockLink(slug);
+  const report = useReportLink(slug);
 
   const [password, setPassword] = useState("");
   const [problem, setProblem] = useState<string | null>(null);
+
+  /* The report form is a disclosure: closed by default so the trust page stays
+     calm, opened by the "Report this link" button. `reported` only flips true
+     after the request resolves — the whole point of #291 is that we never tell
+     a victim their report landed before it actually did. */
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reason, setReason] = useState("Phishing / scam");
+  const [contact, setContact] = useState("");
+  const [reportProblem, setReportProblem] = useState<string | null>(null);
+  const [reported, setReported] = useState(false);
 
   async function submitPassword() {
     if (!password) return;
@@ -38,6 +49,18 @@ export default function LinkPreviewPage() {
       window.location.href = withUnlockKey(data!.shortUrl, unlockToken);
     } catch (err) {
       setProblem((err as Error).message);
+    }
+  }
+
+  async function submitReport() {
+    if (!reason) return;
+    setReportProblem(null);
+    try {
+      await report.mutateAsync({ reason, reporterContact: contact || undefined });
+      // Only now, after the server acknowledged, do we say it was received.
+      setReported(true);
+    } catch (err) {
+      setReportProblem((err as Error).message);
     }
   }
 
@@ -164,7 +187,50 @@ export default function LinkPreviewPage() {
                 })()}{" "}
                 →
               </a>
-              <Button className="justify-center">Report this link</Button>
+              {reported ? (
+                <Chip tone="good" dot>
+                  Report received — thank you
+                </Chip>
+              ) : reportOpen ? (
+                <div className="flex flex-col gap-[9px]">
+                  <Field label="What's wrong with this link?">
+                    <select
+                      value={reason}
+                      onChange={(e) => { setReason(e.target.value); setReportProblem(null); }}
+                      className="w-full px-[11px] py-[9px] rounded-[var(--radius-sm)] bg-surface-2 border border-line-2 text-[13px] text-ink focus:outline-none focus:border-accent focus:bg-surface focus:ring-[3px] focus:ring-accent-wash"
+                    >
+                      <option>Phishing / scam</option>
+                      <option>Malware</option>
+                      <option>Spam</option>
+                      <option>Other</option>
+                    </select>
+                  </Field>
+                  <Field
+                    label="Your email (optional)"
+                    help="Only if you'd like the operator to be able to follow up. We never share it."
+                    error={reportProblem ?? undefined}
+                  >
+                    <Input
+                      type="email"
+                      value={contact}
+                      placeholder="you@example.com"
+                      onChange={(e) => { setContact(e.target.value); setReportProblem(null); }}
+                    />
+                  </Field>
+                  <Button
+                    variant="primary"
+                    className="justify-center w-full"
+                    onClick={submitReport}
+                    disabled={report.isPending || !reason}
+                  >
+                    {report.isPending ? "Reporting…" : "Submit report"}
+                  </Button>
+                </div>
+              ) : (
+                <Button className="justify-center" onClick={() => setReportOpen(true)}>
+                  Report this link
+                </Button>
+              )}
             </div>
           </>
         )}

--- a/web/src/components/app-shell/index.tsx
+++ b/web/src/components/app-shell/index.tsx
@@ -23,6 +23,7 @@ const NAV: { group: string; items: { href: string; label: string; icon: string; 
     group: "Configure",
     items: [
       { href: "/domains", label: "Domains", icon: "◈", count: "domains" },
+      { href: "/reports", label: "Abuse reports", icon: "⚑" },
       { href: "/developers", label: "Developers", icon: "⌘" },
       { href: "/team", label: "Team", icon: "◐", count: "members" },
       { href: "/settings", label: "Settings", icon: "⚙" },

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type {
+  AbuseReport,
   Analytics,
   ApiKey,
   AuditEntry,
@@ -548,6 +549,32 @@ const webhookStore: Webhook[] = [...WEBHOOKS];
 const bioStore: BioPage[] = [...BIO_PAGES];
 const auditStore: AuditEntry[] = [...AUDIT];
 
+/* Two abuse reports for the operator queue (#291). One resolves to a real link
+   in the fixture set so "flag the link" has something to flag; the other is
+   still open. In the real API these are scoped to the caller's workspace. */
+const reportStore: AbuseReport[] = [
+  {
+    id: "rep_phish",
+    slug: "spring-sale",
+    reason: "This link redirects to a fake login page that steals passwords.",
+    reporterContact: "victim@example.com",
+    status: "open",
+    linkId: "lnk_spring",
+    createdAt: daysAgo(1),
+    updatedAt: daysAgo(1),
+  },
+  {
+    id: "rep_spam",
+    slug: "app",
+    reason: "Sends unsolicited bulk traffic to a spam site.",
+    reporterContact: null,
+    status: "reviewed",
+    linkId: "lnk_app",
+    createdAt: daysAgo(4),
+    updatedAt: daysAgo(2),
+  },
+];
+
 const uid = (prefix: string) => `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
 
 /* Only the member actions write audit entries, because only the member actions
@@ -933,6 +960,24 @@ export async function fixtureRequest<T>(
     removeById(bioStore, m(/^\/bio-pages\/([^/]+)$/)![1]);
     data = undefined;
   } else if (m(/^\/bio-pages$/)) data = bioStore;
+  /* ---- abuse reports (operator side, #291) ---- */
+  else if (m(/^\/reports\/([^/]+)$/) && method === "PATCH") {
+    const report = reportStore.find((r) => r.id === m(/^\/reports\/([^/]+)$/)![1]);
+    if (!report) throw new Error(`No fixture report ${path}`);
+    const body = (opts.body as { status?: AbuseReport["status"]; flagLink?: boolean }) ?? {};
+    const willFlag = body.flagLink === true && report.linkId !== null;
+    // Mirrors the service: flagging a link defaults the report to 'actioned'
+    // unless the caller stated a status, and flags the underlying link.
+    report.status = body.status ?? (willFlag ? "actioned" : report.status);
+    report.updatedAt = new Date().toISOString();
+    if (willFlag) {
+      // Flagging pulls the link from circulation; 'archived' is the nearest
+      // fixture-visible equivalent of the server's safeBrowsingStatus='flagged'.
+      const link = findLink(report.linkId!);
+      if (link) link.status = "archived";
+    }
+    data = report;
+  } else if (m(/^\/reports$/)) data = reportStore;
   /* ---- public ---- */
   else if (m(/^\/public\/links\/([^/]+)\/unlock$/)) {
     const password = (opts.body as { password?: string })?.password ?? "";

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -16,6 +16,7 @@ import type {
   MemberRole,
   PublicLinkPreview,
   RecordConversionInput,
+  SubmitReportResult,
   TotpRecoveryCodes,
   TotpSetup,
   UnlockLinkResult,
@@ -939,6 +940,10 @@ export async function fixtureRequest<T>(
     // not the check — the real verification is argon2 on the server.
     if (!password) throw new Error("That password is not right.");
     data = { unlockToken: `unlock.${Math.random().toString(36).slice(2)}`, expiresIn: 300 } satisfies UnlockLinkResult;
+  } else if (m(/^\/public\/links\/([^/]+)\/report$/) && method === "POST") {
+    // The server always acknowledges, whether or not the slug resolves, so
+    // there is nothing to look up — the fixture mirrors that opaque success.
+    data = { ok: true } satisfies SubmitReportResult;
   } else if (m(/^\/public\/links\/([^/]+)\/preview$/)) {
     data = previewFor(m(/^\/public\/links\/([^/]+)\/preview$/)![1]);
   } else throw new Error(`No fixture for ${method} ${path}. Add one in src/lib/api/fixtures.ts.`);

--- a/web/src/lib/api/hooks/index.ts
+++ b/web/src/lib/api/hooks/index.ts
@@ -22,4 +22,5 @@ export * from "./forms";
 export * from "./links";
 export * from "./members";
 export * from "./public";
+export * from "./reports";
 export * from "./workspace";

--- a/web/src/lib/api/hooks/keys.ts
+++ b/web/src/lib/api/hooks/keys.ts
@@ -21,4 +21,5 @@ export const qk = {
   bioPages: ["bio-pages"] as const,
   conversions: (range: string) => ["conversions", range] as const,
   preview: (slug: string) => ["preview", slug] as const,
+  reports: ["reports"] as const,
 };

--- a/web/src/lib/api/hooks/public.ts
+++ b/web/src/lib/api/hooks/public.ts
@@ -1,7 +1,13 @@
 "use client";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { PublicLinkPreview, UnlockLinkResult, type UnlockLinkInput } from "@snapurl/contract";
+import {
+  PublicLinkPreview,
+  SubmitReportResult,
+  UnlockLinkResult,
+  type SubmitReportInput,
+  type UnlockLinkInput,
+} from "@snapurl/contract";
 import { request } from "../client";
 import { qk } from "./keys";
 
@@ -29,5 +35,20 @@ export function useUnlockLink(slug: string) {
   return useMutation({
     mutationFn: (input: UnlockLinkInput) =>
       request(`/public/links/${slug}/unlock`, UnlockLinkResult, { method: "POST", body: input, anonymous: true }),
+  });
+}
+
+/**
+ * Report an abusive link (#291).
+ *
+ * Unauthenticated, like preview and unlock. The server always answers
+ * { ok: true } whether or not the slug resolves, so this cannot be used to
+ * probe which short codes exist. No cache write — a report is a fire-and-forget
+ * write, not page data.
+ */
+export function useReportLink(slug: string) {
+  return useMutation({
+    mutationFn: (input: SubmitReportInput) =>
+      request(`/public/links/${slug}/report`, SubmitReportResult, { method: "POST", body: input, anonymous: true }),
   });
 }

--- a/web/src/lib/api/hooks/reports.ts
+++ b/web/src/lib/api/hooks/reports.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
+import { AbuseReport, type UpdateAbuseReportInput } from "@snapurl/contract";
+import { request } from "../client";
+import { qk } from "./keys";
+
+/* ============================================================
+   Operator-side abuse-report review — #291 (FEAT-003).
+
+   The authed queue an operator uses to see reports filed against their own
+   links and act on them: move a report through its status, and/or flag the
+   underlying link (which sets safeBrowsingStatus='flagged' server-side, the
+   exact value the redirect gate blocks on).
+   ============================================================ */
+
+export function useReports() {
+  return useQuery({ queryKey: qk.reports, queryFn: () => request("/reports", z.array(AbuseReport)) });
+}
+
+export function useReviewReport() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...input }: UpdateAbuseReportInput & { id: string }) =>
+      request(`/reports/${id}`, AbuseReport, { method: "PATCH", body: input }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: qk.reports }),
+  });
+}


### PR DESCRIPTION
Closes #291. Phase 3 of epic #267 (FrontEnd/security release-blocker).

## The problem
There was no report endpoint anywhere in the API, and the public trust page rendered `<Button>Report this link</Button>` with **no onClick** — worse than no button, because it implied a victim's report was received when nothing happened. Under the open-source framing, every operator would inherit a phishing-host default with no way for victims to report.

## What shipped (full-stack)
- **DB:** new `abuse_reports` table (migration **0010**): raw `slug`, nullable `link_id` (FK ON DELETE set null) + `workspace_id` (FK ON DELETE cascade), `reason`, optional `reporter_contact`, `status` (`open|reviewed|dismissed|actioned`, default open), timestamps; indexes on status/lower(slug)/workspace. No drizzle drift.
- **Contract:** `SubmitReportInput` (reason required; optional email contact), `SubmitReportResult`, `AbuseReport` DTO, `AbuseReportStatus`, `UpdateAbuseReportInput`.
- **Unauth intake:** `POST /public/links/:slug/report` — `@Public()` + `@Throttle(10/min)` (via the spoof-resistant `ProxyAwareThrottlerGuard` from #279; looser than unlock's 5/min since no argon2, still bounded against spam). **No-enumeration:** always stores the raw slug, best-effort resolves link/workspace (null if the slug names nothing), and returns `{ok:true}` **unconditionally** — so it can't be a short-code enumeration oracle for a victim.
- **Operator review/flag (authed, workspace-scoped):** `GET /reports` (links:read) lists the caller's reports; `PATCH /reports/:id` (editor + links:write) updates status and/or flags the link. **Flagging reuses the existing gate** — it sets `links.safeBrowsingStatus='flagged'`, the exact value `gateFor` in the redirect already blocks on (→ trust page `?warning=unsafe`). Status + flag are atomic; a report is marked `actioned` and a `link.flagged` audit is written **only if the scoped UPDATE actually matched a row** (so a moved/deleted link can't fake enforcement).
- **Web:** the Report button now opens a small form (reason + optional contact) with **honest states** — 'Reporting…' while pending, and 'Report received' shown **only after the server acknowledges**, with an error state on failure. Plus a minimal operator review queue at `/reports` (mark reviewed/dismiss/flag) and the API hooks + fixtures.

## Done-when
- ✅ Real report endpoint + table (slug, reason, optional contact, timestamp, status).
- ✅ Unauthenticated, per-route rate-limited from the outset.
- ✅ Button wired with an honest confirmation state.
- ✅ Operator review + flag path, reusing the existing `safeBrowsingStatus='flagged'` redirect enforcement.

## How to test
- `corepack pnpm type-check` → pass; `corepack pnpm --filter @snapurl/database generate` → 'No schema changes' (verified). `corepack pnpm build` → pass incl. new `/reports` route.
- `corepack pnpm test`: contract report tests + throttle-metadata test pass; DB-gated `reports.service.integration.test.ts` (insert; identical `{ok:true}` for existing vs non-existent slug; workspace-scoped list; flag sets `safeBrowsingStatus='flagged'`; status-only leaves link untouched; cross-workspace NotFound; moved-link doesn't fake actioned) runs in CI (Postgres 18). The CI `verify`+`integration` jobs also apply migration 0010 via `db:migrate`.

## Follow-ups (non-blocking, from semantic review)
- Reporter-contact PII on *unresolved-slug* reports (null workspace) has no cascade/retention path — I'll open a separate tracking issue for a retention job.
- JWT operators pass the scope gate on role alone (scope enforced only for API keys) — pre-existing repo-wide guard behavior, not introduced here.

Files: DB schema+migration, contract, `apps/api/src/reports/*` + public controller, web trust page + operator page + hooks/fixtures.