### PR TITLE
Introduce configurable NAT egress for the AWS profile (#281)

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -53,8 +53,12 @@ export const EnvSchema = z.object({
   GOOGLE_OAUTH_CLIENT_ID: z.string().optional(),
   APPLE_OAUTH_CLIENT_ID: z.string().optional(),
 
-  /** Local dev writes mail to logs/outbox instead of sending. */
+  /** Local dev writes mail to an outbox dir instead of sending. */
   MAIL_TRANSPORT: z.enum(["outbox", "ses"]).default("outbox"),
+  /** Where the outbox transport writes; defaults to os.tmpdir()/snapurl-outbox
+      so it works on Lambda's read-only FS (only /tmp is writable) and locally.
+      Optional so nothing else changes. */
+  MAIL_OUTBOX_DIR: z.string().optional(),
   MAIL_FROM: z.string().default("SnapURL <no-reply@snapurl.local>"),
 
   THROTTLE_TTL_SECONDS: z.coerce.number().int().default(60),

--- a/apps/api/src/mail/mail.service.test.ts
+++ b/apps/api/src/mail/mail.service.test.ts
@@ -53,17 +53,26 @@ describe("MailService — outbox transport", () => {
     await rm(defaultDir, { recursive: true, force: true });
     cleanup.push(defaultDir);
 
+    /* The old code wrote to process.cwd()/logs/outbox. Snapshot that dir's
+       contents *before* the send so the guard reacts only to what this send
+       writes: a stale logs/outbox left by a previous run of the old code must
+       not cause a spurious pass or fail. We assert on the delta, not on
+       ambient filesystem state. */
+    const cwdOutbox = resolve(process.cwd(), "logs/outbox");
+    const cwdOutboxBefore = existsSync(cwdOutbox) ? await readdir(cwdOutbox) : [];
+
     const svc = new MailService(envStub({ MAIL_OUTBOX_DIR: undefined }));
     await svc.send({ to: "guard@example.com", subject: "Guard", body: "no cwd" });
 
+    // Load-bearing assertion: the message landed in the tmpdir default.
     const files = await readdir(defaultDir);
     expect(files).toHaveLength(1);
     const contents = await readFile(join(defaultDir, files[0]!), "utf8");
     expect(contents).toContain("To: guard@example.com");
 
-    // The old code wrote to process.cwd()/logs/outbox — assert nothing landed there.
-    const cwdOutbox = resolve(process.cwd(), "logs/outbox");
-    expect(existsSync(cwdOutbox)).toBe(false);
+    // Guard: this send must not have written anything to process.cwd()/logs/outbox.
+    const cwdOutboxAfter = existsSync(cwdOutbox) ? await readdir(cwdOutbox) : [];
+    expect(cwdOutboxAfter).toEqual(cwdOutboxBefore);
   });
 });
 

--- a/apps/api/src/mail/mail.service.test.ts
+++ b/apps/api/src/mail/mail.service.test.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Env } from "../config/env.js";
+import { MailService } from "./mail.service.js";
+
+/* The outbox transport used to write to process.cwd()/logs/outbox, which is a
+   read-only path on Lambda (only /tmp is writable), so every invite and reset
+   500'd with EROFS. These assert the fix: writes land in a writable tmp dir by
+   default and can be redirected with MAIL_OUTBOX_DIR. The default-path test is
+   the regression guard — it would fail against the old cwd-based code. */
+
+function envStub(overrides: Partial<Env>): Env {
+  return {
+    MAIL_TRANSPORT: "outbox",
+    WEB_ORIGIN: "http://localhost:3000",
+    ...overrides,
+  } as Env;
+}
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  while (cleanup.length > 0) {
+    const dir = cleanup.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("MailService — outbox transport", () => {
+  it("writes a message file with the To/Subject/body to MAIL_OUTBOX_DIR", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mail-test-"));
+    cleanup.push(dir);
+    const svc = new MailService(envStub({ MAIL_OUTBOX_DIR: dir }));
+
+    await svc.send({ to: "user@example.com", subject: "Hello there", body: "Body content" });
+
+    const files = await readdir(dir);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.endsWith(".txt")).toBe(true);
+
+    const contents = await readFile(join(dir, files[0]!), "utf8");
+    expect(contents).toContain("To: user@example.com");
+    expect(contents).toContain("Subject: Hello there");
+    expect(contents).toContain("Body content");
+  });
+
+  it("defaults to os.tmpdir()/snapurl-outbox, never process.cwd() (EROFS regression guard)", async () => {
+    const defaultDir = resolve(tmpdir(), "snapurl-outbox");
+    // Ensure a clean slate so we only observe files this test writes.
+    await rm(defaultDir, { recursive: true, force: true });
+    cleanup.push(defaultDir);
+
+    const svc = new MailService(envStub({ MAIL_OUTBOX_DIR: undefined }));
+    await svc.send({ to: "guard@example.com", subject: "Guard", body: "no cwd" });
+
+    const files = await readdir(defaultDir);
+    expect(files).toHaveLength(1);
+    const contents = await readFile(join(defaultDir, files[0]!), "utf8");
+    expect(contents).toContain("To: guard@example.com");
+
+    // The old code wrote to process.cwd()/logs/outbox — assert nothing landed there.
+    const cwdOutbox = resolve(process.cwd(), "logs/outbox");
+    expect(existsSync(cwdOutbox)).toBe(false);
+  });
+});
+
+describe("MailService — ses transport", () => {
+  it("does not throw and writes no file when MAIL_TRANSPORT is ses", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "mail-test-ses-"));
+    cleanup.push(dir);
+    const svc = new MailService(envStub({ MAIL_TRANSPORT: "ses", MAIL_OUTBOX_DIR: dir }));
+
+    await expect(svc.send({ to: "ses@example.com", subject: "SES", body: "dropped" })).resolves.toBeUndefined();
+
+    const files = await readdir(dir);
+    expect(files).toHaveLength(0);
+  });
+});

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { ENV, type Env } from "../config/env.js";
 
