### PR TITLE
Resolve DB and JWT secrets at runtime instead of baking them into the template (#292)

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -13,6 +13,22 @@ export const EnvSchema = z.object({
   /** Optional read-replica connection string. Absent means reads use the
       primary — single-node behaviour is unchanged. */
   DATABASE_REPLICA_URL: z.string().optional(),
+
+  /* Runtime secret resolution (see packages/database/src/secrets.ts). When
+     these ARNs are set, main() resolves the values from Secrets Manager at
+     cold start and assigns them onto DATABASE_URL / JWT_ACCESS_SECRET /
+     JWT_REFRESH_SECRET before this schema runs — so by the time we parse, the
+     resolved secrets are already present and validate under the rules below.
+     They are optional passthroughs: absent on every non-AWS profile (local
+     dev, compose, single-node, Kubernetes), which keeps the escape hatch
+     byte-identical. DATABASE_HOST/PORT/NAME fill any fields a password-only
+     rotation secret omits when assembling the URL. */
+  DATABASE_SECRET_ARN: z.string().optional(),
+  JWT_ACCESS_SECRET_ARN: z.string().optional(),
+  JWT_REFRESH_SECRET_ARN: z.string().optional(),
+  DATABASE_HOST: z.string().optional(),
+  DATABASE_PORT: z.string().optional(),
+  DATABASE_NAME: z.string().optional(),
   DATABASE_SSL: z
     .string()
     .default("false")

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,10 +3,26 @@ import { NestFactory } from "@nestjs/core";
 import { FastifyAdapter, type NestFastifyApplication } from "@nestjs/platform-fastify";
 import { Logger } from "nestjs-pino";
 import cors from "@fastify/cors";
+import { resolveSecrets } from "@snapurl/database";
 import { AppModule } from "./app.module.js";
 import { ENV, type Env } from "./config/env.js";
 
+/* Resolve the database and JWT secrets from Secrets Manager (see
+   packages/database/src/secrets.ts) and assign them onto process.env BEFORE the
+   ConfigModule's useFactory runs loadEnv(). When no *_SECRET_ARN env var is set
+   this makes no SDK call and touches nothing, so the plain-env path (local dev,
+   compose, single-node, Kubernetes) is byte-identical. Nothing in the API reads
+   these vars at import time, so running this first is safe. */
+async function hydrateSecretsIntoEnv(): Promise<void> {
+  const { databaseUrl, jwtAccessSecret, jwtRefreshSecret } = await resolveSecrets();
+  if (databaseUrl !== undefined) process.env.DATABASE_URL = databaseUrl;
+  if (jwtAccessSecret !== undefined) process.env.JWT_ACCESS_SECRET = jwtAccessSecret;
+  if (jwtRefreshSecret !== undefined) process.env.JWT_REFRESH_SECRET = jwtRefreshSecret;
+}
+
 async function bootstrap() {
+  await hydrateSecretsIntoEnv();
+
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
     /* Do NOT trust any proxy for Fastify's req.ip: `trustProxy: true` would

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -1,6 +1,6 @@
 import Fastify from "fastify";
 import jwt from "jsonwebtoken";
-import { createDatabase } from "@snapurl/database";
+import { createDatabase, resolveDatabaseUrl, resolveJwtSecret } from "@snapurl/database";
 import {
   REDIRECT_STATUS,
   buildDeepLink,
@@ -35,9 +35,18 @@ import { DailySaltCache } from "./salt.js";
    ============================================================ */
 
 const PORT = Number(process.env.PORT ?? 3002);
-const DATABASE_URL = process.env.DATABASE_URL ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
-const JWT_SECRET = process.env.JWT_ACCESS_SECRET ?? "";
 const WEB_ORIGIN = process.env.WEB_ORIGIN ?? "http://localhost:3000";
+
+/* DATABASE_URL and the JWT signing key used to be read at module top. They are
+   now resolved inside init() (called at the start of main()) so that, when a
+   *_SECRET_ARN env var is set, the values come from Secrets Manager at cold
+   start before the connection is opened or a token is verified. With no ARN
+   set, resolveDatabaseUrl / resolveJwtSecret return the plain env values (or
+   the compose defaults below) and make no SDK call, so the plain-env path is
+   unchanged. Building `db` lazily also keeps module import side-effect free:
+   nothing connects to Postgres just by importing this file, which matters for
+   the tests that import from ./resolver.js. */
+const JWT_SECRET_DEFAULT = process.env.JWT_ACCESS_SECRET ?? "";
 
 /* Five is right for a long-running process serving many requests at once. It
    is wrong on Lambda, where each instance handles one request at a time and
@@ -63,18 +72,35 @@ const app = Fastify({ logger: { level: process.env.LOG_LEVEL ?? "info" }, trustP
    readDb) everywhere: the click-limit gate reads a link's click count and then
    records a click, so it is a read-then-write path. Serving that read from a
    replica would let lag hand back a stale count and overshoot the hard cap. */
-const { db, close } = createDatabase({
-  url: DATABASE_URL,
-  replicaUrl: process.env.DATABASE_REPLICA_URL,
-  ssl: process.env.DATABASE_SSL === "true",
-  sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
-  sslCaCert: process.env.DATABASE_CA_CERT,
-  max: POOL_MAX,
-});
+/* Assigned by init() before app.listen(), and used only from inside request
+   handlers (which cannot fire before the server is listening). Kept as
+   module-level bindings so the handlers below can close over them. */
+let close: () => Promise<void> = async () => {};
+let resolver: LinkResolver;
+let clicks: ClickSink;
+let salts: DailySaltCache;
+let JWT_SECRET = JWT_SECRET_DEFAULT;
 
-const resolver: LinkResolver = new PostgresLinkResolver(db);
-const clicks: ClickSink = new PostgresClickSink(db);
-const salts = new DailySaltCache(db);
+/** Resolve secrets, open the connection and wire up the adapters. Called once
+ *  at the start of main(), before the server starts accepting requests. */
+async function init(): Promise<void> {
+  const url =
+    (await resolveDatabaseUrl()) ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
+  JWT_SECRET = (await resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET")) ?? "";
+
+  const database = createDatabase({
+    url,
+    replicaUrl: process.env.DATABASE_REPLICA_URL,
+    ssl: process.env.DATABASE_SSL === "true",
+    sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
+    sslCaCert: process.env.DATABASE_CA_CERT,
+    max: POOL_MAX,
+  });
+  close = database.close;
+  resolver = new PostgresLinkResolver(database.db);
+  clicks = new PostgresClickSink(database.db);
+  salts = new DailySaltCache(database.db);
+}
 
 app.get("/health", async () => ({ status: "ok" }));
 
@@ -290,6 +316,7 @@ async function record(
 }
 
 async function main() {
+  await init();
   if (!JWT_SECRET) {
     app.log.warn("JWT_ACCESS_SECRET is not set — password-protected links cannot be unlocked.");
   }

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -1,5 +1,5 @@
-import { runMigrations } from "@snapurl/database";
-import { db, runFrequent, runMaintenance } from "./main.js";
+import { resolveDatabaseUrl, runMigrations } from "@snapurl/database";
+import { initDb, runFrequent, runMaintenance } from "./main.js";
 
 /* The worker as a Lambda, with two jobs.
  *
@@ -23,16 +23,24 @@ export interface WorkerEvent {
 
 export const handler = async (event: WorkerEvent = {}) => {
   if (event.task === "migrate") {
-    const url = process.env.DATABASE_URL;
+    /* Resolve via the shared resolver so migrations work under the ARN path
+       too: with DATABASE_SECRET_ARN set this fetches the credentials from
+       Secrets Manager; with no ARN it returns process.env.DATABASE_URL
+       unchanged and makes no SDK call. The throw stays for the case where
+       neither an ARN nor a plain URL yields a value. */
+    const url = await resolveDatabaseUrl();
     if (!url) throw new Error("DATABASE_URL is not set on this function.");
     const result = await runMigrations(url, process.env.DATABASE_SSL === "true");
     return { task: "migrate", ...result };
   }
 
-  /* `db` is module-level on purpose. Lambda reuses a warm container across
+  /* The db handle is created once by initDb() and memoised for the lifetime of
+     the execution environment. Lambda reuses a warm container across
      invocations, so the connection survives between runs rather than being
-     rebuilt every minute. It is deliberately not closed at the end of a call:
-     closing it would make the next warm invocation reconnect for nothing. */
+     rebuilt every minute, and it is deliberately never closed at the end of a
+     call. initDb() also resolves the secret at cold start before the first
+     connection is made. */
+  const { db } = await initDb();
   const frequent = await runFrequent(db);
   const maintenance = await runMaintenance(db);
   return { task: "rollup", frequent, maintenance };

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,5 +1,5 @@
 import pino from "pino";
-import { createDatabase, type Database } from "@snapurl/database";
+import { createDatabase, resolveDatabaseUrl, type Database } from "@snapurl/database";
 import { ensureClickPartitions, pruneRetention, rollupClicks, rotateSalts } from "./jobs/rollup.js";
 import { NoProjection, drainOutbox, pruneOutbox, stuckProjections, sweepExpired } from "./jobs/outbox.js";
 import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
@@ -14,7 +14,6 @@ import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
    ============================================================ */
 
 const log = pino({ level: process.env.LOG_LEVEL ?? "info" });
-const DATABASE_URL = process.env.DATABASE_URL ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
 const ROLLUP_SECONDS = Number(process.env.ROLLUP_INTERVAL_SECONDS ?? 30);
 const MAINTENANCE_SECONDS = Number(process.env.MAINTENANCE_INTERVAL_SECONDS ?? 3600);
 
@@ -27,15 +26,52 @@ const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 4);
    click_events then mark them consumed, retention prunes what it has just
    counted, and so on — every worker read is part of a read-then-write logical
    operation. Reading those from a lagging replica would double-count or skip
-   rows, so there is no readDb here on purpose. */
-export const { db, close } = createDatabase({
-  url: DATABASE_URL,
-  replicaUrl: process.env.DATABASE_REPLICA_URL,
-  ssl: process.env.DATABASE_SSL === "true",
-  sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
-  sslCaCert: process.env.DATABASE_CA_CERT,
-  max: POOL_MAX,
-});
+   rows, so there is no readDb here on purpose.
+
+   The connection used to be created at import. It is now deferred behind
+   initDb() so that, when DATABASE_SECRET_ARN is set, the credentials are
+   resolved from Secrets Manager at cold start BEFORE any connection is made.
+   With no ARN set, resolveDatabaseUrl returns the plain env value (or the
+   compose default below) and no SDK call happens — the plain-env path is
+   unchanged. The handle is memoised: created once and reused across warm Lambda
+   invocations, never closed between calls. */
+let dbHandle: { db: Database; close: () => Promise<void> } | undefined;
+let initPromise: Promise<{ db: Database; close: () => Promise<void> }> | undefined;
+
+/** Resolve secrets and create the database connection once, reusing it across
+ *  warm invocations. Concurrent callers share the same in-flight promise. */
+export function initDb(): Promise<{ db: Database; close: () => Promise<void> }> {
+  if (dbHandle) return Promise.resolve(dbHandle);
+  if (!initPromise) {
+    initPromise = (async () => {
+      const url =
+        (await resolveDatabaseUrl()) ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
+      const handle = createDatabase({
+        url,
+        replicaUrl: process.env.DATABASE_REPLICA_URL,
+        ssl: process.env.DATABASE_SSL === "true",
+        sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
+        sslCaCert: process.env.DATABASE_CA_CERT,
+        max: POOL_MAX,
+      });
+      dbHandle = handle;
+      return handle;
+    })();
+  }
+  return initPromise;
+}
+
+/** The resolved database handle. Throws if accessed before initDb() resolves. */
+export function getDb(): Database {
+  if (!dbHandle) throw new Error("initDb() must be awaited before getDb().");
+  return dbHandle.db;
+}
+
+/** Close the connection if one was opened. Safe to call when none was. */
+export async function close(): Promise<void> {
+  if (dbHandle) await dbHandle.close();
+}
+
 const projection = new NoProjection();
 
 /** Runs often: this is the loop that makes the dashboards current. */
@@ -132,6 +168,8 @@ function everyN(seconds: number, job: () => Promise<unknown>) {
 }
 
 async function main() {
+  const { db } = await initDb();
+
   if (process.argv.includes("--once")) {
     const frequent = await runFrequent(db);
     const maintenance = await runMaintenance(db);

--- a/infra/lib/config.ts
+++ b/infra/lib/config.ts
@@ -20,33 +20,56 @@ import { Construct } from "constructs";
    that no human ever chooses them and no value is ever typed
    into this repository.
 
-   Both are read at *deploy* time, by CloudFormation, and land in
-   the Lambda's environment. Neither is baked into a container
-   image: the images are built from the repository alone and
-   contain no configuration at all, so the same image is
-   deployable to any stage.
+   Neither is baked into a container image: the images are built
+   from the repository alone and contain no configuration at all,
+   so the same image is deployable to any stage.
 
-   Why deploy-time and not a runtime lookup: originally the
-   Lambdas sat in isolated subnets with no NAT, so calling the SSM
-   or Secrets Manager API from inside one needed an interface VPC
-   endpoint at ~$7/month each — roughly half the database bill, per
-   endpoint, to move a value from one place the account owner can
-   read to another place the account owner can read. That rationale
-   no longer strictly holds: natStrategy now defaults to a NAT
-   instance (see the VPC in snapurl-stack.ts), so the app Lambdas
-   have egress and a runtime SSM/Secrets Manager lookup is reachable
-   over the NAT without a dedicated endpoint. A runtime lookup is
-   therefore now a viable future change (issue #292); it is not
-   implemented here, and under natStrategy 'none' the old no-egress
-   constraint still applies. Deploy-time resolution stays as-is: it
-   gets the property that matters here (nothing secret in git,
-   nothing secret in the image) for nothing.
+   Config (SSM) vs secrets (Secrets Manager), resolved differently:
 
-   What that costs: rotating a value takes a redeploy rather than
-   taking effect on the next cold start. For a signing key that
-   is the right shape anyway — rotating one invalidates every
-   token in flight, so it is a deliberate operation, not a
-   background one.
+   Ordinary config is read at *deploy* time, by CloudFormation,
+   and lands in the Lambda's environment as-is. Reading it is
+   harmless, so there is no reason to defer it.
+
+   The two JWT signing keys and the database password are handled
+   by issue #292, now IMPLEMENTED. Originally they too were read
+   at deploy time via `unsafeUnwrap()`, which writes their
+   plaintext into the synthesized CloudFormation template — copies
+   of every secret in the CDK assets bucket and in CloudFormation's
+   stack history, not just in the Lambda environment. The reason
+   given for accepting that was cost: the app Lambdas sat in
+   isolated subnets with no NAT, so a runtime Secrets Manager
+   lookup needed an interface VPC endpoint at ~$7/month, and the
+   only reader of a Lambda's configuration was the account owner.
+
+   Both halves of that trade changed. natStrategy now defaults to a
+   NAT instance (see snapurl-stack.ts), so the app Lambdas have
+   egress and reach Secrets Manager at runtime with no dedicated
+   endpoint — the $7/month is gone. And under the open-source
+   framing every operator is a different account with its own IAM
+   discipline, so "the account owner is the only reader" is not an
+   assumption to make on their behalf. So on the egress profiles
+   ('instance'/'gateway') the stack now passes Secrets Manager
+   *ARNs* into the environment and each function resolves the
+   secret(s) it needs at cold start, caching the result for the
+   life of the execution environment (a warm invocation pays
+   nothing). Per-function IAM grants restrict each function to only
+   the secrets it reads. No `unsafeUnwrap()` runs on these paths,
+   so no secret value reaches the template.
+
+   Two escape hatches keep the other profiles working. natStrategy
+   'none' is isolated with no egress, so a runtime lookup would
+   hang; there the deploy-time `unsafeUnwrap()` is preserved and the
+   plaintext-in-template tradeoff is accepted for that zero-cost
+   choice. And the single-node / Kubernetes profiles have no Secrets
+   Manager at all: the app-side resolver falls back to a plain
+   DATABASE_URL / JWT_* env var whenever the matching *_SECRET_ARN
+   is absent.
+
+   What deploy-time resolution costs, on the profiles that still use
+   it: rotating a value takes a redeploy rather than taking effect
+   on the next cold start. For a signing key that is the right shape
+   anyway — rotating one invalidates every token in flight, so it is
+   a deliberate operation, not a background one.
    ============================================================ */
 
 /** Parameters the stack reads. The names are the suffix under `prefix`. */

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -3,6 +3,7 @@ import {
   Duration,
   RemovalPolicy,
   Stack,
+  Token,
   type StackProps,
 } from "aws-cdk-lib";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
@@ -292,24 +293,50 @@ export class SnapUrlStack extends Stack {
       "Postgres from the SnapURL Lambdas only",
     );
 
-    /* The database password ends up in the Lambda environment.
+    /* How the database password and JWT signing keys reach the functions —
+     * and this is where issue #292 lands.
      *
-     * The alternative is reading it from Secrets Manager at cold start. Under
-     * the old zero-egress topology that required an interface VPC endpoint
-     * (~$7/month) because the functions sat in isolated subnets with no NAT.
-     * With natStrategy defaulting to a NAT instance the app Lambdas now sit in
-     * PRIVATE_WITH_EGRESS subnets (see the VPC block above), so a runtime
-     * Secrets Manager lookup is reachable over the NAT without a dedicated
-     * endpoint — that path is now viable future work (issue #292), not
-     * implemented here.
+     * The problem the old approach had was not really the Lambda environment
+     * variable (only the account owner reads that); it was `unsafeUnwrap()`.
+     * Unwrapping a secret at synth time writes its plaintext into the
+     * synthesized CloudFormation template, which is uploaded to the CDK assets
+     * bucket and kept in CloudFormation's own stack history — copies of the
+     * password and both signing keys in two more places, neither of them
+     * obvious. Under the open-source framing every operator is a different
+     * account with its own IAM discipline, so "the account owner is the only
+     * reader" is no longer an assumption to make on their behalf.
      *
-     * Either way, deploy-time resolution hides nothing from whoever can read a
-     * Lambda's configuration: the account owner. At this scale that is not a
-     * trade worth making; it becomes one the moment anyone else has console
-     * access to this account. Under natStrategy 'none' the old interface-
-     * endpoint constraint still applies. Behaviour is unchanged here. */
-    const databaseUrl = `postgres://snapurl:${database.secret!.secretValueFromJson("password").unsafeUnwrap()}` +
-      `@${database.instanceEndpoint.hostname}:${database.instanceEndpoint.port}/snapurl`;
+     * The fix, now that natStrategy defaults to a NAT instance and the app
+     * Lambdas sit in PRIVATE_WITH_EGRESS (see the VPC block above): pass the
+     * Secrets Manager *ARNs* as environment, not the values, and let each
+     * function resolve them at cold start over the NAT (the shared resolver in
+     * @snapurl/database caches the result for the life of the execution
+     * environment, so a warm invocation pays nothing). Per-function IAM grants
+     * further below give each function read access to only the secret(s) it
+     * needs. No plaintext secret is unwrapped, so none reaches the template.
+     *
+     * The one profile that cannot do this is natStrategy 'none': isolated
+     * subnets with no egress mean a runtime Secrets Manager call would hang.
+     * There the synth-time unwrap is kept as the documented escape hatch — the
+     * operator chose the zero-cost, no-egress profile and inherits the
+     * plaintext-in-template tradeoff for it. (The single-node and Kubernetes
+     * profiles, which have no Secrets Manager at all, get the same escape hatch
+     * on the app side: the resolver falls back to a plain DATABASE_URL / JWT_*
+     * env var whenever the corresponding *_SECRET_ARN is absent.)
+     *
+     * `hasEgress` is the switch: true for 'instance'/'gateway' (ARN + runtime
+     * lookup), false for 'none' (synth-time unwrap fallback). */
+    const hasEgress = natStrategy !== "none";
+
+    /* 'none'-only fallback: no NAT, no route to Secrets Manager, so resolve the
+       DB URL at synth time via unsafeUnwrap. This is the only path that still
+       places the plaintext password in the template, by necessity. Left as a
+       plain empty string on the egress path, where DATABASE_SECRET_ARN +
+       DATABASE_HOST/PORT/NAME drive a cold-start lookup instead. */
+    const databaseUrl = hasEgress
+      ? ""
+      : `postgres://snapurl:${database.secret!.secretValueFromJson("password").unsafeUnwrap()}` +
+        `@${database.instanceEndpoint.hostname}:${database.instanceEndpoint.port}/snapurl`;
 
     /* ---------------------------------------------------------
        Configuration
@@ -320,8 +347,8 @@ export class SnapUrlStack extends Stack {
     /* Nothing below is a literal. Ordinary settings come from Parameter Store
        and the two signing keys are generated into Secrets Manager, so this
        file contains no configuration to keep in step with anything and no
-       secret to leak. `config.ts` explains why both are resolved at deploy
-       time rather than read at cold start. */
+       secret to leak. `config.ts` explains how the secrets are resolved (at
+       cold start over NAT on the egress profiles; deploy-time on 'none'). */
     const commonEnv: Record<string, string> = {
       NODE_ENV: "production",
       // A Lambda instance serves one request at a time, so a pool larger than
@@ -329,7 +356,6 @@ export class SnapUrlStack extends Stack {
       // on a db.t4g.micro is small enough to exhaust under modest concurrency.
       DATABASE_POOL_MAX: "1",
       DATABASE_SSL: "true",
-      DATABASE_URL: databaseUrl,
       // Context wins over Parameter Store, so a one-off deploy against a
       // preview origin does not mean editing the stored value and remembering
       // to put it back.
@@ -341,15 +367,42 @@ export class SnapUrlStack extends Stack {
       MAIL_TRANSPORT: config.get("mail-transport"),
       THROTTLE_LIMIT: config.get("throttle-limit"),
       THROTTLE_TTL_SECONDS: config.get("throttle-ttl-seconds"),
-      /* Absent until this change, and the API would not have started without
-         them: apps/api/src/config/env.ts requires both, at 32 characters
-         minimum, and throws on boot when either is missing. The redirect
-         service needs the access key too — it verifies the short-lived unlock
-         token that password-protected links are opened with, and without it
-         every such link silently bounces back to the password page. */
-      JWT_ACCESS_SECRET: config.jwtAccessSecret.secretValue.unsafeUnwrap(),
-      JWT_REFRESH_SECRET: config.jwtRefreshSecret.secretValue.unsafeUnwrap(),
     };
+
+    if (hasEgress) {
+      /* Egress profiles ('instance'/'gateway'): pass ARNs, not values. Each
+         function resolves the secret it needs at cold start over the NAT and
+         caches it (see @snapurl/database's resolver). The DB URL is assembled
+         at runtime from the non-secret host/port/name below plus the password
+         fetched from DATABASE_SECRET_ARN. Nothing here is unwrapped, so no
+         secret value reaches the template.
+
+         DATABASE_SECRET_ARN is needed by all three functions (all talk to the
+         DB). The two JWT ARNs are set uniformly for simplicity — an env var a
+         function has no IAM permission to read is harmless, and the grants
+         further below enforce least privilege: api fetches both JWT secrets,
+         redirect fetches the access secret only, the worker fetches neither. */
+      commonEnv.DATABASE_SECRET_ARN = database.secret!.secretArn;
+      commonEnv.DATABASE_HOST = database.instanceEndpoint.hostname;
+      commonEnv.DATABASE_PORT = Token.asString(database.instanceEndpoint.port);
+      commonEnv.DATABASE_NAME = "snapurl";
+      commonEnv.JWT_ACCESS_SECRET_ARN = config.jwtAccessSecret.secretArn;
+      commonEnv.JWT_REFRESH_SECRET_ARN = config.jwtRefreshSecret.secretArn;
+    } else {
+      /* 'none'-only escape hatch: no egress means no runtime Secrets Manager
+         lookup is possible, so the values are unwrapped at synth time and set
+         directly. This is the one path that still bakes plaintext into the
+         template — an accepted tradeoff for the zero-cost, no-egress profile.
+
+         apps/api/src/config/env.ts requires both JWT secrets (>=32 chars) and
+         throws on boot without them. The redirect service needs the access key
+         too — it verifies the short-lived unlock token that password-protected
+         links open with, and without it every such link silently bounces back
+         to the password page. */
+      commonEnv.DATABASE_URL = databaseUrl;
+      commonEnv.JWT_ACCESS_SECRET = config.jwtAccessSecret.secretValue.unsafeUnwrap();
+      commonEnv.JWT_REFRESH_SECRET = config.jwtRefreshSecret.secretValue.unsafeUnwrap();
+    }
 
     /* The path each service answers a health probe on. Kept next to the value
        that decides it: the API mounts everything under a prefix, so hardcoding
@@ -620,6 +673,32 @@ export class SnapUrlStack extends Stack {
       targets: [new targets.LambdaFunction(workerFn, { retryAttempts: 2 })],
       description: "Drains the click queue and refreshes the rollup tables.",
     });
+
+    /* ---------------------------------------------------------
+       Secret read grants (issue #292)
+
+       Only on the egress profiles: under natStrategy 'none' nothing is
+       resolved at runtime (the values are baked in at synth time), so no grant
+       is needed or issued there. On 'instance'/'gateway' each function is
+       granted read on ONLY the secret(s) it actually fetches at cold start —
+       IAM enforces the least-privilege matrix even though the JWT ARNs are set
+       uniformly in commonEnv:
+
+         DB secret     -> api, redirect, worker  (all three talk to the DB)
+         JWT access    -> api, redirect           (redirect verifies unlock tokens)
+         JWT refresh   -> api only                (the only issuer/verifier of refresh tokens)
+
+       The worker gets no JWT grant (it never touches JWT); redirect gets no
+       refresh grant (it only verifies access-key-signed unlock tokens). Placed
+       here, after apiFn, redirectFn and workerFn all exist. */
+    if (hasEgress) {
+      database.secret!.grantRead(apiFn);
+      database.secret!.grantRead(redirectFn);
+      database.secret!.grantRead(workerFn);
+      config.jwtAccessSecret.grantRead(apiFn);
+      config.jwtAccessSecret.grantRead(redirectFn);
+      config.jwtRefreshSecret.grantRead(apiFn);
+    }
 
     /* ---------------------------------------------------------
        Budget alarms

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.1121.0",
     "@snapurl/contract": "workspace:*",
     "@snapurl/domain": "workspace:*",
     "drizzle-orm": "^0.44.6",

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client.js";
+export * from "./secrets.js";
 export * from "./schema/index.js";
 export * from "./events.js";
 export { sql, eq, and, or, not, desc, asc, inArray, isNull, isNotNull, gte, lte, gt, lt, count, sum, like, ilike } from "drizzle-orm";

--- a/packages/database/src/secrets.test.ts
+++ b/packages/database/src/secrets.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/* Mock the AWS SDK so no real network call is ever made. `send` is a shared
+   mock we assert call counts against; GetSecretValueCommand is a passthrough
+   that records the SecretId it was constructed with so we can build the
+   response accordingly. */
+const send = vi.fn();
+
+vi.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: vi.fn().mockImplementation(() => ({ send })),
+  GetSecretValueCommand: vi.fn().mockImplementation((input: { SecretId: string }) => ({ input })),
+}));
+
+import {
+  __resetSecretCacheForTests,
+  resolveDatabaseUrl,
+  resolveJwtSecret,
+  resolveSecrets,
+} from "./secrets.js";
+
+/** Build a send() implementation that returns a SecretString per ARN. */
+function respondWith(byArn: Record<string, string>) {
+  send.mockImplementation((command: { input: { SecretId: string } }) => {
+    const secretString = byArn[command.input.SecretId];
+    return Promise.resolve({ SecretString: secretString });
+  });
+}
+
+const DB_ARN = "arn:aws:secretsmanager:us-east-1:111122223333:secret:db-abc";
+const JWT_ARN = "arn:aws:secretsmanager:us-east-1:111122223333:secret:jwt-abc";
+
+const RDS_SECRET = JSON.stringify({
+  username: "snapurl",
+  password: "s3cr3t",
+  host: "db.internal.example",
+  port: 5432,
+  dbname: "snapurl",
+  engine: "postgres",
+});
+
+describe("resolveDatabaseUrl", () => {
+  beforeEach(() => {
+    __resetSecretCacheForTests();
+    send.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("escape hatch: returns plain DATABASE_URL and makes NO SDK call when DATABASE_SECRET_ARN is unset", async () => {
+    const env = { DATABASE_URL: "postgres://local:local@localhost:5432/dev" };
+    const result = await resolveDatabaseUrl(env);
+    expect(result).toBe("postgres://local:local@localhost:5432/dev");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("fetches once and assembles the URL from the RDS secret JSON", async () => {
+    respondWith({ [DB_ARN]: RDS_SECRET });
+    const result = await resolveDatabaseUrl({ DATABASE_SECRET_ARN: DB_ARN });
+    expect(result).toBe("postgres://snapurl:s3cr3t@db.internal.example:5432/snapurl");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches: two calls for the same ARN call send() exactly once", async () => {
+    respondWith({ [DB_ARN]: RDS_SECRET });
+    const env = { DATABASE_SECRET_ARN: DB_ARN };
+    const first = await resolveDatabaseUrl(env);
+    const second = await resolveDatabaseUrl(env);
+    expect(first).toBe(second);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies DATABASE_HOST/PORT/NAME overrides when the secret omits host/port/dbname", async () => {
+    const passwordOnlySecret = JSON.stringify({ username: "snapurl", password: "s3cr3t" });
+    respondWith({ [DB_ARN]: passwordOnlySecret });
+    const result = await resolveDatabaseUrl({
+      DATABASE_SECRET_ARN: DB_ARN,
+      DATABASE_HOST: "override.example",
+      DATABASE_PORT: "6543",
+      DATABASE_NAME: "overridedb",
+    });
+    expect(result).toBe("postgres://snapurl:s3cr3t@override.example:6543/overridedb");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when neither the secret nor env supply host/port/dbname", async () => {
+    const passwordOnlySecret = JSON.stringify({ username: "snapurl", password: "s3cr3t" });
+    respondWith({ [DB_ARN]: passwordOnlySecret });
+    await expect(resolveDatabaseUrl({ DATABASE_SECRET_ARN: DB_ARN })).rejects.toThrow();
+  });
+});
+
+describe("resolveJwtSecret", () => {
+  beforeEach(() => {
+    __resetSecretCacheForTests();
+    send.mockReset();
+  });
+
+  it("escape hatch: returns the plain env value and makes NO SDK call when the ARN env var is unset", async () => {
+    const env = { JWT_ACCESS_SECRET: "plain-access-secret" };
+    const result = await resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET", env);
+    expect(result).toBe("plain-access-secret");
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("fetches and returns the SecretString verbatim when the ARN env var is set", async () => {
+    respondWith({ [JWT_ARN]: "fetched-jwt-signing-key" });
+    const result = await resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET", {
+      JWT_ACCESS_SECRET_ARN: JWT_ARN,
+    });
+    expect(result).toBe("fetched-jwt-signing-key");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches the JWT secret across calls for the same ARN", async () => {
+    respondWith({ [JWT_ARN]: "fetched-jwt-signing-key" });
+    const env = { JWT_ACCESS_SECRET_ARN: JWT_ARN };
+    await resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET", env);
+    await resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET", env);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveSecrets", () => {
+  beforeEach(() => {
+    __resetSecretCacheForTests();
+    send.mockReset();
+  });
+
+  it("full escape hatch: returns all plain env values with NO SDK calls", async () => {
+    const env = {
+      DATABASE_URL: "postgres://local:local@localhost:5432/dev",
+      JWT_ACCESS_SECRET: "plain-access",
+      JWT_REFRESH_SECRET: "plain-refresh",
+    };
+    const result = await resolveSecrets(env);
+    expect(result).toEqual({
+      databaseUrl: "postgres://local:local@localhost:5432/dev",
+      jwtAccessSecret: "plain-access",
+      jwtRefreshSecret: "plain-refresh",
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("resolves each secret from its ARN when all ARNs are provided", async () => {
+    const accessArn = `${JWT_ARN}-access`;
+    const refreshArn = `${JWT_ARN}-refresh`;
+    respondWith({
+      [DB_ARN]: RDS_SECRET,
+      [accessArn]: "access-key",
+      [refreshArn]: "refresh-key",
+    });
+    const result = await resolveSecrets({
+      DATABASE_SECRET_ARN: DB_ARN,
+      JWT_ACCESS_SECRET_ARN: accessArn,
+      JWT_REFRESH_SECRET_ARN: refreshArn,
+    });
+    expect(result).toEqual({
+      databaseUrl: "postgres://snapurl:s3cr3t@db.internal.example:5432/snapurl",
+      jwtAccessSecret: "access-key",
+      jwtRefreshSecret: "refresh-key",
+    });
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/database/src/secrets.ts
+++ b/packages/database/src/secrets.ts
@@ -1,0 +1,137 @@
+import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+
+/**
+ * Runtime resolution of the database and JWT secrets from AWS Secrets Manager.
+ *
+ * WHY this exists (see infra/lib/config.ts for the full history): the AWS
+ * profile used to unwrap the generated RDS password and the JWT signing keys at
+ * synth time, which placed those plaintext values into the Lambda environment
+ * AND into the synthesized CloudFormation template. With NAT egress now in
+ * place the functions can reach Secrets Manager at cold start, so the values
+ * are resolved here at runtime instead of being baked into the template.
+ *
+ * ESCAPE HATCH FIRST: if the relevant *_SECRET_ARN env var is absent this
+ * module makes ZERO SDK calls and returns the plain env value unchanged. That
+ * keeps local dev, CI, docker-compose, the single-node profile and the
+ * Kubernetes profile byte-identical to today — none of them have Secrets
+ * Manager and must not be forced through it.
+ *
+ * CACHING: each resolved secret is cached at module scope keyed by ARN, so a
+ * warm invocation (a reused execution environment) never re-fetches. Only the
+ * first cold start of a given execution environment pays the lookup.
+ */
+
+/** Shape of an RDS-generated secret. `host`/`port`/`dbname` are present on the
+ *  full connection secret but can be absent on a password-only rotation secret,
+ *  in which case the DATABASE_HOST/PORT/NAME env vars fill the gap. */
+interface RdsSecret {
+  username: string;
+  password: string;
+  host?: string;
+  port?: number | string;
+  dbname?: string;
+  engine?: string;
+}
+
+/** Module-level cache: resolved SecretString keyed by ARN. Persists for the
+ *  lifetime of the execution environment (the whole point of the cache). */
+const secretCache = new Map<string, string>();
+
+/** Created lazily on first real fetch and reused thereafter. */
+let client: SecretsManagerClient | undefined;
+
+function getClient(): SecretsManagerClient {
+  if (!client) client = new SecretsManagerClient({});
+  return client;
+}
+
+/** Fetch a secret's SecretString, caching it at module scope keyed by ARN so a
+ *  second call for the same ARN never hits the network. */
+async function fetchSecretString(arn: string): Promise<string> {
+  const cached = secretCache.get(arn);
+  if (cached !== undefined) return cached;
+
+  const response = await getClient().send(new GetSecretValueCommand({ SecretId: arn }));
+  const value = response.SecretString;
+  if (value === undefined) {
+    throw new Error(`Secret ${arn} has no SecretString (binary secrets are not supported).`);
+  }
+  secretCache.set(arn, value);
+  return value;
+}
+
+/**
+ * Resolve the database connection string.
+ *
+ * Escape hatch: with no DATABASE_SECRET_ARN set, returns env.DATABASE_URL as-is
+ * and makes no SDK call.
+ *
+ * With DATABASE_SECRET_ARN set, fetches the RDS secret once, parses its JSON and
+ * assembles `postgres://<username>:<password>@<host>:<port>/<dbname>`. When the
+ * secret JSON omits host/port/dbname (a password-only rotation secret) the
+ * DATABASE_HOST / DATABASE_PORT / DATABASE_NAME env vars supply them.
+ */
+export async function resolveDatabaseUrl(env: NodeJS.ProcessEnv = process.env): Promise<string | undefined> {
+  const arn = env.DATABASE_SECRET_ARN;
+  if (!arn) return env.DATABASE_URL;
+
+  const raw = await fetchSecretString(arn);
+  const secret = JSON.parse(raw) as RdsSecret;
+
+  const username = encodeURIComponent(secret.username);
+  const password = encodeURIComponent(secret.password);
+  const host = secret.host ?? env.DATABASE_HOST;
+  const port = secret.port ?? env.DATABASE_PORT;
+  const dbname = secret.dbname ?? env.DATABASE_NAME;
+
+  if (!host || port === undefined || port === "" || !dbname) {
+    throw new Error(
+      "Database secret is missing host/port/dbname and DATABASE_HOST / DATABASE_PORT / DATABASE_NAME were not supplied to fill the gap.",
+    );
+  }
+
+  return `postgres://${username}:${password}@${host}:${port}/${dbname}`;
+}
+
+/**
+ * Resolve a JWT signing key.
+ *
+ * Escape hatch: when `arnEnvVar` is not set, returns the plain `plainEnvVar`
+ * value unchanged and makes no SDK call. When it is set, fetches that secret's
+ * SecretString (used verbatim as the signing key) and caches it.
+ */
+export async function resolveJwtSecret(
+  arnEnvVar: string,
+  plainEnvVar: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+  const arn = env[arnEnvVar];
+  if (!arn) return env[plainEnvVar];
+  return fetchSecretString(arn);
+}
+
+export interface ResolvedSecrets {
+  databaseUrl: string | undefined;
+  jwtAccessSecret: string | undefined;
+  jwtRefreshSecret: string | undefined;
+}
+
+/**
+ * Resolve all three secrets in one call. Each field independently honours its
+ * escape hatch, so a deployment that provides only some ARNs still works.
+ */
+export async function resolveSecrets(env: NodeJS.ProcessEnv = process.env): Promise<ResolvedSecrets> {
+  const [databaseUrl, jwtAccessSecret, jwtRefreshSecret] = await Promise.all([
+    resolveDatabaseUrl(env),
+    resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET", env),
+    resolveJwtSecret("JWT_REFRESH_SECRET_ARN", "JWT_REFRESH_SECRET", env),
+  ]);
+  return { databaseUrl, jwtAccessSecret, jwtRefreshSecret };
+}
+
+/** Test-only: clears the module-level cache and lazily-created client so each
+ *  unit test starts from a clean slate. Not part of the runtime contract. */
+export function __resetSecretCacheForTests(): void {
+  secretCache.clear();
+  client = undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
 
   packages/database:
     dependencies:
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.1121.0
+        version: 3.1121.0
       '@snapurl/contract':
         specifier: workspace:*
         version: link:../contract
@@ -365,6 +368,70 @@ packages:
     bundledDependencies:
       - jsonschema
       - semver
+
+  '@aws-sdk/client-secrets-manager@3.1121.0':
+    resolution: {integrity: sha512-kx66Imv5DomVdd5uwai10Dhf0zZg9Z3EODxJCYRGjmaD0GR08GkvuIPPIqE+ZmpHANCWbur9UKpgyXGJzk60pg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.9':
+    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    resolution: {integrity: sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.44':
+    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1116.0':
+    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1583,6 +1650,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.11.3':
+    resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1974,6 +2065,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
@@ -3592,6 +3686,151 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@54.21.0': {}
 
+  '@aws-sdk/client-secrets-manager@3.1121.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.9':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-login': 3.972.77
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.81':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.70
+      '@aws-sdk/credential-provider-http': 3.972.72
+      '@aws-sdk/credential-provider-ini': 3.973.15
+      '@aws-sdk/credential-provider-process': 3.972.70
+      '@aws-sdk/credential-provider-sso': 3.973.14
+      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -4400,6 +4639,39 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.63.0':
     optional: true
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -4787,6 +5059,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.18:
     dependencies:


### PR DESCRIPTION
Closes #292. Phase 3 of epic #267 (aws/security/infra/self-hosting). Unblocked by #281's NAT.

## The problem
The AWS profile unwrapped the RDS password and both JWT signing keys at **synth time** (`unsafeUnwrap()`), placing plaintext into the Lambda env **and the synthesized CloudFormation template** — which lives in the CDK assets bucket and CFN history. Under the open-source framing every operator is a different account with varying IAM discipline, so 'the account owner is the only reader' is no longer a safe assumption, and with NAT (#281) a runtime lookup no longer needs a $7/mo interface endpoint.

## Approach (escape-hatch-first)
- **Shared resolver** `packages/database/src/secrets.ts`: when a `*_SECRET_ARN` env is set, calls Secrets Manager `GetSecretValue` **once per ARN** and caches it in a module-level map for the execution environment's lifetime (warm invocations pay nothing). When no ARN is set it returns the plain `DATABASE_URL`/`JWT_*` env unchanged and makes **zero** SDK calls — so single-node, Kubernetes, compose, local, and CI are byte-identical.
- **New env contract:** `DATABASE_SECRET_ARN`, `JWT_ACCESS_SECRET_ARN`, `JWT_REFRESH_SECRET_ARN` (secrets) + non-secret `DATABASE_HOST`/`PORT`/`NAME` (URL assembled at runtime; only the password comes from the secret).
- **Async-safe boot:** api hydrates secrets into `process.env` before the zod parse; redirect moved DB/JWT/db construction into an async `init()`; **worker** deferred its previously-synchronous module-top `createDatabase` behind a memoized async `initDb()` (awaited by both the long-running process and the Lambda handler) — the key restructure so secrets resolve before any DB connection.
- **SDK dependency:** `@aws-sdk/client-secrets-manager` added to `packages/database` (all apps depend on it). Required because the images are pruned with `pnpm deploy --prod` onto plain Node bases (lambda-web = node:22-alpine + LWA), so no AWS-provided SDK is on the path — confirmed from the repo's own Dockerfile.
- **Least-privilege grants** (egress path): DB→api+redirect+worker; JWT access→api+redirect; JWT refresh→**api only**; worker gets no JWT. Synth shows exactly 6 GetSecretValue statements.
- **`natStrategy=none` fallback:** no egress means a runtime SM lookup would hang, so under `'none'` the stack retains today's synth-time unwrap, issues no ARNs and no grants — documented as the zero-egress operator's explicit tradeoff (same framing as #281).

## Template-leak audit (from `cdk synth`)
- **instance/gateway path:** ZERO plaintext `DATABASE_URL`/`JWT_*` in the template; only ARN refs + non-secret host/port/name + 6 grants. Plaintext no longer reaches the template/assets/CFN history.
- **none path:** plaintext preserved via dynamic refs (expected fallback), no ARNs/grants.
- CfnOutputs emit ARNs, not values — not a leak.

## How to test
- `corepack pnpm install --frozen-lockfile` clean; `corepack pnpm type-check` pass; `corepack pnpm --filter @snapurl/database test` → 10 new `secrets.test.ts` tests (mock the SDK: escape-hatch no-op makes no SDK call, single-fetch + URL assembly, cache = 2 calls→1 fetch, host/port/name override, JWT verbatim). Verified.
- `cdk synth` verified for `-c natStrategy=instance` (no plaintext, 6 grants) and `=none` (fallback). CI `verify`+`integration` use plain-env, so they exercise the escape hatch (unchanged behavior).

## Non-blocking (from review)
Per-ARN cache memoizes the value not the in-flight promise (double-fetch only if two concurrent first-time callers — unreachable at one-resolve-per-cold-start); an unused `getDb()` export in worker. Left as-is.

Files: resolver + test in packages/database (+ SDK dep + lockfile), api/redirect/worker boots, infra stack + config.ts. **Local/CI/compose behavior unchanged** (resolver is a no-op without ARNs).