### PR TITLE
Small correctness and cost items from the Phase-3 audit (#283)

### DIFF
--- a/apps/redirect/package.json
+++ b/apps/redirect/package.json
@@ -17,7 +17,6 @@
     "@snapurl/domain": "workspace:*",
     "fastify": "^5.6.1",
     "jsonwebtoken": "^9.0.2",
-    "argon2": "^0.44.0",
     "pino": "^9.6.0"
   },
   "devDependencies": {

--- a/apps/redirect/src/resolver.test.ts
+++ b/apps/redirect/src/resolver.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { normaliseHost } from "./resolver.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createDatabase,
+  domains,
+  eq,
+  links,
+  routingRules,
+  workspaces,
+  type Database,
+} from "@snapurl/database";
+import { PostgresLinkResolver, normaliseHost } from "./resolver.js";
 
 describe("normaliseHost", () => {
   it("lowercases the host so a printed QR read as SNAP.TO still resolves", () => {
@@ -12,5 +21,102 @@ describe("normaliseHost", () => {
 
   it("keeps the port, because links are created against host:port in dev", () => {
     expect(normaliseHost("localhost:3002")).toBe("localhost:3002");
+  });
+});
+
+/* ============================================================
+   PostgresLinkResolver against a real Postgres.
+
+   The rest of resolve() is exercised by the redirect integration
+   tests; what this file pins is the property the parallelisation
+   change turned on — the routing rules are fetched by (host, slug)
+   rather than by the resolved link id, so they must still come back
+   in position order and be empty when a link has none.
+
+   Runs only when DATABASE_URL is set, matching partitions.test.ts.
+   ============================================================ */
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeDb = DATABASE_URL ? describe : describe.skip;
+
+describeDb("PostgresLinkResolver.resolve", () => {
+  let handle: ReturnType<typeof createDatabase>;
+  let db: Database;
+  let resolver: PostgresLinkResolver;
+  let workspaceId: string;
+  let host: string;
+
+  beforeAll(async () => {
+    handle = createDatabase({ url: DATABASE_URL!, max: 1 });
+    db = handle.db;
+    resolver = new PostgresLinkResolver(db);
+
+    const stamp = Date.now();
+    host = `resolver-${stamp}.test`;
+
+    const [ws] = await db
+      .insert(workspaces)
+      .values({ name: "resolver test", slug: `resolver-${stamp}` })
+      .returning({ id: workspaces.id });
+    workspaceId = ws!.id;
+
+    const [dom] = await db
+      .insert(domains)
+      .values({ workspaceId, domain: host })
+      .returning({ id: domains.id });
+
+    /* A link with two routing rules, inserted position 1 before position 0 so
+       the ordering asserted below can only come from the query's ORDER BY, not
+       from insertion order. */
+    const [withRules] = await db
+      .insert(links)
+      .values({ workspaceId, domainId: dom!.id, slug: "ruled", destination: "https://example.com/default" })
+      .returning({ id: links.id });
+    await db.insert(routingRules).values([
+      { linkId: withRules!.id, position: 1, whenCountry: "US", then: "https://example.com/us", weight: null },
+      { linkId: withRules!.id, position: 0, whenDevice: "mobile", then: "https://example.com/mobile", weight: null },
+    ]);
+
+    // A second link on the same (host) with no rules at all.
+    await db
+      .insert(links)
+      .values({ workspaceId, domainId: dom!.id, slug: "plain", destination: "https://example.com/plain" });
+  });
+
+  afterAll(async () => {
+    if (workspaceId) await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    await handle?.close();
+  });
+
+  it("returns the routing rules in position order with the resolved link", async () => {
+    const resolved = await resolver.resolve(host, "ruled");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.destination).toBe("https://example.com/default");
+    // Position 0 (mobile) before position 1 (US), regardless of insert order.
+    expect(resolved!.rules.map((r) => r.then)).toEqual([
+      "https://example.com/mobile",
+      "https://example.com/us",
+    ]);
+    expect(resolved!.rules[0]!.when.device).toBe("mobile");
+    expect(resolved!.rules[1]!.when.country).toBe("US");
+  });
+
+  it("returns an empty rules array for a link with no routing rules", async () => {
+    const resolved = await resolver.resolve(host, "plain");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.destination).toBe("https://example.com/plain");
+    expect(resolved!.rules).toEqual([]);
+  });
+
+  it("resolves a slug case-insensitively and does not leak another link's rules", async () => {
+    // "PLAIN" resolves to the ruleless link and must not pick up "ruled"'s
+    // rules — the (host, slug) predicate is what keeps them apart now that the
+    // rules query no longer keys off the resolved link id.
+    const resolved = await resolver.resolve(host, "PLAIN");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.rules).toEqual([]);
   });
 });

--- a/apps/redirect/src/resolver.ts
+++ b/apps/redirect/src/resolver.ts
@@ -63,33 +63,53 @@ export class PostgresLinkResolver implements LinkResolver {
   constructor(private readonly db: Database) {}
 
   async resolve(host: string, slug: string): Promise<ResolvedLink | null> {
-    const [row] = await this.db
-      .select({ link: links, domainId: domains.id, clicks: sql<number>`coalesce(${linkCounters.clicks}, 0)` })
-      .from(links)
-      .innerJoin(domains, eq(links.domainId, domains.id))
-      .leftJoin(linkCounters, eq(linkCounters.linkId, links.id))
-      .where(
-        and(
-          sql`lower(${domains.domain}) = ${normaliseHost(host)}`,
-          sql`lower(${links.slug}) = ${slug.toLowerCase()}`,
-        ),
-      )
-      .limit(1);
+    const normalisedHost = normaliseHost(host);
+    const normalisedSlug = slug.toLowerCase();
+
+    /* The link row (with its counter) and the routing rules are independent
+       lookups, so they run concurrently — one RTT saved on every redirect.
+       The rules query used to filter on `routingRules.linkId = row.link.id`,
+       which forced it to wait for the link query first. Keying it off the same
+       (host, slug) predicate via a join to links -> domains removes that
+       dependency without changing the result: a (host, slug) pair resolves to
+       at most one link, so the rules matched are exactly the ones that link
+       owns. The rules query usually returns zero rows, so this is a cheap
+       parallel query on the hot path. */
+    const [[row], rules] = await Promise.all([
+      this.db
+        .select({ link: links, domainId: domains.id, clicks: sql<number>`coalesce(${linkCounters.clicks}, 0)` })
+        .from(links)
+        .innerJoin(domains, eq(links.domainId, domains.id))
+        .leftJoin(linkCounters, eq(linkCounters.linkId, links.id))
+        .where(
+          and(
+            sql`lower(${domains.domain}) = ${normalisedHost}`,
+            sql`lower(${links.slug}) = ${normalisedSlug}`,
+          ),
+        )
+        .limit(1),
+      this.db
+        .select({ rule: routingRules })
+        .from(routingRules)
+        .innerJoin(links, eq(routingRules.linkId, links.id))
+        .innerJoin(domains, eq(links.domainId, domains.id))
+        .where(
+          and(
+            sql`lower(${domains.domain}) = ${normalisedHost}`,
+            sql`lower(${links.slug}) = ${normalisedSlug}`,
+          ),
+        )
+        .orderBy(routingRules.position),
+    ]);
 
     if (!row) return null;
-
-    const rules = await this.db
-      .select()
-      .from(routingRules)
-      .where(eq(routingRules.linkId, row.link.id))
-      .orderBy(routingRules.position);
 
     return {
       id: row.link.id,
       workspaceId: row.link.workspaceId,
       destination: row.link.destination,
       redirectType: row.link.redirectType as ResolvedLink["redirectType"],
-      rules: rules.map((r) => ({
+      rules: rules.map(({ rule: r }) => ({
         id: r.id,
         when: {
           country: r.whenCountry,

--- a/apps/worker/src/jobs/partitions.test.ts
+++ b/apps/worker/src/jobs/partitions.test.ts
@@ -383,6 +383,120 @@ describeDb("click_events partitioning", () => {
     }
   });
 
+  it("drops the oldest partitions beyond MAX_RETAINED_DAYS as an age-independent cap", async () => {
+    /* The volume cap, distinct from age retention. These partitions sit ~2
+       years back — old, but well inside the default 3-year retention, so the
+       age-based pass leaves them alone. What removes them here is the cap: with
+       an explicit maxRetainedDays low enough that the table is over the ceiling,
+       pruneRetention drops the OLDEST attached day-partitions until the count is
+       back under the cap. This is the storage-cliff backstop: age bounds how old
+       data is, the cap bounds how much of it there is. */
+    const stamp = Date.now();
+
+    // A contiguous block of days ~2 years back, older than anything the other
+    // tests provision (today/future and the -730 mixed-retention day, which is
+    // dropped in its own finally). Lexical order on YYYYMMDD is chronological,
+    // so these are the globally-oldest attached day-partitions.
+    const capOffsets = [-760, -759, -758, -757];
+    const capPartitions = capOffsets.map((o) => partitionName(o));
+
+    // Start clean so a previous run's leftovers do not skew the attached count.
+    for (const name of capPartitions) await dropPartition(name);
+
+    try {
+      for (const offset of capOffsets) {
+        const day = utcDay(offset);
+        day.setUTCHours(11);
+        await db.execute(sql`select click_events_ensure_partition(${day.toISOString().slice(0, 10)}::date)`);
+        // Rolled up, so the un-rolled-up guard never pins them — the cap alone
+        // decides whether they survive.
+        await addClickAt(day, `cap-${stamp}-${offset}`);
+        expect(await isAttached(partitionName(offset))).toBe(true);
+      }
+
+      // How many day-partitions are attached right now. Set the cap two below
+      // that so exactly the two globally-oldest (the two oldest of this block)
+      // are over the ceiling and get dropped.
+      const [{ attached }] = (await db.execute(sql`
+        select count(*)::int as attached
+        from pg_class c
+        join pg_inherits i on i.inhrelid = c.oid
+        where i.inhparent = 'public.click_events'::regclass
+          and c.relname ~ '^click_events_[0-9]{8}$'
+      `)) as unknown as [{ attached: number }];
+
+      const cap = attached - 2;
+      const result = await pruneRetention(db, 20, cap);
+
+      // The two oldest of the block are dropped; the two newer ones remain.
+      expect(await partitionExists(capPartitions[0]!)).toBe(false);
+      expect(await partitionExists(capPartitions[1]!)).toBe(false);
+      expect(await isAttached(capPartitions[2]!)).toBe(true);
+      expect(await isAttached(capPartitions[3]!)).toBe(true);
+      expect(result.partitionsDropped).toBeGreaterThanOrEqual(2);
+
+      // And the DEFAULT partition is never a cap candidate.
+      expect(await isAttached("click_events_default")).toBe(true);
+    } finally {
+      for (const name of capPartitions) await dropPartition(name);
+    }
+  });
+
+  it("never drops a capped partition that still holds un-rolled-up clicks", async () => {
+    /* The cap honours the same invariant as the age pass: raw detail is never
+       discarded before it has been counted. A partition pinned by an
+       un-rolled-up row is skipped even when it is the oldest and the table is
+       over the cap — the cap falls on the next droppable day instead. */
+    const stamp = Date.now();
+    const capOffsets = [-756, -755];
+    const capPartitions = capOffsets.map((o) => partitionName(o));
+
+    for (const name of capPartitions) await dropPartition(name);
+
+    try {
+      // Oldest of the pair: provisioned with a PENDING (un-rolled-up) click, so
+      // it must survive the cap.
+      const oldest = utcDay(capOffsets[0]!);
+      oldest.setUTCHours(11);
+      await db.execute(sql`select click_events_ensure_partition(${oldest.toISOString().slice(0, 10)}::date)`);
+      await db.insert(clickEvents).values({
+        linkId,
+        workspaceId,
+        occurredAt: oldest,
+        visitorHash: `cap-pending-${stamp}`,
+        rolledUpAt: null,
+      });
+
+      // Newer of the pair: rolled up, so it is droppable.
+      const newer = utcDay(capOffsets[1]!);
+      newer.setUTCHours(11);
+      await db.execute(sql`select click_events_ensure_partition(${newer.toISOString().slice(0, 10)}::date)`);
+      await addClickAt(newer, `cap-rolled-${stamp}`);
+
+      const [{ attached }] = (await db.execute(sql`
+        select count(*)::int as attached
+        from pg_class c
+        join pg_inherits i on i.inhrelid = c.oid
+        where i.inhparent = 'public.click_events'::regclass
+          and c.relname ~ '^click_events_[0-9]{8}$'
+      `)) as unknown as [{ attached: number }];
+
+      // One over the cap. The oldest is pinned by its pending row, so the cap
+      // must fall on the newer, rolled-up partition instead — the pinned one is
+      // still counted against the cap, so a droppable day is dropped in its
+      // place rather than nothing happening.
+      const cap = attached - 1;
+      await pruneRetention(db, 20, cap);
+
+      expect(await isAttached(capPartitions[0]!)).toBe(true); // pinned, kept
+      expect(await partitionExists(capPartitions[1]!)).toBe(false); // dropped in its place
+    } finally {
+      // The pending row blocks a plain drop path only via the guard; teardown
+      // removes the table regardless.
+      for (const name of capPartitions) await dropPartition(name);
+    }
+  });
+
   it("does not drop a partition whose range extends past the cutoff", async () => {
     /* Boundary. A partition covers [day, day + 1), so it is only spent once
        day + 1 has reached the cutoff. Dropping the partition that straddles the

--- a/apps/worker/src/jobs/rollup.ts
+++ b/apps/worker/src/jobs/rollup.ts
@@ -281,6 +281,30 @@ const PARTITION_LOOKBACK_DAYS = 7;
  *  days become spent at once. The rest are dropped by later passes. */
 const MAX_PARTITION_DROPS = 20;
 
+/** Hard ceiling on the number of retained day-partitions, as a storage cliff
+ *  backstop that is independent of per-workspace age retention.
+ *
+ *  The arithmetic: at the design load of ~86M click rows a day, one day is a
+ *  large partition. RDS storage autoscales up to `maxAllocatedStorage` (50 GB
+ *  in infra/lib/snapurl-stack.ts) and then stops — at which point the instance
+ *  goes READ-ONLY, and RDS allocated storage can never be reduced afterwards.
+ *  That is a cliff, not a slope: once hit, the database stops accepting writes
+ *  and the only recovery is a costly rebuild.
+ *
+ *  Age-based retention (the per-workspace `retention_years`, default 3) does
+ *  not defend against this, because the *count* of partitions past the cutoff
+ *  is unbounded — a workspace configured for a long retention keeps years of
+ *  days attached. Partitioning largely supersedes the old row-level prune, but
+ *  it does not by itself cap total volume. So this is a coarse, age-independent
+ *  ceiling: keep at most this many day-partitions attached, dropping the oldest
+ *  beyond it, so storage cannot silently walk into the read-only cliff.
+ *
+ *  Default 1100 (~3 years of daily partitions, matching the default retention)
+ *  so it never fires under normal operation and only acts as a true backstop.
+ *  Override with CLICK_EVENTS_MAX_RETAINED_DAYS when the storage budget or the
+ *  ingest rate demands a tighter cap. */
+const MAX_RETAINED_DAYS = Number(process.env.CLICK_EVENTS_MAX_RETAINED_DAYS ?? 1100);
+
 export interface RetentionResult {
   /** Whole days removed by dropping a partition. Constant-time, near-zero WAL. */
   partitionsDropped: number;
@@ -349,8 +373,28 @@ export async function ensureClickPartitions(
  * the `DELETE` does not disappear, it just stops carrying the volume. When
  * every workspace uses the same retention (the common case, and the default),
  * `rowsDeleted` is zero and the whole job is a partition drop.
+ *
+ * **A third pass: the volume cap.** After age-based expiry, this also enforces
+ * `MAX_RETAINED_DAYS` — an age-*independent* ceiling on how many day-partitions
+ * stay attached. Age retention bounds how *old* data is, not how *much* of it
+ * there is, and RDS storage autoscales to a hard 50 GB ceiling past which the
+ * instance goes read-only and can never be shrunk. The cap is the backstop that
+ * keeps total volume from silently walking into that cliff. It is deliberately
+ * a no-op under normal operation (the default cap matches the default 3-year
+ * retention); it only bites when partition count runs ahead of the storage
+ * budget. Like the age pass it never drops a partition still holding
+ * un-rolled-up rows, and it respects `maxDropsPerPass`. Cap-driven drops are
+ * folded into the returned `partitionsDropped`.
  */
-export async function pruneRetention(db: Database, maxDropsPerPass = MAX_PARTITION_DROPS): Promise<RetentionResult> {
+export async function pruneRetention(
+  db: Database,
+  maxDropsPerPass = MAX_PARTITION_DROPS,
+  /* The volume cap, defaulting to the env-overridable module constant. Exposed
+     as a parameter so the cap can be exercised directly in tests without
+     provisioning MAX_RETAINED_DAYS+1 partitions; production always uses the
+     default. */
+  maxRetainedDays = MAX_RETAINED_DAYS,
+): Promise<RetentionResult> {
   /* One expiry pass at a time. Without this, two overlapping passes both read
      the same list of spent partitions and the second fails on one the first
      already dropped — which would abort every maintenance job queued behind it.
@@ -395,6 +439,77 @@ export async function pruneRetention(db: Database, maxDropsPerPass = MAX_PARTITI
         select click_events_drop_partition(${part}) as ok
       `)) as unknown as [{ ok: boolean }];
       if (ok) partitionsDropped++;
+    }
+
+    /* The volume cap, an age-independent backstop. See MAX_RETAINED_DAYS.
+     *
+     * The age pass above bounds how *old* the retained data is; it does not
+     * bound how *many* day-partitions are attached, and past the RDS 50 GB
+     * autoscale ceiling the instance goes read-only for good. So if more than
+     * MAX_RETAINED_DAYS day-partitions remain attached, drop the OLDEST ones
+     * beyond the cap.
+     *
+     * The candidate list matches click_events_spent_partitions' own selection:
+     * attached day-partitions (relname ~ ^click_events_[0-9]{8}$), excluding the
+     * DEFAULT partition, and — crucially — only those with NO un-rolled-up rows,
+     * so a cap-driven drop can never discard clicks that have not yet been
+     * counted into the rollups (the same invariant the age pass and the SQL
+     * helper both hold). The EXISTS(... rolled_up_at IS NULL) guard is checked
+     * against ONLY the partition, matching the helper. Ordered oldest-first by
+     * name (names are YYYYMMDD, so lexical order is chronological), and the
+     * count of *all* attached day-partitions decides how many are over the cap
+     * — but only the rolled-up, droppable ones are offered as candidates, so a
+     * partition pinned by pending rows is skipped rather than lost. */
+    const capBudget = maxDropsPerPass - partitionsDropped;
+    if (capBudget > 0) {
+      /* Every attached day-partition, oldest first. Names are YYYYMMDD, so
+         lexical order is chronological. The DEFAULT partition does not match
+         the ^click_events_[0-9]{8}$ pattern, so it is excluded here exactly as
+         it is by click_events_spent_partitions. */
+      const attached = (await db.execute(sql`
+        select c.relname as part
+        from pg_class c
+        join pg_inherits i on i.inhrelid = c.oid
+        where i.inhparent = 'public.click_events'::regclass
+          and c.relname ~ '^click_events_[0-9]{8}$'
+        order by c.relname
+      `)) as unknown as Array<{ part: string }>;
+
+      /* How many attached day-partitions are over the ceiling. The count is of
+         ALL attached days, not just droppable ones, so a partition pinned by
+         un-rolled-up rows still counts against the cap — a younger droppable
+         partition is taken in its place, which keeps total volume falling
+         without ever discarding uncounted clicks. */
+      let overCap = attached.length - maxRetainedDays;
+      for (const { part } of attached) {
+        // Stop once volume is back under the cap or the per-pass drop budget is
+        // spent — the rest are dropped by later passes, keeping the parent lock
+        // short even after a sudden cap change.
+        if (overCap <= 0 || partitionsDropped >= maxDropsPerPass) break;
+
+        /* The un-rolled-up guard, mirroring click_events_spent_partitions: raw
+           detail is never discarded before it has been counted. `FROM ONLY` and
+           the `rolled_up_at IS NULL` predicate hit the partial
+           click_events_pending_idx, so this is a cheap index probe. The name is
+           regex-validated above, so sql.raw here cannot inject. A pinned
+           partition is left attached (it is retained until a rollup consumes
+           it) but is NOT decremented from overCap, so the cap is still enforced
+           by dropping the next droppable day. */
+        const [{ pending }] = (await db.execute(
+          sql.raw(
+            `select exists (select 1 from only "${part}" where rolled_up_at is null) as pending`,
+          ),
+        )) as unknown as [{ pending: boolean }];
+        if (pending) continue;
+
+        const [{ ok }] = (await db.execute(sql`
+          select click_events_drop_partition(${part}) as ok
+        `)) as unknown as [{ ok: boolean }];
+        if (ok) {
+          partitionsDropped++;
+          overCap--;
+        }
+      }
     }
 
     /* Only workspaces retaining less than the maximum.

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -1,11 +1,30 @@
 import { resolveDatabaseUrl, runMigrations } from "@snapurl/database";
 import { initDb, runFrequent, runMaintenance } from "./main.js";
 
-/* The worker as a Lambda, with two jobs.
+/* The worker as a Lambda, dispatched by a `task` discriminator.
  *
- * EventBridge invokes it on a schedule with no payload, which runs the
- * rollups. Passing `{ "task": "migrate" }` applies database migrations
- * instead.
+ * EventBridge invokes it on two schedules (see infra/lib/snapurl-stack.ts):
+ * a 1-minute rule carrying `{ "task": "frequent" }` and an hourly rule
+ * carrying `{ "task": "maintenance" }`. Frequent drains the click queue and
+ * refreshes the rollups; maintenance does the hourly housekeeping
+ * (partition provisioning, salt rotation, retention). Splitting them matters
+ * because the handler used to run BOTH on every invocation while the only
+ * rule fired every minute — so the hourly job actually ran 60x/hour against a
+ * shared t4g.micro. Now each schedule runs exactly one job.
+ *
+ * The `task` values:
+ *   - `"migrate"`            -> apply database migrations (see below).
+ *   - `"maintenance"`        -> runMaintenance only.
+ *   - `"frequent"`           -> runFrequent only.
+ *   - `"rollup"`             -> runFrequent only (back-compat alias for the
+ *                               old payload; the previous handler treated a
+ *                               no-payload/rollup invocation as the recurring
+ *                               job).
+ *   - default / no payload   -> runFrequent only.
+ *
+ * The DEFAULT partition still guarantees inserts never fail between the hourly
+ * ensureClickPartitions runs, so moving maintenance off the 1-minute cadence
+ * costs no clicks (per the #268 partitioning design).
  *
  * Migrations live here because this is the only place they can run. RDS sits
  * in isolated subnets with publiclyAccessible false, so there is no route to
@@ -15,10 +34,11 @@ import { initDb, runFrequent, runMaintenance } from "./main.js";
  *
  * It is a separate task rather than something the schedule does, because
  * migrations should run when someone decides to run them. A scheduled
- * migration is a schema change nobody was watching.
+ * migration is a schema change nobody was watching — which is why migrate is
+ * on no schedule at all and only ever runs on a manual invocation.
  */
 export interface WorkerEvent {
-  task?: "rollup" | "migrate";
+  task?: "frequent" | "maintenance" | "rollup" | "migrate";
 }
 
 export const handler = async (event: WorkerEvent = {}) => {
@@ -39,9 +59,16 @@ export const handler = async (event: WorkerEvent = {}) => {
      invocations, so the connection survives between runs rather than being
      rebuilt every minute, and it is deliberately never closed at the end of a
      call. initDb() also resolves the secret at cold start before the first
-     connection is made. */
+     connection is made. Shared by both the frequent and maintenance branches. */
   const { db } = await initDb();
+
+  if (event.task === "maintenance") {
+    const maintenance = await runMaintenance(db);
+    return { task: "maintenance", maintenance };
+  }
+
+  /* Everything else — the 1-minute frequent schedule, the "rollup" back-compat
+     alias, and a bare no-payload invocation — runs the frequent job only. */
   const frequent = await runFrequent(db);
-  const maintenance = await runMaintenance(db);
-  return { task: "rollup", frequent, maintenance };
+  return { task: "frequent", frequent };
 };

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -667,11 +667,38 @@ export class SnapUrlStack extends Stack {
 
     /* EventBridge rather than an in-process interval: a scheduled rule
        survives a redeploy and a scale-to-zero, which the v1 node-cron did
-       not — it died with the process that started it. */
+       not — it died with the process that started it.
+
+       Two rules, not one, because the handler runs one job per invocation
+       keyed on the `task` payload (see apps/worker/src/lambda.ts). Previously
+       a single 1-minute rule with no payload ran BOTH the frequent rollup and
+       the hourly maintenance on every tick — so the hourly job actually ran
+       60x/hour against a shared t4g.micro that is also serving redirects.
+       Splitting the schedule runs maintenance once an hour as intended. The
+       DEFAULT click_events partition guarantees inserts never fail between
+       the hourly ensureClickPartitions passes, so the slower maintenance
+       cadence loses no clicks. Migrate stays on no schedule — it is invoked
+       manually with {"task":"migrate"}. */
     new events.Rule(this, "WorkerSchedule", {
       schedule: events.Schedule.rate(Duration.minutes(1)),
-      targets: [new targets.LambdaFunction(workerFn, { retryAttempts: 2 })],
-      description: "Drains the click queue and refreshes the rollup tables.",
+      targets: [
+        new targets.LambdaFunction(workerFn, {
+          event: events.RuleTargetInput.fromObject({ task: "frequent" }),
+          retryAttempts: 2,
+        }),
+      ],
+      description: "Frequent pass: drains the click queue and refreshes the rollup tables (every minute).",
+    });
+
+    new events.Rule(this, "WorkerMaintenanceSchedule", {
+      schedule: events.Schedule.rate(Duration.hours(1)),
+      targets: [
+        new targets.LambdaFunction(workerFn, {
+          event: events.RuleTargetInput.fromObject({ task: "maintenance" }),
+          retryAttempts: 2,
+        }),
+      ],
+      description: "Hourly maintenance: partition provisioning, salt rotation, retention and pruning.",
     });
 
     /* ---------------------------------------------------------

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -13,6 +13,7 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as events from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as ecrAssets from "aws-cdk-lib/aws-ecr-assets";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as apigw from "aws-cdk-lib/aws-apigatewayv2";
 import * as integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
@@ -472,6 +473,21 @@ export class SnapUrlStack extends Stack {
         file: "Dockerfile",
         buildArgs: { APP: app },
         target,
+        /* arm64/Graviton. A container-image Lambda's architecture MUST match
+           the architecture the image was built for, so this platform and the
+           `architecture: lambda.Architecture.ARM_64` on each function below are
+           a pair — set one without the other and the function fails to invoke.
+           The base images (node:22-alpine, public.ecr.aws/lambda/nodejs:22,
+           public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1) are all multi-arch
+           and publish arm64, so no Dockerfile change is needed.
+
+           Build-host caveat: cross-building an arm64 image on an x86 CI/deploy
+           host needs `docker buildx` with QEMU emulation registered (e.g.
+           `docker run --privileged tonistiigi/binfmt --install arm64`), or an
+           arm64 build host. `cdk synth` does NOT build images, so it succeeds
+           regardless of host arch — the emulation is only needed at `cdk
+           deploy` / asset-publish time on an x86 host. */
+        platform: ecrAssets.Platform.LINUX_ARM64,
         // Staging writes into `infra/cdk.out`, which is inside `repoRoot` —
         // the directory being staged. Left alone, each asset copies the
         // previous one's output into itself until `cdk synth` dies with
@@ -493,6 +509,9 @@ export class SnapUrlStack extends Stack {
 
     const apiFn = new lambda.DockerImageFunction(this, "ApiFn", {
       code: imageFor("api", "lambda-web"),
+      // arm64/Graviton: ~20% cheaper per GB-s and typically faster. Must match
+      // the image's LINUX_ARM64 platform set in imageFor().
+      architecture: lambda.Architecture.ARM_64,
       memorySize: 1024, // CPU scales with memory; 1024 is the usual sweet spot.
       timeout: Duration.seconds(30),
       reservedConcurrentExecutions: API_RESERVED_CONCURRENCY,
@@ -521,6 +540,9 @@ export class SnapUrlStack extends Stack {
 
     const redirectFn = new lambda.DockerImageFunction(this, "RedirectFn", {
       code: imageFor("redirect", "lambda-web"),
+      // arm64/Graviton: ~20% cheaper per GB-s and typically faster. Must match
+      // the image's LINUX_ARM64 platform set in imageFor().
+      architecture: lambda.Architecture.ARM_64,
       // Smaller than the API on purpose: this function does one key lookup and
       // a 302. Paying for memory it never uses is paying for nothing.
       memorySize: 512,
@@ -651,6 +673,10 @@ export class SnapUrlStack extends Stack {
 
     const workerFn = new lambda.DockerImageFunction(this, "WorkerFn", {
       code: imageFor("worker", "lambda-job"),
+      // arm64/Graviton: ~20% cheaper per GB-s and typically faster, and the RDS
+      // instance is already Graviton. Must match the image's LINUX_ARM64
+      // platform set in imageFor().
+      architecture: lambda.Architecture.ARM_64,
       memorySize: 1024,
       // Rollups over a day of clicks; generous because it runs once a minute,
       // not once a request.

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -543,9 +543,14 @@ export class SnapUrlStack extends Stack {
       // arm64/Graviton: ~20% cheaper per GB-s and typically faster. Must match
       // the image's LINUX_ARM64 platform set in imageFor().
       architecture: lambda.Architecture.ARM_64,
-      // Smaller than the API on purpose: this function does one key lookup and
-      // a 302. Paying for memory it never uses is paying for nothing.
-      memorySize: 512,
+      /* 1024 MB, not 512, even though this function does one key lookup and a
+         302. Lambda scales CPU with memory: at 512 MB it gets ~1/3 of a vCPU,
+         so the work is CPU-starved and runs longer. Doubling memory roughly
+         halves wall time, so the GB-s billed is about the same — you pay for
+         the same compute either way — while p50/p99 latency and cold start
+         both roughly halve. On the redirect hot path that latency is the whole
+         point. Independent of the reservedConcurrentExecutions cap (#278). */
+      memorySize: 1024,
       timeout: Duration.seconds(10),
       reservedConcurrentExecutions: REDIRECT_RESERVED_CONCURRENCY,
       logGroup: logGroupFor("RedirectLogGroup"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       '@snapurl/domain':
         specifier: workspace:*
         version: link:../../packages/domain
-      argon2:
-        specifier: ^0.44.0
-        version: 0.44.0
       fastify:
         specifier: ^5.6.1
         version: 5.11.3


### PR DESCRIPTION
Closes #283. Phase 3 of epic #267 (last Phase 3 item). Six independent fixes, **each its own commit** with its rationale:

1. **Split the worker's maintenance off the 1-minute schedule** (`lambda.ts` + infra). The handler ran `runFrequent` AND `runMaintenance` on every invocation, and EventBridge fired every minute — so hourly work (partition provisioning, salt rotation, retention prune) ran **60×/hour** on a shared t4g.micro. `WorkerEvent.task` is now `frequent|maintenance|rollup|migrate`; the handler runs exactly one job. Infra gains a **second EventBridge rule**: 1-min → `{task:frequent}`, new hourly → `{task:maintenance}`; migrate stays manual-only. Safe because the DEFAULT partition (#268) catches any un-provisioned day, so inserts never fail at the hourly cadence. **`main.ts` (the long-running compose worker) is byte-identical** — its dual-interval loop is unchanged, so integration-assertions.sh's 90s rollup still holds.
2. **Parallelise the resolver's two queries** (`resolver.ts`). The routing-rules query was keyed off the resolved `link.id`, forcing sequential awaits. Rekeyed it off the same `(host, slug)` via joins (a (host,slug) pair resolves to at most one link, per the unique constraints), then `Promise.all` — one RTT saved per redirect, identical `ResolvedLink`. Test added.
3. **ARM_64/Graviton on all three Lambdas** (~20% cheaper per GB-s, typically faster; RDS is already Graviton). Sets `architecture: ARM_64` **and** `platform: LINUX_ARM64` on the shared image asset (both required so image matches function arch). Base images are multi-arch. **Caveat:** cross-building arm64 on an x86 deploy host needs `docker buildx`+QEMU (documented in-code); `cdk synth` is unaffected.
4. **Redirect memory 512→1024 MB**. 512 is ~⅓ vCPU; doubling finishes in ~half the wall time for the same GB-s and halves cold start.
5. **Drop unused `argon2`** from the redirect image (confirmed unimported — redirect uses `jsonwebtoken` for unlock tokens; argon2 is the API's hasher). Lockfile regenerated; `--frozen-lockfile` clean.
6. **Volume cap on `click_events`** (`rollup.ts`). `pruneRetention` deleted by age only (default ~3yr); storage autoscales to 50 GB then RDS goes **read-only** and allocated storage can't shrink — a cliff. Added `MAX_RETAINED_DAYS` (env `CLICK_EVENTS_MAX_RETAINED_DAYS`, default 1100 ≈ 3yr so it's a no-op backstop under normal retention) that drops the oldest day-partitions beyond the cap, **never dropping a partition with un-rolled-up rows** (EXISTS guard). Partition-name interpolation is regex-validated (injection-safe). DB-gated cap + guard tests added.

## How to test
- `corepack pnpm type-check`, `corepack pnpm test`, `corepack pnpm install --frozen-lockfile` (clean after argon2 drop) — all pass (verified).
- `cdk synth` (both natStrategy values) verified: exactly **two** EventBridge rules (1-min frequent + hourly maintenance, both retry=2, migrate unscheduled); `Architectures=[arm64]` on all three functions; RedirectFn `MemorySize=1024`; image assets built `linux/arm64`.
- DB-gated resolver + partition-cap tests run in CI (Postgres 18); compose `integration` job (uses main.ts, unchanged) re-validates the rollup path.

Files: `apps/worker/src/{lambda.ts,jobs/rollup.ts,jobs/partitions.test.ts}`, `apps/redirect/src/{resolver.ts,resolver.test.ts}`, `apps/redirect/package.json`, `infra/lib/snapurl-stack.ts`, `pnpm-lock.yaml`.