### PR TITLE
Serialize package test runs so DB suites don't deadlock in CI (#310)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "pnpm -r build",
     "build:packages": "pnpm --filter \"./packages/*\" build",
     "type-check": "pnpm build:packages && pnpm -r type-check",
-    "test": "pnpm build:packages && pnpm -r test",
+    "test": "pnpm build:packages && pnpm -r --workspace-concurrency=1 test",
     "lint": "pnpm -r lint",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",


### PR DESCRIPTION
Closes #310.

## The problem
The root `test` script runs `pnpm -r test`, which executes each package's tests **concurrently**. In CI all DB-integration suites share one Postgres, so two packages hit it at once:
- **apps/api** — `links`/`reports` integration tests INSERT into `links`/`abuse_reports` (RowShareLock on `click_events` via FKs).
- **apps/worker** — `partitions`/`rollup` tests run `ATTACH`/`DETACH`/`DROP PARTITION` on `click_events` (AccessExclusiveLock).

Run together they **deadlock** (Postgres `40P01`). The failure is non-deterministic and moves between suites run-to-run — the signature of cross-suite lock contention, not a code defect. It has already flaked unrelated PRs (e.g. #309, infra-only).

`apps/worker/vitest.config.ts` already sets `fileParallelism: false` for exactly this reason, but that only serializes files **within** the worker package — api and worker still ran in parallel with each other.

## The fix
One line: `pnpm -r test` → `pnpm -r --workspace-concurrency=1 test`, so package test scripts run one at a time. The full suite is only a few seconds, so the cost is negligible and the entire cross-package deadlock class is removed.

## How to test
- CI `verify` should now be stable across repeated runs (the 'Unit tests' step runs `pnpm test`). This PR's own run exercises it; re-running it should be consistently green.

Discovered while merging #281 (PR #309).