### PR TITLE
Use CloudFront PriceClass 200 so India is served from an Indian edge (#275)

### DIFF
--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -577,8 +577,18 @@ export class SnapUrlStack extends Stack {
       // IP address: the custom origin request policy above forwards CloudFront's
       // CloudFront-Viewer-Country / -City headers, and the viewer-request
       // function supplies x-forwarded-host so the app can resolve the link's
-      // domain. PriceClass 100 keeps egress cheapest.
-      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      // domain.
+      //
+      // PriceClass 200, not 100: India is in Price Class 200, and 100 (US /
+      // Canada / Mexico / Europe / Israel) excludes it. Under 100 an Indian
+      // visitor — the primary audience — routes to a European edge and back to
+      // ap-south-1 for every request, and since the behaviour is
+      // CACHING_DISABLED nothing is absorbed at the edge, so every request pays
+      // both legs (~150-210 ms of p50). 200 adds the Indian (and wider APAC/
+      // South-American) edges; the marginally higher per-GB egress there is
+      // immaterial at the payload size of a 302. (300 — the whole world,
+      // incl. Australia/NZ — buys nothing this audience uses.)
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_200,
       comment: "SnapURL redirect edge",
     });
 


### PR DESCRIPTION
Closes #275. Phase 3 of epic #267 (bug/aws/performance). One line + comment.

## The problem
The redirect distribution used `PriceClass.PRICE_CLASS_100`, which covers US / Canada / Mexico / Europe / Israel — **India is Price Class 200**. So every Indian visitor (the primary audience) routed to a European edge and back to `ap-south-1`, and because the behaviour is `CACHING_DISABLED` nothing is absorbed at the edge — each request paid both legs (~150–210 ms of p50, per the issue).

## The fix
`PRICE_CLASS_100` → `PRICE_CLASS_200` (adds the Indian + wider APAC/South-American edges). The marginally higher per-GB egress in India is immaterial at the payload size of a 302. Comment updated to explain the choice (and why 300 buys nothing this audience uses).

## Done when
- ✅ (in code) the distribution serves Indian viewers from an Indian edge.
- The measured p50 improvement is a Phase-7-deploy observation to record in the epic once deployed.

## Test
`corepack pnpm type-check` (incl. infra) → pass (verified). CI re-runs type-check.

Files: `infra/lib/snapurl-stack.ts`.