@@ -7,8 +8,10 @@ import { ENV, type Env } from "../config/env.js";
 
    SES needs a verified domain and a sandbox-exit request, neither of which I
    can do from here. The outbox transport writes each message to
-   logs/outbox/ so invitations and resets are testable end to end without a
-   mail provider. MailerPort is the seam — wiring SES is one adapter. */
+   os.tmpdir()/snapurl-outbox by default (writable on Lambda, whose filesystem
+   is read-only except for /tmp), overridable via MAIL_OUTBOX_DIR, so
+   invitations and resets are testable end to end without a mail provider.
+   MailerPort is the seam — wiring SES is one adapter. */
 
 export interface MailMessage {
   to: string;
@@ -24,7 +27,7 @@ export class MailService {
 
   async send(message: MailMessage): Promise<void> {
     if (this.env.MAIL_TRANSPORT === "outbox") {
-      const dir = resolve(process.cwd(), "logs/outbox");
+      const dir = this.env.MAIL_OUTBOX_DIR ?? resolve(tmpdir(), "snapurl-outbox");
       await mkdir(dir, { recursive: true });
       const file = resolve(dir, `${Date.now()}-${message.to.replace(/[^a-z0-9]/gi, "_")}.txt`);
       await writeFile(file, `To: ${message.to}\nSubject: ${message.subject}\n\n${message.body}\n`, "utf8");

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -213,15 +213,29 @@ An internal transport would be ceremony.
     page, the create drawer and `/p/[slug]` no longer say anything is scanned. Set
     `GOOGLE_SAFE_BROWSING_API_KEY` and the claim can come back, this time truthfully.
 
+    **Egress caveat (see the natStrategy entry in Part 4b).** Even with a key set, Safe Browsing
+    calls Google's API from inside the backend, so it only *functions* when the AWS profile has
+    egress — i.e. `natStrategy != 'none'`. Under the default NAT-instance profile it works; under
+    `natStrategy = 'none'` (the free zero-egress topology) the call cannot leave the VPC, so the
+    feature is non-functional there regardless of the key.
+
 11. **Email is stubbed, and only one message exists.** `MailService.sendInvite` is the only mail
-    the system sends; with `MAIL_TRANSPORT=outbox` (the default) it writes to `logs/outbox/`
-    instead of sending. SES needs a verified domain and a sandbox exit request.
+    the system sends; with `MAIL_TRANSPORT=outbox` (the default) it writes each message to a file
+    instead of sending. The outbox directory defaults to `os.tmpdir()/snapurl-outbox` and is
+    overridable via `MAIL_OUTBOX_DIR`. It used to write to `process.cwd()/logs/outbox`, which
+    threw `EROFS` on Lambda — whose filesystem is read-only except for `/tmp` — so every invite
+    500'd; writing to a writable tmp dir fixes that crash. SES needs a verified domain and a
+    sandbox exit request and remains unwired (the `MAIL_TRANSPORT=ses` branch still logs "not
+    wired yet; message dropped") — future work, out of scope here.
 
     This entry used to say invitations, verification *and* password reset were stubbed. There is
     no verification flow and no password reset flow — not stubbed, absent: no endpoint on
     `AuthController`, no method on `MailService`. A user who forgets their password currently has
     no way back into their account. `MailerPort` was named here as the seam for wiring SES; it
     does not exist either, only a comment mentioning it. The seam is `MailService.send`.
+
+    **Egress caveat.** Once SES is wired, actually delivering mail (like Safe Browsing and
+    webhooks) needs egress, so it only functions when `natStrategy != 'none'`.
 
 12. **No rate limit on the redirect path.** Rate limiting the dashboard API protects the database;
     rate limiting redirects would mean a state lookup on the hot path, and CloudFront already
@@ -308,12 +322,19 @@ someone to distrust both. Analytics now counts the conversions table directly.
 
 ### Config is resolved at deploy time, not at cold start
 
-**The constraint:** the Lambdas sit in isolated subnets with no NAT, because a NAT
-gateway costs more per month than everything else in the stack combined. Nothing in
-there can call the SSM or Secrets Manager API without an interface VPC endpoint, at
-about $7/month each — roughly half the database bill, per endpoint, to move a value
-from one place the account owner can read into another place the account owner can
-read.
+**The constraint (as it originally stood).** The Lambdas sat in isolated subnets with no
+NAT, because a NAT gateway costs more per month than everything else in the stack
+combined. Nothing in there could call the SSM or Secrets Manager API without an
+interface VPC endpoint, at about $7/month each — roughly half the database bill, per
+endpoint, to move a value from one place the account owner can read into another place
+the account owner can read.
+
+**Update:** this rationale no longer strictly holds. `natStrategy` now defaults to a NAT
+instance (see the natStrategy entry below), so the app Lambdas have egress and a runtime
+SSM/Secrets Manager lookup is reachable over the NAT without a dedicated endpoint. That
+makes a runtime lookup a *viable future change* (issue #292) rather than a $7/month
+upgrade. It is deliberately not implemented here — deploy-time resolution stays as-is —
+and under `natStrategy = 'none'` the original no-egress constraint still applies.
 
 **What I did instead:** CloudFormation resolves both stores at deploy time.
 Ordinary config comes from SSM Parameter Store (`/snapurl/<stage>/*`, free at
@@ -326,9 +347,10 @@ same image deployable to any stage.
 **What it costs:** changing a value takes a redeploy rather than taking effect on
 the next cold start. For a signing key that is the right shape anyway — rotating one
 invalidates every token it signed, so it is a deliberate operation. For a log level
-it is mildly annoying. The upgrade path is one interface endpoint and a runtime
-lookup, and the day it becomes worth $7/month is the day someone else has console
-access to this account.
+it is mildly annoying. The upgrade path is a runtime lookup — no longer gated on a
+$7/month interface endpoint now that the default NAT profile gives these Lambdas
+egress (issue #292) — and the day it becomes worth doing is the day someone else has
+console access to this account.
 
 **The one thing this does not do** is hide a value from anyone who can read a
 Lambda's configuration. That was already true of the database password before this
@@ -509,6 +531,52 @@ that holds.
 
 Verified by synthesising twice from clean: three assets, 1.4 MB each, identical
 across runs, and the nested `cdk.out` directories left empty.
+
+### Egress is a property of the AWS profile: `natStrategy`, defaulting to a NAT instance
+
+**Forced by #281 (a #267 release blocker):** the AWS profile set `natGateways: 0` with
+every Lambda in `PRIVATE_ISOLATED` subnets, so nothing in the backend could reach the
+internet. Safe Browsing, customer webhooks, Google OAuth (JWKS) and mail all call out —
+so all four were dead on arrival, while the docs and UI presented Safe Browsing and
+webhooks as working features. That is the contradiction this entry resolves.
+
+**Decision.** Egress is now a configurable property of the stack via a
+`natStrategy: 'gateway' | 'instance' | 'none'` prop, wired from
+`app.node.tryGetContext('natStrategy')` in `bin/snapurl.ts`, **defaulting to
+`'instance'`**: a single t4g.nano NAT *instance* (`ec2.NatProvider.instanceV2`, ~$3/mo)
+rather than a managed NAT gateway. A hobby stack does not need the gateway's per-AZ
+redundancy, and $3/mo is a fraction of the ~$32/mo a gateway costs. RDS always stays in
+`PRIVATE_ISOLATED` (it never egresses); the app Lambdas move to `PRIVATE_WITH_EGRESS`
+when NAT is on.
+
+**NAT over IPv6 egress-only.** An egress-only IGW is free, but this was chosen against:
+arbitrary customer webhook endpoints cannot be relied on to publish `AAAA` records, so
+IPv6-only egress would leave webhook coverage patchy — some customers' endpoints would
+simply be unreachable. This was the decision recorded by epic #267; NAT trades a few
+dollars a month for reaching any IPv4 endpoint a customer configures.
+
+**The three options.**
+
+| `natStrategy` | Cost | What it is | Egress features |
+| --- | --- | --- | --- |
+| `'instance'` (default) | ~$3/mo | t4g.nano NAT instance, single AZ (a deliberate SPOF for a hobby stack) | Function |
+| `'gateway'` | ~$32/mo | Managed NAT gateway, highly available — the one-flag upgrade | Function |
+| `'none'` | $0 | The original zero-egress isolated-only topology, preserved exactly | **Non-functional** |
+
+Under `'none'`, Safe Browsing, webhooks, OAuth (JWKS) and mail delivery are all
+non-functional by design — it preserves the free option for an operator who does not
+need them and accepts that trade knowingly, rather than being surprised by it.
+
+**What this does and does not do.** This makes egress *capability* exist and be
+configurable. Actual end-to-end egress is a deploy-time concern (Phase 7); nothing here
+sends a real webhook or email in this environment. And because the default profile now
+gives the app Lambdas egress, a runtime SSM/Secrets Manager lookup becomes reachable
+without a dedicated interface endpoint — which unblocks, but does not implement, issue
+#292 (see the deploy-time-config entry above).
+
+**Revisit if** the single NAT instance's availability becomes a problem (flip to
+`'gateway'`), or if a deployment genuinely needs none of the egress features and wants
+to save the ~$3/mo (`'none'`).
 
 ---
 

--- a/infra/bin/snapurl.ts
+++ b/infra/bin/snapurl.ts
@@ -22,6 +22,12 @@ new SnapUrlStack(app, "SnapUrl", {
      empty with a CORS error in the console. */
   webOrigin: app.node.tryGetContext("webOrigin"),
   redirectOrigin: app.node.tryGetContext("redirectOrigin"),
+  /* A topology/synth-time choice (it shapes the VPC), not deploy-time config,
+     so it lives here and not in SSM. Defaults to 'instance' (t4g.nano NAT
+     instance, ~$3/mo) inside the stack; override with `-c natStrategy=gateway`
+     (managed NAT, ~$32/mo) or `-c natStrategy=none` (free, no egress). Context
+     is untyped, so the stack validates it and throws on anything else. */
+  natStrategy: app.node.tryGetContext("natStrategy"),
   description: "SnapURL: API, redirect service, worker, and the Postgres they share.",
   tags: {
     Project: "SnapURL",

--- a/infra/lib/config.ts
+++ b/infra/lib/config.ts
@@ -26,15 +26,21 @@ import { Construct } from "constructs";
    contain no configuration at all, so the same image is
    deployable to any stage.
 
-   Why deploy-time and not a runtime lookup: these Lambdas sit in
-   isolated subnets with no NAT (see the VPC in snapurl-stack.ts,
-   where that is worth ~$32/month). Calling the SSM or Secrets
-   Manager API from inside one needs an interface VPC endpoint at
-   ~$7/month each — roughly half the database bill, per endpoint,
-   to move a value from one place the account owner can read to
-   another place the account owner can read. Deploy-time
-   resolution gets the property that matters here (nothing
-   secret in git, nothing secret in the image) for nothing.
+   Why deploy-time and not a runtime lookup: originally the
+   Lambdas sat in isolated subnets with no NAT, so calling the SSM
+   or Secrets Manager API from inside one needed an interface VPC
+   endpoint at ~$7/month each — roughly half the database bill, per
+   endpoint, to move a value from one place the account owner can
+   read to another place the account owner can read. That rationale
+   no longer strictly holds: natStrategy now defaults to a NAT
+   instance (see the VPC in snapurl-stack.ts), so the app Lambdas
+   have egress and a runtime SSM/Secrets Manager lookup is reachable
+   over the NAT without a dedicated endpoint. A runtime lookup is
+   therefore now a viable future change (issue #292); it is not
+   implemented here, and under natStrategy 'none' the old no-egress
+   constraint still applies. Deploy-time resolution stays as-is: it
+   gets the property that matters here (nothing secret in git,
+   nothing secret in the image) for nothing.
 
    What that costs: rotating a value takes a redeploy rather than
    taking effect on the next cold start. For a signing key that

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -32,12 +32,38 @@ import { SnapUrlConfig } from "./config.js";
    would be about $58/month against Lambda's ~$0, and would burn
    the credits in under two months.
 
-   The single most expensive mistake available in this file is a
-   NAT Gateway. It costs ~$32/month before a byte moves — more
-   than everything else combined, including the database — and
-   the standard "put RDS in a private subnet" tutorial creates
-   one without mentioning it. See the VPC below.
+   Egress is the one place where cost and correctness pull
+   against each other. A managed NAT Gateway costs ~$32/month
+   before a byte moves — more than everything else combined,
+   including the database — and the standard "put RDS in a
+   private subnet" tutorial creates one without mentioning it.
+   But the backend genuinely needs the internet: Safe Browsing,
+   customer webhooks, Google OAuth (JWKS) and mail all call out.
+   The `natStrategy` prop reconciles the two; see the VPC below.
    ============================================================ */
+
+/**
+ * How the private subnets reach the internet.
+ *
+ * - `'instance'` (default): a single t4g.nano NAT *instance* via
+ *   `ec2.NatProvider.instanceV2`, ~$3/month. Gives full IPv4 egress so Safe
+ *   Browsing, customer webhooks, Google OAuth (JWKS) and mail actually work.
+ *   Single point of failure (one instance, one AZ) — acceptable for a hobby
+ *   stack, and the reason this is an instance rather than a managed gateway.
+ * - `'gateway'`: a managed NAT gateway, ~$32/month. Same topology as
+ *   `'instance'` but highly available and zero-maintenance — a one-flag
+ *   upgrade when the budget or the traffic justifies it.
+ * - `'none'`: the original free, no-egress topology (natGateways: 0, a single
+ *   isolated subnet group). Safe Browsing, webhooks, OAuth and mail then stay
+ *   non-functional; choosing this is the operator's explicit decision to trade
+ *   those features for $0 of egress cost.
+ *
+ * NAT (instance/gateway) was chosen over an IPv6 egress-only IGW because
+ * arbitrary customer webhook endpoints cannot be relied on to publish AAAA
+ * records, so IPv6-only egress would leave webhook coverage patchy. See the
+ * VPC block below and docs/DECISIONS.md.
+ */
+export type NatStrategy = "gateway" | "instance" | "none";
 
 export interface SnapUrlStackProps extends StackProps {
   /**
@@ -55,6 +81,14 @@ export interface SnapUrlStackProps extends StackProps {
   webOrigin?: string;
   /** Public hostname the redirect service answers on. Same precedence as above. */
   redirectOrigin?: string;
+  /**
+   * How the backend reaches the internet. Defaults to `'instance'` (a
+   * t4g.nano NAT instance, ~$3/month) so Safe Browsing, webhooks, OAuth and
+   * mail work out of the box. `'gateway'` is the one-flag ~$32/month managed
+   * upgrade; `'none'` preserves the original free, no-egress isolated-only
+   * topology at the cost of those features. See {@link NatStrategy}.
+   */
+  natStrategy?: NatStrategy;
 }
 
 export class SnapUrlStack extends Stack {
@@ -65,19 +99,107 @@ export class SnapUrlStack extends Stack {
        Network
        --------------------------------------------------------- */
 
-    const vpc = new ec2.Vpc(this, "Vpc", {
-      maxAzs: 2, // RDS requires a subnet group spanning at least two.
-      /* natGateways: 0 is the most important line in this stack.
-         With no NAT, nothing in a private subnet can reach the internet —
-         which is fine here, because nothing needs to. The Lambdas talk to
-         RDS inside the VPC and to AWS services through VPC endpoints. */
-      natGateways: 0,
-      subnetConfiguration: [
-        { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
-        // ISOLATED, not PRIVATE_WITH_EGRESS: the latter implies a NAT.
-        { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
-      ],
-    });
+    /* How the backend reaches the internet. Default 'instance': a t4g.nano NAT
+       instance (~$3/month) rather than a managed NAT gateway (~$32/month),
+       because a hobby stack does not need the gateway's per-AZ redundancy.
+       'gateway' is the one-flag upgrade to that redundancy; 'none' keeps the
+       original zero-egress topology. See NatStrategy above. A value that is
+       present but not one of the three fails synth loudly here rather than
+       silently defaulting, so a `-c natStrategy=gatway` typo is caught. */
+    const natStrategy: NatStrategy = props.natStrategy ?? "instance";
+    if (!["gateway", "instance", "none"].includes(natStrategy)) {
+      throw new Error(
+        `Invalid natStrategy '${natStrategy as string}'. ` +
+          `Expected one of: 'gateway', 'instance', 'none' (default 'instance').`,
+      );
+    }
+
+    /* Three egress strategies, one VPC shape parameterised by natStrategy:
+
+         'none'      natGateways: 0, no NAT device. PUBLIC + a single isolated
+                     subnet group. Nothing in a private subnet reaches the
+                     internet — the original free topology. Safe Browsing,
+                     webhooks, OAuth and mail stay dead; the operator's choice.
+         'instance'  natGateways: 1 through a t4g.nano NAT *instance*
+                     (NatProvider.instanceV2, ~$3/month). Full IPv4 egress.
+                     Single instance in a single AZ — a single point of
+                     failure, which is why it is an instance and not a gateway;
+                     acceptable for a hobby stack, the default.
+         'gateway'   natGateways: 1 through a managed NAT *gateway*
+                     (~$32/month). Same topology, highly available, no
+                     maintenance — the paid upgrade from 'instance'.
+
+       NAT (either device) over an IPv6 egress-only IGW: arbitrary customer
+       webhook endpoints cannot be relied on to publish AAAA records, so
+       IPv6-only egress would leave webhook coverage patchy. When NAT is on we
+       add a PRIVATE_WITH_EGRESS group ('egress') for the app Lambdas and keep
+       a PRIVATE_ISOLATED group ('isolated') for the DB, which never egresses.
+       The exhaustive switch below leaves no unhandled strategy, so synth is
+       valid by construction for all three values. */
+    const egressAz = ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE4_GRAVITON,
+      ec2.InstanceSize.NANO,
+    );
+    let vpcProps: ec2.VpcProps;
+    switch (natStrategy) {
+      case "none":
+        vpcProps = {
+          maxAzs: 2, // RDS requires a subnet group spanning at least two.
+          natGateways: 0,
+          subnetConfiguration: [
+            { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+            // ISOLATED, not PRIVATE_WITH_EGRESS: the latter implies a NAT.
+            { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+          ],
+        };
+        break;
+      case "instance":
+        vpcProps = {
+          maxAzs: 2,
+          natGateways: 1, // One instance, not one per AZ — the hobby-stack SPOF tradeoff.
+          natGatewayProvider: ec2.NatProvider.instanceV2({ instanceType: egressAz }),
+          subnetConfiguration: [
+            { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+            { name: "egress", subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },
+            { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+          ],
+        };
+        break;
+      case "gateway":
+        vpcProps = {
+          maxAzs: 2,
+          natGateways: 1, // One gateway, not one per AZ — cost over redundancy.
+          // No natGatewayProvider: the default is a managed NAT gateway.
+          subnetConfiguration: [
+            { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+            { name: "egress", subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },
+            { name: "isolated", subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+          ],
+        };
+        break;
+      default: {
+        // Exhaustiveness guard: if NatStrategy gains a member, this is a
+        // compile error rather than a silent no-egress deploy.
+        const unreachable: never = natStrategy;
+        throw new Error(`Unhandled natStrategy: ${String(unreachable)}`);
+      }
+    }
+
+    const vpc = new ec2.Vpc(this, "Vpc", vpcProps);
+
+    /* The DB never needs egress, so it stays in the isolated group in every
+       mode. The app Lambdas take the egress-aware group: PRIVATE_WITH_EGRESS
+       when a NAT device exists, else the isolated group (which is all there is
+       when natStrategy === 'none'). */
+    const databaseSubnets: ec2.SubnetSelection = {
+      subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+    };
+    const appLambdaSubnets: ec2.SubnetSelection = {
+      subnetType:
+        natStrategy === "none"
+          ? ec2.SubnetType.PRIVATE_ISOLATED
+          : ec2.SubnetType.PRIVATE_WITH_EGRESS,
+    };
 
     /* Gateway endpoints are free. Interface endpoints are ~$7/month each, so
        only S3 and DynamoDB get one — the two that happen to be gateways. */
@@ -103,7 +225,8 @@ export class SnapUrlStack extends Stack {
       // Graviton. Same price class as t3.micro and measurably faster.
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO),
       vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      // Always isolated: the database never needs egress, in any natStrategy.
+      vpcSubnets: databaseSubnets,
       securityGroups: [dbSecurityGroup],
       multiAz: false, // Doubles the cost. A hobby project does not need it.
       allocatedStorage: 20,
@@ -130,6 +253,10 @@ export class SnapUrlStack extends Stack {
     const lambdaSecurityGroup = new ec2.SecurityGroup(this, "LambdaSg", {
       vpc,
       description: "SnapURL Lambdas.",
+      /* Outbound-open so the Lambdas can egress on 443 through the NAT device.
+         This path only actually reaches the internet when natStrategy !==
+         'none' (the app Lambdas then sit in PRIVATE_WITH_EGRESS); under 'none'
+         the same rule is harmless because there is no route out. */
       allowAllOutbound: true,
     });
     dbSecurityGroup.addIngressRule(
@@ -201,7 +328,12 @@ export class SnapUrlStack extends Stack {
        ISecurityGroup[], and a readonly tuple will not satisfy it. */
     const vpcSettings = {
       vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED } as ec2.SubnetSelection,
+      /* Egress-aware: PRIVATE_WITH_EGRESS when NAT is on so the API, redirect
+         and worker can call Safe Browsing / webhooks / OAuth / mail; the
+         isolated group under natStrategy === 'none'. Redirect shares this
+         object for RDS access — giving it egress when NAT is on is harmless
+         and consistent, and Phase 7 may rely on it. */
+      vpcSubnets: appLambdaSubnets,
       securityGroups: [lambdaSecurityGroup] as ec2.ISecurityGroup[],
     };
 

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -267,15 +267,20 @@ export class SnapUrlStack extends Stack {
 
     /* The database password ends up in the Lambda environment.
      *
-     * The alternative is reading it from Secrets Manager at cold start, which
-     * needs an interface VPC endpoint because these functions sit in isolated
-     * subnets with no NAT. That endpoint costs ~$7/month -- around 45% of the
-     * database itself -- to hide a password from the only person who can read
-     * a Lambda's configuration in the first place: the account owner.
+     * The alternative is reading it from Secrets Manager at cold start. Under
+     * the old zero-egress topology that required an interface VPC endpoint
+     * (~$7/month) because the functions sat in isolated subnets with no NAT.
+     * With natStrategy defaulting to a NAT instance the app Lambdas now sit in
+     * PRIVATE_WITH_EGRESS subnets (see the VPC block above), so a runtime
+     * Secrets Manager lookup is reachable over the NAT without a dedicated
+     * endpoint — that path is now viable future work (issue #292), not
+     * implemented here.
      *
-     * At this scale that is not a trade worth making. It becomes one the
-     * moment anyone else has console access to this account, and the fix is
-     * one endpoint plus a runtime lookup. */
+     * Either way, deploy-time resolution hides nothing from whoever can read a
+     * Lambda's configuration: the account owner. At this scale that is not a
+     * trade worth making; it becomes one the moment anyone else has console
+     * access to this account. Under natStrategy 'none' the old interface-
+     * endpoint constraint still applies. Behaviour is unchanged here. */
     const databaseUrl = `postgres://snapurl:${database.secret!.secretValueFromJson("password").unsafeUnwrap()}` +
       `@${database.instanceEndpoint.hostname}:${database.instanceEndpoint.port}/snapurl`;
 

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -157,7 +157,21 @@ export class SnapUrlStack extends Stack {
         vpcProps = {
           maxAzs: 2,
           natGateways: 1, // One instance, not one per AZ — the hobby-stack SPOF tradeoff.
-          natGatewayProvider: ec2.NatProvider.instanceV2({ instanceType: egressAz }),
+          natGatewayProvider: ec2.NatProvider.instanceV2({
+            instanceType: egressAz,
+            /* OUTBOUND_ONLY, not the INBOUND_AND_OUTBOUND default: a NAT
+               accepts traffic *from the private subnets* and forwards it out;
+               it must not accept unsolicited inbound from the internet. The
+               default synthesizes a security group that allows all inbound
+               from 0.0.0.0/0 on this public-IP instance (cdk synth W2508),
+               which is unnecessary attack surface. OUTBOUND_ONLY keeps
+               allowAllOutbound (so egress still forwards) and drops the
+               0.0.0.0/0 ingress rule; return traffic for outbound flows is
+               permitted by the SG's stateful behaviour, and the private-subnet
+               default route still points at this instance's ENI, so egress is
+               unaffected. */
+            defaultAllowedTraffic: ec2.NatTrafficDirection.OUTBOUND_ONLY,
+          }),
           subnetConfiguration: [
             { name: "public", subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
             { name: "egress", subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },


### PR DESCRIPTION
Closes #281. Phase 3 of epic #267 (aws/architecture/infra release-blocker).

## The problem (structural)
The AWS profile ran `natGateways: 0` with every Lambda in `PRIVATE_ISOLATED` subnets, so the backend had **no internet route at all** — Safe Browsing, customer webhooks, Google OAuth (JWKS), and mail were dead on arrival. Mail additionally **500'd with EROFS** writing to `process.cwd()/logs/outbox` on Lambda's read-only filesystem.

## The decision (already recorded in epic #267 — not re-litigated)
**NAT, not IPv6.** IPv6-only egress was rejected because arbitrary customer webhook endpoints can't be relied on to publish AAAA records. Implemented as a configurable `natStrategy` prop.

## What changed
- **`natStrategy: 'gateway' | 'instance' | 'none'`** (default `'instance'`), wired via `-c natStrategy=...` in `bin/snapurl.ts`:
  - **`instance`** (default): one **t4g.nano NAT instance** (~$3/mo) via `ec2.NatProvider.instanceV2({ instanceType, defaultAllowedTraffic: OUTBOUND_ONLY })` (the V2 provider; the old `NatProvider.instance` is deprecated/EOL). Single-AZ SPOF documented.
  - **`gateway`**: managed NAT gateway (~$32/mo one-flag upgrade).
  - **`none`**: byte-for-byte the original free zero-egress topology (those four features stay off by the operator's explicit choice).
  - An invalid value throws a clear error; the VPC is built in an exhaustive `switch` with a `never` default guard, so synth is valid by construction in all modes.
- **Subnet topology:** RDS stays `PRIVATE_ISOLATED` in every mode (never needs egress); the API/redirect/worker Lambdas move to `PRIVATE_WITH_EGRESS` when NAT is on, else isolated. DB SG stays `allowAllOutbound:false`; the NAT instance SG is `OUTBOUND_ONLY` (no inbound from 0.0.0.0/0).
- **Mail EROFS fix:** outbox now writes to `os.tmpdir()/snapurl-outbox` (overridable via `MAIL_OUTBOX_DIR`) instead of a read-only cwd — works on Lambda and locally. Regression-guarded unit test asserts it writes under tmpdir and NOT under cwd/logs/outbox. (SES-proper wiring remains out of scope — the 'message dropped' branch is unchanged.)
- **DECISIONS.md reconciled:** A10 (Safe Browsing) and A11 (Email) now carry egress caveats (they FUNCTION only when `natStrategy != 'none'`); a new entry records the natStrategy default + NAT-over-IPv6 rationale + costs + the 'none' escape hatch. The 'config resolved at deploy time' section + `config.ts` comment are annotated to note a runtime SSM/Secrets lookup is now POSSIBLE (unblocks #292) — **but #292 is NOT implemented here**.

## Done-when
- ✅ The backend CAN reach the internet in the AWS profile (via NAT), configurable per operator.
- ✅ Mail no longer crashes on Lambda's read-only FS.
- ✅ DECISIONS.md no longer presents Safe Browsing/webhooks as unconditionally working.

## How to test
- `corepack pnpm type-check` (incl. infra) → pass; `corepack pnpm test` → 282 pass / 51 DB-gated skips, incl. 3 new mail tests (verified).
- **`cdk synth` ran clean in all three modes** in the sandbox: `instance` → NAT-instance SG egress-only, no managed gateway; `gateway` → exactly 1 NatGateway; `none` → 0 NAT devices, original topology; invalid strategy throws. CI re-runs type-check (includes infra).

## Scope
This makes the egress **capability** exist and be configurable. Actual end-to-end egress is Phase-7 deploy-deferred. Runtime-secrets (#292, the next issue) is now unblocked but separate.

Files: `infra/lib/snapurl-stack.ts`, `infra/bin/snapurl.ts`, `infra/lib/config.ts`, `apps/api/src/mail/mail.service.ts` (+test), `apps/api/src/config/env.ts`, `docs/DECISIONS.md`.