### PR TITLE
Add a CacheStore port and scope the Redis decision per-profile (#285)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY apps/worker/package.json     apps/worker/
 COPY packages/contract/package.json  packages/contract/
 COPY packages/domain/package.json    packages/domain/
 COPY packages/database/package.json  packages/database/
+COPY packages/cache/package.json     packages/cache/
 
 # --frozen-lockfile fails if any manifest disagrees with the lockfile, so an
 # image can never be built from a dependency set nobody committed.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-fastify": "^11.1.6",
     "@nestjs/throttler": "^6.4.0",
+    "@snapurl/cache": "workspace:*",
     "@snapurl/contract": "workspace:*",
     "@snapurl/database": "workspace:*",
     "@snapurl/domain": "workspace:*",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,8 +3,11 @@ import { APP_FILTER, APP_GUARD } from "@nestjs/core";
 import { ThrottlerModule } from "@nestjs/throttler";
 import { LoggerModule } from "nestjs-pino";
 
+import { createCacheStore } from "@snapurl/cache";
+
 import { ConfigModule } from "./config/config.module.js";
 import { ENV, loadEnv, type Env } from "./config/env.js";
+import { CacheStoreThrottlerStorage } from "./common/cache-throttler-storage.js";
 import { DatabaseModule } from "./database/database.module.js";
 import { MailModule } from "./mail/mail.module.js";
 import { AuthModule } from "./auth/auth.module.js";
@@ -52,8 +55,22 @@ import { ProxyAwareThrottlerGuard } from "./common/proxy-aware-throttler.guard.j
     }),
     ThrottlerModule.forRootAsync({
       inject: [ENV],
-      useFactory: (env: Env) => ({
+      /* Back the throttler with a CacheStore selected by CACHE_DRIVER. The
+         default 'memory' driver is a Map-backed atomic counter — behaviourally
+         the stock in-memory storage, so single-node/CI limits are unchanged.
+         With CACHE_DRIVER=redis + REDIS_URL the counter is SHARED across
+         instances, which is the multi-instance fix (the effective limit stops
+         being limit x instances). The factory is async because of its lazy
+         redis/dynamodb imports, so the useFactory is async too. */
+      useFactory: async (env: Env) => ({
         throttlers: [{ ttl: env.THROTTLE_TTL_SECONDS * 1000, limit: env.THROTTLE_LIMIT }],
+        storage: new CacheStoreThrottlerStorage(
+          await createCacheStore({
+            driver: env.CACHE_DRIVER,
+            redisUrl: env.REDIS_URL,
+            dynamoTable: env.CACHE_DYNAMO_TABLE,
+          }),
+        ),
       }),
     }),
     DatabaseModule,

--- a/apps/api/src/common/cache-throttler-storage.test.ts
+++ b/apps/api/src/common/cache-throttler-storage.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryCacheStore } from "@snapurl/cache";
+import { CacheStoreThrottlerStorage } from "./cache-throttler-storage.js";
+
+/* Pure unit tests: no DB gate, no network. A real MemoryCacheStore backs the
+   storage so the counter semantics are exercised for real, and fake timers
+   make the ttl-ms->s window deterministic. */
+
+// @nestjs/throttler passes ttl / blockDuration in MILLISECONDS.
+const TTL_MS = 60_000;
+const LIMIT = 3;
+const BLOCK_MS = 0;
+const NAME = "default";
+
+describe("CacheStoreThrottlerStorage", () => {
+  let cache: MemoryCacheStore;
+  let storage: CacheStoreThrottlerStorage;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    cache = new MemoryCacheStore();
+    storage = new CacheStoreThrottlerStorage(cache);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns totalHits 1, 2, 3 across repeated increments of the same key", async () => {
+    const first = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    const second = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    const third = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+
+    expect(first.totalHits).toBe(1);
+    expect(second.totalHits).toBe(2);
+    expect(third.totalHits).toBe(3);
+  });
+
+  it("flips isBlocked once totalHits exceeds the limit", async () => {
+    for (let i = 0; i < LIMIT; i++) {
+      const record = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+      // Hits 1..LIMIT are within budget.
+      expect(record.isBlocked).toBe(false);
+    }
+    // The (LIMIT + 1)th hit exceeds the budget.
+    const blocked = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    expect(blocked.totalHits).toBe(LIMIT + 1);
+    expect(blocked.isBlocked).toBe(true);
+  });
+
+  it("reports an accurate timeToExpire (millis) that counts down within the window", async () => {
+    const first = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    // First hit stamps the window; the full ttl remains.
+    expect(first.timeToExpire).toBe(TTL_MS);
+
+    // Half the window later, roughly half remains — and the window is NOT
+    // reset by the second increment (fixed window).
+    vi.setSystemTime(new Date("2025-01-01T00:00:30.000Z"));
+    const second = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    expect(second.timeToExpire).toBe(30_000);
+  });
+
+  it("applies the ttl ms->s conversion so the counter resets after the window", async () => {
+    await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+
+    // Advance past the 60s window: the fixed-window key expires and the next
+    // increment starts a fresh window at 1.
+    vi.setSystemTime(new Date("2025-01-01T00:01:00.000Z"));
+    const afterWindow = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    expect(afterWindow.totalHits).toBe(1);
+  });
+
+  it("namespaces by throttler name so distinct throttlers count separately", async () => {
+    const a = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, "default");
+    const b = await storage.increment("ip", TTL_MS, LIMIT, BLOCK_MS, "argon2");
+    // Same tracker key, different named throttlers -> independent counters.
+    expect(a.totalHits).toBe(1);
+    expect(b.totalHits).toBe(1);
+  });
+
+  /* The concrete evidence for the multi-instance fix: two storage instances
+     over ONE shared backing store see a COMBINED count. That is exactly the
+     Lambda scenario the port fixes — each instance would otherwise keep its
+     own Map and the effective limit would be limit x instances. */
+  it("shares the counter across instances over one backing store", async () => {
+    const shared = new MemoryCacheStore();
+    const instanceA = new CacheStoreThrottlerStorage(shared);
+    const instanceB = new CacheStoreThrottlerStorage(shared);
+
+    const a1 = await instanceA.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    expect(a1.totalHits).toBe(1);
+
+    // The SECOND instance sees the first instance's count, not a fresh 1.
+    const b1 = await instanceB.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    expect(b1.totalHits).toBe(2);
+
+    const a2 = await instanceA.increment("ip", TTL_MS, LIMIT, BLOCK_MS, NAME);
+    expect(a2.totalHits).toBe(3);
+  });
+});

--- a/apps/api/src/common/cache-throttler-storage.ts
+++ b/apps/api/src/common/cache-throttler-storage.ts
@@ -67,9 +67,14 @@ export class CacheStoreThrottlerStorage implements ThrottlerStorage {
     const timeToExpire = remaining >= 0 ? remaining : ttl;
 
     const isBlocked = totalHits > limit;
-    // Once blocked, callers stay blocked for the block duration. We do not
-    // have a separate block key, so mirror the stock behaviour closely:
-    // the block clears when the current window does.
+    // blockDuration is intentionally not honoured as a separate timer. The
+    // app configures only { ttl, limit } (no block), so a block always clears
+    // when the current window does and mirroring the window here is correct.
+    // If a block LONGER than the window is ever configured, this would need a
+    // dedicated block key (e.g. `block:${throttlerName}:${key}`) stamped with
+    // blockDuration on the first over-limit hit and read back for
+    // timeToBlockExpire; until then, tying the block to the window keeps the
+    // storage single-round-trip and matches the stock in-memory behaviour.
     const timeToBlockExpire = isBlocked ? timeToExpire : 0;
 
     return { totalHits, timeToExpire, isBlocked, timeToBlockExpire };

--- a/apps/api/src/common/cache-throttler-storage.ts
+++ b/apps/api/src/common/cache-throttler-storage.ts
@@ -1,0 +1,77 @@
+import type { ThrottlerStorage } from "@nestjs/throttler";
+import type { CacheStore } from "@snapurl/cache";
+
+/* @nestjs/throttler 6.5.0 exports ThrottlerStorage from its barrel but does NOT
+   re-export the ThrottlerStorageRecord interface, so we restate its exact shape
+   here (verified against
+   node_modules/@nestjs/throttler/dist/throttler-storage-record.interface.d.ts).
+   totalHits / timeToExpire / isBlocked / timeToBlockExpire, timings in millis. */
+interface ThrottlerStorageRecord {
+  totalHits: number;
+  timeToExpire: number;
+  isBlocked: boolean;
+  timeToBlockExpire: number;
+}
+
+/* ============================================================
+   CacheStoreThrottlerStorage — rate-limit counters over a CacheStore.
+
+   @nestjs/throttler's default ThrottlerStorageService is a `new Map()`
+   in the process. On Lambda that is the bug the CacheStore port fixes:
+   each concurrent instance keeps its own Map and a cold start resets
+   it, so the effective limit is (limit x instances) rather than the
+   configured limit. Backing the counter with a CacheStore means the
+   scaled profile can share ONE counter across every instance (Redis)
+   and the limit is honoured globally.
+
+   With the default 'memory' driver this wraps a MemoryCacheStore — a
+   Map-backed atomic counter, behaviourally the same as the stock
+   in-memory storage for single-node/CI, so existing rate-limit tests
+   and smoke stay green.
+
+   Unit conventions to keep straight:
+     - @nestjs/throttler 6.5.0 passes `ttl` and `blockDuration` in
+       MILLISECONDS.
+     - CacheStore.incr takes SECONDS, so we convert with Math.ceil.
+     - The returned record's timeToExpire / timeToBlockExpire are in
+       MILLISECONDS.
+
+   The window count is a fixed-window incr (first write stamps the
+   ttl, later increments in the window do not reset it). timeToExpire
+   is read back accurately via CacheStore.pttl (remaining millis)
+   rather than approximated from the configured ttl on every hit.
+   ============================================================ */
+export class CacheStoreThrottlerStorage implements ThrottlerStorage {
+  constructor(private readonly cache: CacheStore) {}
+
+  async increment(
+    key: string,
+    ttl: number,
+    limit: number,
+    blockDuration: number,
+    throttlerName: string,
+  ): Promise<ThrottlerStorageRecord> {
+    // ttl is millis; the CacheStore window is seconds.
+    const ttlSeconds = Math.ceil(ttl / 1000);
+    // Namespace by throttler so distinct named throttlers (e.g. the
+    // global limit and the tighter argon2-route limit) count separately
+    // and never collide on the same tracker key.
+    const prefixedKey = `throttle:${throttlerName}:${key}`;
+
+    const totalHits = await this.cache.incr(prefixedKey, ttlSeconds);
+
+    // Read the remaining window accurately. pttl returns millis, or a
+    // negative sentinel when the key is absent / has no expiry; fall back
+    // to the configured ttl in that (rare, first-hit-race) case.
+    const remaining = await this.cache.pttl(prefixedKey);
+    const timeToExpire = remaining >= 0 ? remaining : ttl;
+
+    const isBlocked = totalHits > limit;
+    // Once blocked, callers stay blocked for the block duration. We do not
+    // have a separate block key, so mirror the stock behaviour closely:
+    // the block clears when the current window does.
+    const timeToBlockExpire = isBlocked ? timeToExpire : 0;
+
+    return { totalHits, timeToExpire, isBlocked, timeToBlockExpire };
+  }
+}

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -80,6 +80,20 @@ export const EnvSchema = z.object({
   THROTTLE_TTL_SECONDS: z.coerce.number().int().default(60),
   THROTTLE_LIMIT: z.coerce.number().int().default(120),
 
+  /* Which CacheStore backs the rate-limit counters (and, in the redirect
+     service, hot-link caching). 'memory' is the default: a per-instance
+     in-memory counter, byte-for-byte the single-node/CI behaviour. 'redis'
+     shares one counter across instances so the limit is honoured globally —
+     the multi-instance fix; 'dynamodb' is the AWS serverless profile. See
+     docs/DECISIONS.md for the per-profile reasoning. */
+  CACHE_DRIVER: z.enum(["memory", "redis", "dynamodb"]).default("memory"),
+  /** Only used when CACHE_DRIVER=redis: the ioredis connection URL. Absent on
+      every other profile, so the default memory driver needs nothing set. */
+  REDIS_URL: z.string().optional(),
+  /** Only used when CACHE_DRIVER=dynamodb: the cache table name. The DynamoDB
+      adapter exists in code; the CDK table itself is a Phase-7 follow-up. */
+  CACHE_DYNAMO_TABLE: z.string().optional(),
+
   /* How many proxies in front of this service APPEND their edge IP to
      X-Forwarded-For. The throttler derives the real client IP as the
      (TRUSTED_PROXY_HOPS+1)th entry from the right of that chain, so a

--- a/apps/redirect/package.json
+++ b/apps/redirect/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@snapurl/cache": "workspace:*",
     "@snapurl/contract": "workspace:*",
     "@snapurl/database": "workspace:*",
     "@snapurl/domain": "workspace:*",

--- a/apps/redirect/src/caching-resolver.test.ts
+++ b/apps/redirect/src/caching-resolver.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryCacheStore } from "@snapurl/cache";
+import { CachingLinkResolver } from "./caching-resolver.js";
+import type { LinkResolver, ResolvedDomain, ResolvedLink } from "./resolver.js";
+
+/* Pure unit tests: no DB gate, no network. A real MemoryCacheStore backs the
+   cache and a spy LinkResolver stands in for the Postgres resolver, so we can
+   assert that a hot link is served without touching the inner resolver. */
+
+const TTL = 10;
+
+/** A fully-populated ResolvedLink whose Date fields exercise the revive path:
+ *  expiresAt is a real Date, activatesAt is null. */
+function makeLink(overrides: Partial<ResolvedLink> = {}): ResolvedLink {
+  return {
+    id: "link-1",
+    workspaceId: "ws-1",
+    destination: "https://example.com/dest",
+    redirectType: "302",
+    rules: [],
+    expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+    expiresTo: null,
+    activatesAt: null,
+    scheduledTo: null,
+    clickLimit: null,
+    clicks: 0,
+    hasPassword: false,
+    forwardQuery: false,
+    deepLink: false,
+    hideReferrer: false,
+    publicPreview: false,
+    archived: false,
+    safeBrowsingStatus: "clean",
+    utm: null,
+    ...overrides,
+  };
+}
+
+/** A spy inner resolver whose resolve() returns a fixed link per (host, slug). */
+function spyInner(link: ResolvedLink | null): {
+  resolver: LinkResolver;
+  resolve: ReturnType<typeof vi.fn>;
+  resolveDomain: ReturnType<typeof vi.fn>;
+} {
+  const resolve = vi.fn(async () => link);
+  const resolveDomain = vi.fn(async (): Promise<ResolvedDomain | null> => null);
+  return { resolver: { resolve, resolveDomain }, resolve, resolveDomain };
+}
+
+describe("CachingLinkResolver", () => {
+  let cache: MemoryCacheStore;
+
+  beforeEach(() => {
+    cache = new MemoryCacheStore();
+  });
+
+  it("calls the inner resolver on a miss and populates the cache", async () => {
+    const link = makeLink();
+    const { resolver, resolve } = spyInner(link);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    const result = await caching.resolve("snap.to", "hot");
+    expect(result).toEqual(link);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    // The entry is now cached under the normalised key.
+    expect(await cache.get("link:snap.to:hot")).not.toBeNull();
+  });
+
+  it("serves a second resolve of the same link from the cache without touching the inner resolver", async () => {
+    const link = makeLink();
+    const { resolver, resolve } = spyInner(link);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    await caching.resolve("snap.to", "hot");
+    const second = await caching.resolve("snap.to", "hot");
+
+    // The DB (inner resolver) was NOT touched the second time.
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(link);
+  });
+
+  it("round-trips the ResolvedLink shape identically through the cache, including Date fields", async () => {
+    const link = makeLink();
+    const { resolver } = spyInner(link);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    await caching.resolve("snap.to", "hot");
+    const revived = await caching.resolve("snap.to", "hot");
+
+    expect(revived).not.toBeNull();
+    // Date fields come back as real Date instances, not ISO strings.
+    expect(revived!.expiresAt).toBeInstanceOf(Date);
+    expect(revived!.expiresAt!.toISOString()).toBe("2030-01-01T00:00:00.000Z");
+    // null is preserved exactly, not turned into a string or a Date.
+    expect(revived!.activatesAt).toBeNull();
+    // The whole shape is byte-identical to the original.
+    expect(revived).toEqual(link);
+  });
+
+  it("keys case-insensitively so a hit matches the DB normalisation", async () => {
+    const link = makeLink();
+    const { resolver, resolve } = spyInner(link);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    await caching.resolve("SNAP.TO", "HOT");
+    // Different casing on host + slug resolves to the same cache entry.
+    const second = await caching.resolve("snap.to", "hot");
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(link);
+  });
+
+  it("falls through to the inner resolver on a miss for a different slug", async () => {
+    const link = makeLink();
+    const { resolver, resolve } = spyInner(link);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    await caching.resolve("snap.to", "hot");
+    await caching.resolve("snap.to", "other");
+    // Each distinct slug is its own miss, so the inner resolver is called twice.
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a miss (null) — a later create is not shadowed by a negative entry", async () => {
+    const { resolver, resolve } = spyInner(null);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    expect(await caching.resolve("snap.to", "ghost")).toBeNull();
+    expect(await caching.resolve("snap.to", "ghost")).toBeNull();
+    // Both calls fell through: nulls are never cached.
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(await cache.get("link:snap.to:ghost")).toBeNull();
+  });
+
+  it("passes resolveDomain straight through to the inner resolver", async () => {
+    const { resolver, resolveDomain } = spyInner(null);
+    const domain: ResolvedDomain = {
+      id: "dom-1",
+      rootRedirect: "https://example.com/root",
+      notFoundRedirect: null,
+    };
+    resolveDomain.mockResolvedValue(domain);
+    const caching = new CachingLinkResolver(resolver, cache, TTL);
+
+    const result = await caching.resolveDomain("snap.to");
+    expect(result).toEqual(domain);
+    expect(resolveDomain).toHaveBeenCalledWith("snap.to");
+  });
+});

--- a/apps/redirect/src/caching-resolver.ts
+++ b/apps/redirect/src/caching-resolver.ts
@@ -31,6 +31,19 @@ import {
    integration assertions of exactly one click_events row per
    redirect and the click_daily rollup are unaffected.
 
+   One interaction to keep in mind: the cached ResolvedLink includes
+   link.clicks, which is frozen at cache-write time for the whole TTL.
+   gateFor() reads that field for the click-limit cap, so on a cache
+   hit the count it sees is up to LINK_CACHE_TTL_SECONDS stale on top
+   of the pre-existing rollup lag (gateFor's own comment already notes
+   the cap can overshoot "by a handful under concurrency"). This is a
+   deliberate trade: the whole ResolvedLink is cached as one shape so
+   callers get an identical link on hit and miss, and the short TTL
+   keeps the widened overshoot bounded. Time-based gates (expiry,
+   activation) are NOT frozen — they are evaluated against Date.now()
+   at request time from the revived Date fields, so only the click
+   count carries this staleness, not the expiry decision.
+
    Only positive hits are cached. Caching a miss (null) would make a
    link created just after a lookup 404 until the negative entry
    expired, which is a worse failure than one uncached DB read, so

--- a/apps/redirect/src/caching-resolver.ts
+++ b/apps/redirect/src/caching-resolver.ts
@@ -1,0 +1,88 @@
+import type { CacheStore } from "@snapurl/cache";
+import {
+  normaliseHost,
+  type LinkResolver,
+  type ResolvedDomain,
+  type ResolvedLink,
+} from "./resolver.js";
+
+/* ============================================================
+   CachingLinkResolver — a short-lived cache in front of the DB.
+
+   PostgresLinkResolver hits the database on every redirect. The
+   overwhelming majority of redirects are for a small set of hot
+   links, so a short-lived cached ResolvedLink lets the hot path
+   answer without touching Postgres at all.
+
+   Bounded staleness, on purpose. The product promise is "print it
+   once, change where it points forever": an edited link must not
+   keep serving the old destination for long. So the TTL is short
+   (seconds, env-tunable via LINK_CACHE_TTL_SECONDS) and this
+   decorator never invalidates on edit itself. Proper
+   edit-invalidation — the API busting the cache key when a link
+   changes — is the projection/outbox's job and a follow-up; until
+   then the short TTL is the whole guarantee, and a few seconds of
+   staleness on a just-edited link is the accepted trade for taking
+   the database out of the hot path.
+
+   What this decorator does NOT touch: click recording. main.ts
+   still calls record() per request after resolve(), so caching the
+   resolve changes nothing about how clicks are counted — the
+   integration assertions of exactly one click_events row per
+   redirect and the click_daily rollup are unaffected.
+
+   Only positive hits are cached. Caching a miss (null) would make a
+   link created just after a lookup 404 until the negative entry
+   expired, which is a worse failure than one uncached DB read, so
+   misses always fall through to the inner resolver.
+   ============================================================ */
+
+/** The JSON shape a ResolvedLink serialises to: Date fields become
+ *  ISO strings (or null), everything else round-trips as-is. */
+type CachedLink = Omit<ResolvedLink, "expiresAt" | "activatesAt"> & {
+  expiresAt: string | null;
+  activatesAt: string | null;
+};
+
+export class CachingLinkResolver implements LinkResolver {
+  constructor(
+    private readonly inner: LinkResolver,
+    private readonly cache: CacheStore,
+    private readonly ttlSeconds: number,
+  ) {}
+
+  async resolve(host: string, slug: string): Promise<ResolvedLink | null> {
+    // Key on the SAME normalisation the DB lookup uses, so a printed
+    // "SNAP.TO/Foo" and a header "snap.to/foo" share one cache entry.
+    const key = `link:${normaliseHost(host)}:${slug.toLowerCase()}`;
+
+    const cached = await this.cache.get(key);
+    if (cached !== null) {
+      return reviveLink(JSON.parse(cached) as CachedLink);
+    }
+
+    const link = await this.inner.resolve(host, slug);
+    // Only cache positive hits (see the header note on negative caching).
+    if (link !== null) {
+      await this.cache.set(key, JSON.stringify(link), this.ttlSeconds);
+    }
+    return link;
+  }
+
+  /* Domain lookups (root/not-found redirects) are not the hot per-slug
+     path, and their misses are the common case anyway, so they pass
+     straight through to the inner resolver without caching. */
+  async resolveDomain(host: string): Promise<ResolvedDomain | null> {
+    return this.inner.resolveDomain(host);
+  }
+}
+
+/** Revive a cached link: JSON.stringify turned the Date fields into ISO
+ *  strings, so parse them back to Date, preserving null exactly. */
+function reviveLink(cached: CachedLink): ResolvedLink {
+  return {
+    ...cached,
+    expiresAt: cached.expiresAt === null ? null : new Date(cached.expiresAt),
+    activatesAt: cached.activatesAt === null ? null : new Date(cached.activatesAt),
+  };
+}

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -16,7 +16,9 @@ import {
   visitorHash,
   clientIpFromXff,
 } from "@snapurl/domain";
+import { createCacheStore, type CacheDriver } from "@snapurl/cache";
 import { PostgresLinkResolver, type LinkResolver, type ResolvedLink } from "./resolver.js";
+import { CachingLinkResolver } from "./caching-resolver.js";
 import { PostgresClickSink, type ClickSink } from "./click-sink.js";
 import { DailySaltCache } from "./salt.js";
 
@@ -62,6 +64,19 @@ const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 5);
    behind CloudFront sets it to 1 (or higher for additional appending hops). */
 const TRUSTED_PROXY_HOPS = Number(process.env.TRUSTED_PROXY_HOPS ?? 0);
 
+/* Which CacheStore backs the hot-link cache. 'memory' (the default) is a
+   per-instance in-memory cache, which is all local/CI/compose and any
+   single-node deployment needs. The scaled profile sets 'redis' + REDIS_URL so
+   the cache is shared across instances; the AWS profile uses 'dynamodb'. See
+   docs/DECISIONS.md for the per-profile reasoning. */
+const CACHE_DRIVER = (process.env.CACHE_DRIVER ?? "memory") as CacheDriver;
+const REDIS_URL = process.env.REDIS_URL;
+/* A short bounded-staleness window: an edited link stops serving its old
+   destination within this many seconds even before edit-invalidation lands.
+   Ten seconds keeps the database out of the hot path for the common repeated
+   click while honouring "change where it points forever". */
+const LINK_CACHE_TTL_SECONDS = Number(process.env.LINK_CACHE_TTL_SECONDS ?? 10);
+
 /* trustProxy is OFF: Fastify's request.ip is then the socket peer, and we
    derive the real client IP ourselves via clientIpFromXff. Fastify 5's numeric
    hop-count is disabled as unsafe, and `true` would surface the client-typed
@@ -97,7 +112,13 @@ async function init(): Promise<void> {
     max: POOL_MAX,
   });
   close = database.close;
-  resolver = new PostgresLinkResolver(database.db);
+  const postgresResolver = new PostgresLinkResolver(database.db);
+  /* Wrap the Postgres resolver in the short-lived cache. With the default
+     'memory' driver this is a per-instance cache with a 10s TTL — a safe
+     optimization that never changes redirect correctness: a hot link still
+     302s to the right place and the click is still recorded per request. */
+  const cacheStore = await createCacheStore({ driver: CACHE_DRIVER, redisUrl: REDIS_URL });
+  resolver = new CachingLinkResolver(postgresResolver, cacheStore, LINK_CACHE_TTL_SECONDS);
   clicks = new PostgresClickSink(database.db);
   salts = new DailySaltCache(database.db);
 }

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -253,7 +253,11 @@ function gateFor(link: ResolvedLink): "archived" | "expired" | "click_limit" | "
   if (link.expiresAt && link.expiresAt.getTime() <= Date.now()) return "expired";
   /* The count is the last rollup's, not a live one, so a hard cap can be
      overshot by a handful under concurrency. A synchronous read-modify-write
-     here would cost more latency than the accuracy is worth. */
+     here would cost more latency than the accuracy is worth. Note the
+     CachingLinkResolver freezes link.clicks for up to LINK_CACHE_TTL_SECONDS
+     on a cache hit, so on the hot path the overshoot window widens by that
+     TTL on top of the rollup lag; still bounded, still cheaper than a live
+     count, and the short TTL keeps it small. */
   if (link.clickLimit != null && link.clicks >= link.clickLimit) return "click_limit";
   /* Nothing schedules this. The row carries a date and every request compares
      it against the clock, so the link starts working at exactly that moment

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -156,9 +156,30 @@ it does not, delete the script and move on.
 
 ### Things I deliberately did not use
 
-**Redis.** Every use I had for it — rate limit counters, the click queue, caching — is served by
-DynamoDB, SQS, or CloudFront at a lower cost. Adding ElastiCache would nearly double the monthly
-bill to solve problems this system does not have yet.
+**Redis, per profile.** I used to reject Redis outright. That was the right call for the AWS
+serverless profile and the wrong call to apply to every profile. The CacheStore port (#285,
+`packages/cache`) makes the store a swappable adapter, so the Redis decision is now recorded per
+profile rather than globally, chosen at deploy time by `CACHE_DRIVER`.
+
+- **Single-node / local / compose:** the in-memory CacheStore, and it is the default. Nothing to
+  run alongside the app, no container to warm, no extra dependency. This is what CI, docker compose
+  and any single-node deployment use, and it covers hot-link caching and rate-limit counters
+  perfectly well when there is exactly one process.
+- **Scaled / self-host:** Redis. For a self-hostable product Redis is the most portable scaling
+  primitive there is. One container, runs anywhere, and it covers caching, rate-limit counters,
+  queueing and sketch merging at the same time. This is the profile where the in-memory counter's
+  limit x instances bug actually bites (each instance keeps its own Map), and a shared Redis counter
+  is what makes the configured limit the effective limit. Revisit if a deployment already runs Redis
+  for something else, in which case this is free.
+- **AWS serverless:** DynamoDB + SQS + CloudFront, and Redis is still rejected here. Every use I had
+  for it in this profile (rate limit counters, the click queue, caching) is served by DynamoDB, SQS
+  or CloudFront at a lower cost, and adding ElastiCache would nearly double the monthly bill (roughly
+  $12/mo minimum) to solve problems this profile does not have. That is the original reasoning,
+  preserved and still correct.
+
+The DynamoDB adapter exists in code (`packages/cache`), but the CDK DynamoDB cache table is a
+Phase-7 follow-up (#288 territory), so `CACHE_DRIVER=dynamodb` is not wired into the stack yet. The
+point of the port is precisely that this stays a per-profile config choice, not a rewrite.
 
 **A GraphQL layer.** The frontend is TanStack Query over REST and the contract is already typed
 end to end. GraphQL would add a schema to keep in sync with no caller asking for it.

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@snapurl/cache",
+  "version": "2.0.0",
+  "private": true,
+  "description": "The CacheStore port and its three adapters (in-memory, Redis, DynamoDB) plus an env-driven driver factory. Confines ioredis/aws-sdk to the one package that needs them, keeping @snapurl/domain pure.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "type-check": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1121.0",
+    "@aws-sdk/lib-dynamodb": "^3.1121.0",
+    "@snapurl/domain": "workspace:*",
+    "ioredis": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/cache/src/cache-store.ts
+++ b/packages/cache/src/cache-store.ts
@@ -75,6 +75,19 @@ export interface CacheStore {
   del(key: string): Promise<void>;
 
   /**
+   * Return the remaining time-to-live of a key in MILLISECONDS, or a
+   * negative number when the key is absent or has no expiry.
+   *
+   * This mirrors Redis PTTL semantics: -2 when the key does not exist,
+   * -1 when it exists but has no associated expiry. The rate-limit
+   * throttler uses it to report an accurate timeToExpire for the
+   * fixed window (the count is bumped by incr, the remaining window is
+   * read by pttl), rather than approximating it from the configured
+   * ttl on every hit.
+   */
+  pttl(key: string): Promise<number>;
+
+  /**
    * Merge the given HLL sketch register-wise into the sketch stored at
    * key and return the current estimate.
    *

--- a/packages/cache/src/cache-store.ts
+++ b/packages/cache/src/cache-store.ts
@@ -1,0 +1,97 @@
+/* ============================================================
+   CacheStore — one port, three problems.
+
+   Three separate needs in the product share the same shape of
+   storage and, until now, had no common seam:
+
+     1. Hot-link caching. The redirect path reads Postgres on
+        every request; a short-lived cached ResolvedLink lets it
+        answer without touching the database.
+     2. Rate-limit counters. A fixed-window counter that must be
+        shared across instances, so the effective limit is the
+        configured limit and not (limit x instances). That is
+        what `incr` with a first-write expiry is for.
+     3. Unique-visitor sketch merging. The HyperLogLog sketch in
+        @snapurl/domain is merged register-wise; `mergeSketch`
+        does that over stored bytes.
+
+   This is behind a port on purpose, following the same
+   port-and-adapter seam as resolver.ts and analytics.reader.ts.
+   The single-node profile uses the in-memory adapter, the scaled
+   profile uses Redis, and the AWS serverless profile uses
+   DynamoDB. All three return the same shapes, so nothing
+   downstream knows or cares which one it got.
+
+   Conventions shared by every method:
+     - keys are opaque utf-8 strings chosen by the caller;
+     - string values are utf-8 strings;
+     - sketch values are raw HLL bytes (exactly HLL_BYTE_SIZE,
+       the fixed 16 KiB @snapurl/domain layout), NOT Redis's own
+       PFADD/PFMERGE format, so the byte format is identical
+       across all three adapters and portable between profiles;
+     - ttlSeconds, when present, is a whole number of seconds of
+       time-to-live measured from the moment of the write.
+   ============================================================ */
+
+export interface CacheStore {
+  /**
+   * Read a string value. Returns null when the key is absent or has
+   * expired. Sketch keys (written via mergeSketch) are not string
+   * values and must not be read with get.
+   */
+  get(key: string): Promise<string | null>;
+
+  /**
+   * Write a string value, optionally with a time-to-live. When
+   * ttlSeconds is omitted the value has no expiry. A set always
+   * replaces both the value and its expiry (unlike incr, which only
+   * sets the expiry on first write).
+   */
+  set(key: string, value: string, ttlSeconds?: number): Promise<void>;
+
+  /**
+   * Atomically increment an integer counter and return the NEW count.
+   * The key is created at 1 on first increment; subsequent increments
+   * return 2, 3, ...
+   *
+   * This is the fixed-window rate-limit primitive: when the key is
+   * first created, and ttlSeconds is given, its expiry is set to
+   * ttlSeconds. A later increment WITHIN the same window must NOT
+   * reset that expiry, or the window would never close under
+   * sustained traffic. The atomicity (increment and first-write
+   * expiry as one step) matters so a window is never lost between the
+   * increment and the expiry under concurrency.
+   */
+  incr(key: string, ttlSeconds?: number): Promise<number>;
+
+  /**
+   * Set or update the time-to-live of an existing key. A no-op shape
+   * when the key is absent (adapters differ in whether they create
+   * it; callers should only expire keys they know exist).
+   */
+  expire(key: string, ttlSeconds: number): Promise<void>;
+
+  /** Delete a key and its value/expiry. Absent keys are a no-op. */
+  del(key: string): Promise<void>;
+
+  /**
+   * Merge the given HLL sketch register-wise into the sketch stored at
+   * key and return the current estimate.
+   *
+   * The stored bytes (or a fresh empty sketch when the key is absent)
+   * are merged with the incoming sketch using @snapurl/domain `merge`
+   * (register-wise max, which is idempotent and commutative), the
+   * merged bytes are persisted, and the estimate is computed via
+   * @snapurl/domain `estimate`. On first write the expiry is set from
+   * ttlSeconds, matching the incr convention.
+   *
+   * The incoming sketch must be exactly HLL_BYTE_SIZE bytes; the
+   * stored bytes use the same layout, so a sketch written by one
+   * adapter can be read and merged by any other.
+   */
+  mergeSketch(
+    key: string,
+    sketch: Uint8Array,
+    ttlSeconds?: number,
+  ): Promise<{ estimate: number }>;
+}

--- a/packages/cache/src/dynamodb-cache-store.test.ts
+++ b/packages/cache/src/dynamodb-cache-store.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import {
+  addHashed,
+  createSketch,
+  estimate,
+  hashForTesting,
+  serialize,
+} from "@snapurl/domain";
+import { DynamoDbCacheStore } from "./dynamodb-cache-store.js";
+
+/* MOCK-based unit tests: no live DynamoDB is available in-sandbox or
+   in CI, so a fake DynamoDBDocumentClient whose `send` is stubbed by
+   command constructor name asserts the RIGHT commands are issued. A
+   live-Dynamo integration test is deferred to the deploy phase. */
+
+const TABLE = "snapurl-cache";
+
+/** The command name AWS SDK v3 sets on each command instance. */
+function commandName(command: unknown): string {
+  return (command as { constructor: { name: string } }).constructor.name;
+}
+
+describe("DynamoDbCacheStore", () => {
+  let send: ReturnType<typeof vi.fn>;
+  let store: DynamoDbCacheStore;
+
+  function makeStore(handlers: Record<string, (input: unknown) => unknown>) {
+    send = vi.fn(async (command: unknown) => {
+      const name = commandName(command);
+      const handler = handlers[name];
+      if (!handler) throw new Error(`unexpected command ${name}`);
+      return handler((command as { input: unknown }).input);
+    });
+    const client = { send } as unknown as DynamoDBDocumentClient;
+    return new DynamoDbCacheStore(client, TABLE);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+  });
+
+  it("incr sends an UpdateCommand with ADD + if_not_exists and returns the new value", async () => {
+    let captured: any;
+    store = makeStore({
+      UpdateCommand: (input) => {
+        captured = input;
+        return { Attributes: { value: 3 } };
+      },
+    });
+
+    const n = await store.incr("c", 60);
+    expect(n).toBe(3);
+    expect(captured.UpdateExpression).toContain("ADD");
+    expect(captured.UpdateExpression).toContain("if_not_exists");
+    // TTL is unix epoch seconds computed from ttlSeconds.
+    expect(captured.ExpressionAttributeValues[":exp"]).toBe(
+      Math.floor(Date.parse("2025-01-01T00:00:00.000Z") / 1000) + 60,
+    );
+  });
+
+  it("incr without ttl sends ADD only (no SET of expiresAt)", async () => {
+    let captured: any;
+    store = makeStore({
+      UpdateCommand: (input) => {
+        captured = input;
+        return { Attributes: { value: 1 } };
+      },
+    });
+    const n = await store.incr("c");
+    expect(n).toBe(1);
+    expect(captured.UpdateExpression).toContain("ADD");
+    expect(captured.UpdateExpression).not.toContain("if_not_exists");
+  });
+
+  it("set sends a PutCommand with a numeric expiresAt", async () => {
+    let captured: any;
+    store = makeStore({
+      PutCommand: (input) => {
+        captured = input;
+        return {};
+      },
+    });
+    await store.set("k", "v", 30);
+    expect(captured.Item.pk).toBe("k");
+    expect(captured.Item.value).toBe("v");
+    expect(typeof captured.Item.expiresAt).toBe("number");
+  });
+
+  it("get returns the value for a live item", async () => {
+    store = makeStore({
+      GetCommand: () => ({ Item: { pk: "k", value: "v" } }),
+    });
+    expect(await store.get("k")).toBe("v");
+  });
+
+  it("get treats an expired item as absent", async () => {
+    store = makeStore({
+      GetCommand: () => ({
+        Item: {
+          pk: "k",
+          value: "v",
+          // Expired one second ago.
+          expiresAt: Math.floor(Date.now() / 1000) - 1,
+        },
+      }),
+    });
+    expect(await store.get("k")).toBeNull();
+  });
+
+  it("get returns null for an absent item", async () => {
+    store = makeStore({ GetCommand: () => ({}) });
+    expect(await store.get("k")).toBeNull();
+  });
+
+  it("del sends a DeleteCommand", async () => {
+    let called = false;
+    store = makeStore({
+      DeleteCommand: () => {
+        called = true;
+        return {};
+      },
+    });
+    await store.del("k");
+    expect(called).toBe(true);
+  });
+
+  it("mergeSketch sends Get then a conditional Put and returns the estimate", async () => {
+    const b = createSketch();
+    for (let i = 0; i < 300; i++) addHashed(b, hashForTesting(`b-${i}`));
+
+    let put: any;
+    store = makeStore({
+      GetCommand: () => ({}), // absent -> start from empty sketch
+      PutCommand: (input) => {
+        put = input;
+        return {};
+      },
+    });
+
+    const result = await store.mergeSketch("s", b, 120);
+    expect(put.ConditionExpression).toContain("attribute_not_exists");
+    expect(put.Item.value).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(put.Item.value)).toEqual(serialize(b));
+    expect(put.Item.ver).toBe(1);
+    expect(result.estimate).toBe(estimate(b));
+  });
+
+  it("mergeSketch retries on a ConditionalCheckFailedException then succeeds", async () => {
+    const b = createSketch();
+    for (let i = 0; i < 100; i++) addHashed(b, hashForTesting(`b-${i}`));
+
+    let putAttempts = 0;
+    store = makeStore({
+      GetCommand: () => ({ Item: { pk: "s", ver: 1, value: createSketch() } }),
+      PutCommand: () => {
+        putAttempts++;
+        if (putAttempts === 1) {
+          const err = new Error("conditional failed");
+          err.name = "ConditionalCheckFailedException";
+          throw err;
+        }
+        return {};
+      },
+    });
+
+    const result = await store.mergeSketch("s", b);
+    expect(putAttempts).toBe(2);
+    expect(result.estimate).toBe(estimate(b));
+  });
+});

--- a/packages/cache/src/dynamodb-cache-store.test.ts
+++ b/packages/cache/src/dynamodb-cache-store.test.ts
@@ -126,6 +126,32 @@ describe("DynamoDbCacheStore", () => {
     expect(called).toBe(true);
   });
 
+  it("pttl derives the remainder from expiresAt with Redis-style sentinels", async () => {
+    // Absent item -> -2.
+    store = makeStore({ GetCommand: () => ({}) });
+    expect(await store.pttl("k")).toBe(-2);
+
+    // Item with no expiry -> -1.
+    store = makeStore({ GetCommand: () => ({ Item: { pk: "k", value: "v" } }) });
+    expect(await store.pttl("k")).toBe(-1);
+
+    // Item with a future expiry -> remaining millis.
+    store = makeStore({
+      GetCommand: () => ({
+        Item: { pk: "k", value: "v", expiresAt: Math.floor(Date.now() / 1000) + 60 },
+      }),
+    });
+    expect(await store.pttl("k")).toBe(60_000);
+
+    // Item past its expiry (TTL deletion is eventually consistent) -> -2.
+    store = makeStore({
+      GetCommand: () => ({
+        Item: { pk: "k", value: "v", expiresAt: Math.floor(Date.now() / 1000) - 1 },
+      }),
+    });
+    expect(await store.pttl("k")).toBe(-2);
+  });
+
   it("mergeSketch sends Get then a conditional Put and returns the estimate", async () => {
     const b = createSketch();
     for (let i = 0; i < 300; i++) addHashed(b, hashForTesting(`b-${i}`));

--- a/packages/cache/src/dynamodb-cache-store.ts
+++ b/packages/cache/src/dynamodb-cache-store.ts
@@ -1,0 +1,215 @@
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  type DynamoDBDocumentClient,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  createSketch,
+  deserialize,
+  estimate,
+  merge,
+  serialize,
+} from "@snapurl/domain";
+import type { CacheStore } from "./cache-store.js";
+
+/* ============================================================
+   DynamoDbCacheStore — the AWS-serverless-profile adapter
+   (@aws-sdk/lib-dynamodb 3.1121.0).
+
+   This is the adapter the architecture epic keeps on DynamoDB:
+   in the AWS profile the rate-limit counters, the click queue and
+   caching are served by DynamoDB, SQS and CloudFront rather than a
+   Redis container, at a lower cost. The DynamoDBDocumentClient and
+   the table name are injected via the constructor so the command
+   shapes can be unit-tested against a mocked client.
+
+   Item shape (single-table, partition key `pk` = the cache key):
+     - `value`  a String (get/set), a Number (incr counter) or
+                Binary (sketch bytes), depending on the operation;
+     - `expiresAt` a Number in unix EPOCH SECONDS — DynamoDB TTL
+                semantics, which deletes items lazily after this
+                time; and
+     - `ver`    a Number version used by mergeSketch for optimistic
+                concurrency.
+
+   Two design choices mirror the other adapters:
+
+     - incr is a single UpdateCommand: `ADD` is an atomic counter,
+       and `if_not_exists` sets the ttl only on the first write, so
+       a fixed window is set once and never reset — the same
+       contract the port defines.
+
+     - mergeSketch keeps OUR @snapurl/domain sketch bytes (stored
+       as Binary), not any DynamoDB-native format, so the byte
+       layout is identical across all three adapters. Because
+       DynamoDB has no server-side merge, it is a read-merge-write
+       guarded by a version condition: read the current bytes and
+       version, merge in JS, and conditionally write back with an
+       incremented version. A ConditionalCheckFailedException means
+       a concurrent writer won the race, so we re-read and retry a
+       bounded number of times.
+   ============================================================ */
+
+/** Bounded retries for the optimistic mergeSketch write. */
+const MERGE_MAX_ATTEMPTS = 5;
+
+/** DynamoDB TTL is expressed in whole seconds since the epoch. */
+function epochSeconds(ttlSeconds: number): number {
+  return Math.floor(Date.now() / 1000) + ttlSeconds;
+}
+
+/** Now, in unix epoch seconds, for comparing against a stored TTL. */
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export class DynamoDbCacheStore implements CacheStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly table: string,
+  ) {}
+
+  async get(key: string): Promise<string | null> {
+    const result = await this.client.send(
+      new GetCommand({ TableName: this.table, Key: { pk: key } }),
+    );
+    const item = result.Item;
+    if (!item) return null;
+    // DynamoDB TTL deletion is eventually consistent, so an item may
+    // still be readable after its expiry; treat that as absent.
+    if (typeof item.expiresAt === "number" && item.expiresAt <= nowSeconds()) {
+      return null;
+    }
+    return typeof item.value === "string" ? item.value : null;
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    const item: Record<string, unknown> = { pk: key, value };
+    if (ttlSeconds !== undefined) item.expiresAt = epochSeconds(ttlSeconds);
+    await this.client.send(
+      new PutCommand({ TableName: this.table, Item: item }),
+    );
+  }
+
+  async incr(key: string, ttlSeconds?: number): Promise<number> {
+    // ADD is an atomic counter; if_not_exists stamps the ttl only on
+    // the first write so the fixed window is never reset by a later
+    // increment. When no ttl is given we ADD to the counter only.
+    const command =
+      ttlSeconds === undefined
+        ? new UpdateCommand({
+            TableName: this.table,
+            Key: { pk: key },
+            UpdateExpression: "ADD #v :one",
+            ExpressionAttributeNames: { "#v": "value" },
+            ExpressionAttributeValues: { ":one": 1 },
+            ReturnValues: "UPDATED_NEW",
+          })
+        : new UpdateCommand({
+            TableName: this.table,
+            Key: { pk: key },
+            UpdateExpression:
+              "ADD #v :one SET #e = if_not_exists(#e, :exp)",
+            ExpressionAttributeNames: { "#v": "value", "#e": "expiresAt" },
+            ExpressionAttributeValues: {
+              ":one": 1,
+              ":exp": epochSeconds(ttlSeconds),
+            },
+            ReturnValues: "UPDATED_NEW",
+          });
+    const result = await this.client.send(command);
+    return Number(result.Attributes?.value ?? 0);
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<void> {
+    await this.client.send(
+      new UpdateCommand({
+        TableName: this.table,
+        Key: { pk: key },
+        UpdateExpression: "SET #e = :exp",
+        ExpressionAttributeNames: { "#e": "expiresAt" },
+        ExpressionAttributeValues: { ":exp": epochSeconds(ttlSeconds) },
+      }),
+    );
+  }
+
+  async del(key: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({ TableName: this.table, Key: { pk: key } }),
+    );
+  }
+
+  async mergeSketch(
+    key: string,
+    sketch: Uint8Array,
+    ttlSeconds?: number,
+  ): Promise<{ estimate: number }> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MERGE_MAX_ATTEMPTS; attempt++) {
+      // Read the current bytes and version.
+      const read = await this.client.send(
+        new GetCommand({ TableName: this.table, Key: { pk: key } }),
+      );
+      const item = read.Item;
+      const currentBytes = item?.value;
+      const currentVersion =
+        typeof item?.ver === "number" ? item.ver : 0;
+      const current =
+        currentBytes instanceof Uint8Array
+          ? deserialize(currentBytes)
+          : createSketch();
+      const merged = merge(current, sketch);
+
+      const putItem: Record<string, unknown> = {
+        pk: key,
+        value: serialize(merged),
+        ver: currentVersion + 1,
+      };
+      if (ttlSeconds !== undefined && !item) {
+        // First write stamps the ttl; later merges keep the original.
+        putItem.expiresAt = epochSeconds(ttlSeconds);
+      } else if (typeof item?.expiresAt === "number") {
+        putItem.expiresAt = item.expiresAt;
+      }
+
+      try {
+        // Conditionally write: succeed only if nobody else advanced the
+        // version since our read. This closes the read-merge-write race.
+        await this.client.send(
+          new PutCommand({
+            TableName: this.table,
+            Item: putItem,
+            ConditionExpression:
+              "attribute_not_exists(#ver) OR #ver = :expectedVer",
+            ExpressionAttributeNames: { "#ver": "ver" },
+            ExpressionAttributeValues: { ":expectedVer": currentVersion },
+          }),
+        );
+        return { estimate: estimate(merged) };
+      } catch (error) {
+        // A lost race re-reads and retries; anything else propagates.
+        if (isConditionalCheckFailed(error)) {
+          lastError = error;
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error(
+      `dynamodb: mergeSketch for ${JSON.stringify(key)} failed after ${MERGE_MAX_ATTEMPTS} attempts under contention`,
+      { cause: lastError },
+    );
+  }
+}
+
+/** DynamoDB signals a failed optimistic write with this error name. */
+function isConditionalCheckFailed(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "ConditionalCheckFailedException"
+  );
+}

--- a/packages/cache/src/dynamodb-cache-store.ts
+++ b/packages/cache/src/dynamodb-cache-store.ts
@@ -39,7 +39,13 @@ import type { CacheStore } from "./cache-store.js";
      - incr is a single UpdateCommand: `ADD` is an atomic counter,
        and `if_not_exists` sets the ttl only on the first write, so
        a fixed window is set once and never reset — the same
-       contract the port defines.
+       contract the port defines. This implies an invariant: `incr`
+       stores a Number under `value` while `set` stores a String
+       there, so a single key must never be used for both a counter
+       and a string value — `ADD` against a stored String would
+       fail with a type error. Nothing mixes them on one key today
+       (counter keys and value/cache keys are disjoint), and callers
+       must keep them so.
 
      - mergeSketch keeps OUR @snapurl/domain sketch bytes (stored
        as Binary), not any DynamoDB-native format, so the byte

--- a/packages/cache/src/dynamodb-cache-store.ts
+++ b/packages/cache/src/dynamodb-cache-store.ts
@@ -141,6 +141,22 @@ export class DynamoDbCacheStore implements CacheStore {
     );
   }
 
+  async pttl(key: string): Promise<number> {
+    // DynamoDB has no TTL-read command, so derive the remainder from the
+    // stored expiresAt (unix epoch SECONDS). Returns Redis-style sentinels:
+    // -2 when the item is absent or already past its expiry, -1 when it
+    // exists with no expiry. TTL deletion is eventually consistent, so an
+    // item read after its expiry reports absent, matching get().
+    const result = await this.client.send(
+      new GetCommand({ TableName: this.table, Key: { pk: key } }),
+    );
+    const item = result.Item;
+    if (!item) return -2;
+    if (typeof item.expiresAt !== "number") return -1;
+    const remainingMs = item.expiresAt * 1000 - Date.now();
+    return remainingMs <= 0 ? -2 : remainingMs;
+  }
+
   async mergeSketch(
     key: string,
     sketch: Uint8Array,

--- a/packages/cache/src/factory.ts
+++ b/packages/cache/src/factory.ts
@@ -1,0 +1,74 @@
+import { MemoryCacheStore } from "./memory-cache-store.js";
+import type { CacheStore } from "./cache-store.js";
+
+/* ============================================================
+   createCacheStore — the env-driven driver factory.
+
+   Each profile picks its adapter by a driver string that the app
+   validates from its own env (the factory takes a plain config
+   object, NOT process.env, so apps/api and apps/redirect can each
+   pass their own zod-validated values). 'memory' is the default,
+   so a deployment that configures nothing runs single-node
+   in-memory.
+
+   The redis and dynamodb branches use dynamic `await import()` so
+   a memory-only deployment never loads ioredis or the AWS SDK at
+   module-eval time. That keeps cold starts light on the profiles
+   that do not need the heavy modules, mirroring how the rest of
+   the codebase defers optional dependencies.
+   ============================================================ */
+
+/** The set of adapters createCacheStore can build. */
+export type CacheDriver = "memory" | "redis" | "dynamodb";
+
+export interface CacheStoreConfig {
+  /** Which adapter to build. Defaults to 'memory'. */
+  driver?: CacheDriver;
+  /** Required when driver is 'redis': the ioredis connection URL. */
+  redisUrl?: string;
+  /** Required when driver is 'dynamodb': the cache table name. */
+  dynamoTable?: string;
+}
+
+export async function createCacheStore(
+  config: CacheStoreConfig = {},
+): Promise<CacheStore> {
+  const driver = config.driver ?? "memory";
+  switch (driver) {
+    case "memory":
+      return new MemoryCacheStore();
+
+    case "redis": {
+      if (!config.redisUrl) {
+        throw new Error(
+          "createCacheStore: driver 'redis' requires a redisUrl",
+        );
+      }
+      // Lazy: ioredis is only loaded when the redis profile is chosen.
+      const { Redis } = await import("ioredis");
+      const { RedisCacheStore } = await import("./redis-cache-store.js");
+      return new RedisCacheStore(new Redis(config.redisUrl));
+    }
+
+    case "dynamodb": {
+      if (!config.dynamoTable) {
+        throw new Error(
+          "createCacheStore: driver 'dynamodb' requires a dynamoTable",
+        );
+      }
+      // Lazy: the AWS SDK is only loaded when the dynamodb profile is chosen.
+      const { DynamoDBClient } = await import("@aws-sdk/client-dynamodb");
+      const { DynamoDBDocumentClient } = await import("@aws-sdk/lib-dynamodb");
+      const { DynamoDbCacheStore } = await import("./dynamodb-cache-store.js");
+      const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+      return new DynamoDbCacheStore(client, config.dynamoTable);
+    }
+
+    default: {
+      // Exhaustiveness: a new driver added to the union without a case
+      // here is a compile-time error.
+      const exhaustive: never = driver;
+      throw new Error(`createCacheStore: unknown driver ${String(exhaustive)}`);
+    }
+  }
+}

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./cache-store.js";
+export * from "./memory-cache-store.js";
+export * from "./redis-cache-store.js";
+export * from "./dynamodb-cache-store.js";
+export * from "./factory.js";

--- a/packages/cache/src/memory-cache-store.test.ts
+++ b/packages/cache/src/memory-cache-store.test.ts
@@ -78,6 +78,25 @@ describe("MemoryCacheStore", () => {
     expect(await store.get("k")).toBeNull();
   });
 
+  it("reports remaining ttl in millis via pttl (Redis-style sentinels)", async () => {
+    // -2 for an absent key.
+    expect(await store.pttl("missing")).toBe(-2);
+
+    // -1 for a key with no expiry.
+    await store.set("forever", "v");
+    expect(await store.pttl("forever")).toBe(-1);
+
+    // A positive remainder for a key with a ttl, counting down with time.
+    await store.set("k", "v", 60);
+    expect(await store.pttl("k")).toBe(60_000);
+    vi.setSystemTime(new Date("2025-01-01T00:00:59.000Z"));
+    expect(await store.pttl("k")).toBe(1_000);
+
+    // Past expiry the key is evicted, so pttl reports absent, not 0.
+    vi.setSystemTime(new Date("2025-01-01T00:01:00.000Z"));
+    expect(await store.pttl("k")).toBe(-2);
+  });
+
   it("mergeSketch equals the domain merge/estimate", async () => {
     // Two independent domain sketches.
     const a = createSketch();

--- a/packages/cache/src/memory-cache-store.test.ts
+++ b/packages/cache/src/memory-cache-store.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addHashed,
+  createSketch,
+  estimate,
+  hashForTesting,
+  merge,
+} from "@snapurl/domain";
+import { MemoryCacheStore } from "./memory-cache-store.js";
+
+/* Pure unit tests for the default adapter: no network, no DB gate.
+   Time is controlled with vi.setSystemTime so ttl expiry is
+   deterministic. */
+
+describe("MemoryCacheStore", () => {
+  let store: MemoryCacheStore;
+
+  beforeEach(() => {
+    store = new MemoryCacheStore();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("round-trips a value with get/set", async () => {
+    expect(await store.get("k")).toBeNull();
+    await store.set("k", "hello");
+    expect(await store.get("k")).toBe("hello");
+  });
+
+  it("expires a value after its ttl (lazy, on read)", async () => {
+    await store.set("k", "v", 60);
+    expect(await store.get("k")).toBe("v");
+
+    vi.setSystemTime(new Date("2025-01-01T00:00:59.000Z"));
+    expect(await store.get("k")).toBe("v");
+
+    vi.setSystemTime(new Date("2025-01-01T00:01:00.000Z"));
+    expect(await store.get("k")).toBeNull();
+  });
+
+  it("increments and returns the new count", async () => {
+    expect(await store.incr("c")).toBe(1);
+    expect(await store.incr("c")).toBe(2);
+    expect(await store.incr("c")).toBe(3);
+  });
+
+  it("sets the window on the first incr and does NOT reset it later", async () => {
+    // First incr in the window stamps a 60s expiry.
+    expect(await store.incr("w", 60)).toBe(1);
+
+    // A later incr just before the window closes must NOT push it out.
+    vi.setSystemTime(new Date("2025-01-01T00:00:59.000Z"));
+    expect(await store.incr("w", 60)).toBe(2);
+
+    // The key still expires at the ORIGINAL time, not 60s after the 2nd incr.
+    vi.setSystemTime(new Date("2025-01-01T00:01:00.000Z"));
+    expect(await store.get("w")).toBeNull();
+    // And the counter has been evicted, so the next incr starts fresh at 1.
+    expect(await store.incr("w", 60)).toBe(1);
+  });
+
+  it("updates ttl via expire", async () => {
+    await store.set("k", "v");
+    await store.expire("k", 30);
+    expect(await store.get("k")).toBe("v");
+
+    vi.setSystemTime(new Date("2025-01-01T00:00:30.000Z"));
+    expect(await store.get("k")).toBeNull();
+  });
+
+  it("removes a key via del", async () => {
+    await store.set("k", "v");
+    await store.del("k");
+    expect(await store.get("k")).toBeNull();
+  });
+
+  it("mergeSketch equals the domain merge/estimate", async () => {
+    // Two independent domain sketches.
+    const a = createSketch();
+    const b = createSketch();
+    for (let i = 0; i < 500; i++) addHashed(a, hashForTesting(`a-${i}`));
+    for (let i = 0; i < 500; i++) addHashed(b, hashForTesting(`b-${i}`));
+
+    await store.mergeSketch("s", a);
+    const result = await store.mergeSketch("s", b);
+
+    // The store's accumulated estimate equals estimate(merge(a, b)).
+    const expected = estimate(merge(a, b));
+    expect(result.estimate).toBe(expected);
+  });
+
+  it("mergeSketch is idempotent for a repeated sketch", async () => {
+    const a = createSketch();
+    for (let i = 0; i < 300; i++) addHashed(a, hashForTesting(`x-${i}`));
+
+    const first = await store.mergeSketch("s", a);
+    const second = await store.mergeSketch("s", a);
+    expect(second.estimate).toBe(first.estimate);
+    expect(second.estimate).toBe(estimate(a));
+  });
+});

--- a/packages/cache/src/memory-cache-store.ts
+++ b/packages/cache/src/memory-cache-store.ts
@@ -97,6 +97,16 @@ export class MemoryCacheStore implements CacheStore {
     this.store.delete(key);
   }
 
+  async pttl(key: string): Promise<number> {
+    // -2 (absent) mirrors Redis PTTL: live() also evicts an expired key,
+    // so a key past its expiry reports absent, not a stale remainder.
+    const entry = this.live(key);
+    if (!entry) return -2;
+    // -1 mirrors Redis PTTL for a key that exists with no expiry.
+    if (entry.expiresAt === null) return -1;
+    return Math.max(0, entry.expiresAt - Date.now());
+  }
+
   async mergeSketch(
     key: string,
     sketch: Uint8Array,

--- a/packages/cache/src/memory-cache-store.ts
+++ b/packages/cache/src/memory-cache-store.ts
@@ -1,0 +1,123 @@
+import {
+  createSketch,
+  deserialize,
+  estimate,
+  merge,
+  serialize,
+} from "@snapurl/domain";
+import type { CacheStore } from "./cache-store.js";
+
+/* ============================================================
+   MemoryCacheStore — the default adapter.
+
+   Backed by a single Map in one Node process. This is what CI,
+   docker compose and local development use, and it is the
+   single-node profile of the product: no external dependency,
+   nothing to warm, nothing to run alongside the app.
+
+   Two things are worth stating plainly:
+
+     - Expiry is lazy. There is no background sweeper; a key is
+       evicted the first time it is read (get/incr/mergeSketch)
+       after its expiresAt has passed. That keeps writes cheap and
+       is correct for every read path the port exposes.
+
+     - incr is atomic here for free. A single Node process runs
+       one increment to completion before the next microtask, so
+       the read-modify-write below cannot interleave. That is the
+       whole reason the in-memory profile is single-node: two
+       processes each with their own Map would each count to the
+       limit, which is exactly the bug the Redis/DynamoDB adapters
+       exist to fix for the scaled and serverless profiles.
+   ============================================================ */
+
+interface Entry {
+  /** String values for get/set/incr; Uint8Array for sketch keys. */
+  value: string | Uint8Array;
+  /** Epoch millis at which this key expires, or null for no expiry. */
+  expiresAt: number | null;
+}
+
+export class MemoryCacheStore implements CacheStore {
+  private readonly store = new Map<string, Entry>();
+
+  /**
+   * Evict the key if it has an expiry that has passed, then return the
+   * live entry (or undefined). Every read path calls this first so
+   * lazy expiry is observed consistently.
+   */
+  private live(key: string): Entry | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt !== null && Date.now() >= entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  private expiryFrom(ttlSeconds?: number): number | null {
+    return ttlSeconds === undefined ? null : Date.now() + ttlSeconds * 1000;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.live(key);
+    if (!entry) return null;
+    return typeof entry.value === "string" ? entry.value : null;
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    this.store.set(key, { value, expiresAt: this.expiryFrom(ttlSeconds) });
+  }
+
+  async incr(key: string, ttlSeconds?: number): Promise<number> {
+    const entry = this.live(key);
+    if (!entry) {
+      // First write in this window: create at 1 and stamp the expiry.
+      this.store.set(key, {
+        value: "1",
+        expiresAt: this.expiryFrom(ttlSeconds),
+      });
+      return 1;
+    }
+    // Subsequent increment within the window: bump the count but leave
+    // expiresAt untouched, so the fixed window still closes on schedule.
+    const current = typeof entry.value === "string" ? parseInt(entry.value, 10) : 0;
+    const next = (Number.isNaN(current) ? 0 : current) + 1;
+    entry.value = String(next);
+    return next;
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<void> {
+    const entry = this.live(key);
+    if (entry) entry.expiresAt = Date.now() + ttlSeconds * 1000;
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async mergeSketch(
+    key: string,
+    sketch: Uint8Array,
+    ttlSeconds?: number,
+  ): Promise<{ estimate: number }> {
+    const entry = this.live(key);
+    const current =
+      entry && entry.value instanceof Uint8Array
+        ? deserialize(entry.value)
+        : createSketch();
+    const merged = merge(current, sketch);
+    if (!entry) {
+      // First write: persist the merged bytes and stamp the expiry.
+      this.store.set(key, {
+        value: serialize(merged),
+        expiresAt: this.expiryFrom(ttlSeconds),
+      });
+    } else {
+      // Subsequent merge: persist bytes, keep the original expiry.
+      entry.value = serialize(merged);
+    }
+    return { estimate: estimate(merged) };
+  }
+}

--- a/packages/cache/src/redis-cache-store.test.ts
+++ b/packages/cache/src/redis-cache-store.test.ts
@@ -21,6 +21,7 @@ interface FakeRedis {
   eval: ReturnType<typeof vi.fn>;
   expire: ReturnType<typeof vi.fn>;
   del: ReturnType<typeof vi.fn>;
+  pttl: ReturnType<typeof vi.fn>;
 }
 
 function fakeClient(): FakeRedis {
@@ -31,6 +32,7 @@ function fakeClient(): FakeRedis {
     eval: vi.fn(),
     expire: vi.fn().mockResolvedValue(1),
     del: vi.fn().mockResolvedValue(1),
+    pttl: vi.fn().mockResolvedValue(-2),
   };
 }
 
@@ -102,6 +104,12 @@ describe("RedisCacheStore", () => {
   it("del delegates to client.del", async () => {
     await store.del("k");
     expect(client.del).toHaveBeenCalledWith("k");
+  });
+
+  it("pttl delegates to client.pttl and returns the remaining millis", async () => {
+    client.pttl.mockResolvedValue(1234);
+    expect(await store.pttl("k")).toBe(1234);
+    expect(client.pttl).toHaveBeenCalledWith("k");
   });
 
   it("mergeSketch reads via getBuffer, writes merged bytes, returns the estimate", async () => {

--- a/packages/cache/src/redis-cache-store.test.ts
+++ b/packages/cache/src/redis-cache-store.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Redis } from "ioredis";
+import {
+  addHashed,
+  createSketch,
+  estimate,
+  hashForTesting,
+  merge,
+  serialize,
+} from "@snapurl/domain";
+import { RedisCacheStore } from "./redis-cache-store.js";
+
+/* MOCK-based unit tests: no live Redis is available in-sandbox or in
+   CI, so a fake ioredis client asserts the RIGHT commands are issued.
+   A live-Redis integration test is deferred to the deploy phase. */
+
+interface FakeRedis {
+  get: ReturnType<typeof vi.fn>;
+  getBuffer: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  eval: ReturnType<typeof vi.fn>;
+  expire: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+}
+
+function fakeClient(): FakeRedis {
+  return {
+    get: vi.fn(),
+    getBuffer: vi.fn(),
+    set: vi.fn().mockResolvedValue("OK"),
+    eval: vi.fn(),
+    expire: vi.fn().mockResolvedValue(1),
+    del: vi.fn().mockResolvedValue(1),
+  };
+}
+
+describe("RedisCacheStore", () => {
+  let client: FakeRedis;
+  let store: RedisCacheStore;
+
+  beforeEach(() => {
+    client = fakeClient();
+    store = new RedisCacheStore(client as unknown as Redis);
+  });
+
+  it("get delegates to client.get", async () => {
+    client.get.mockResolvedValue("v");
+    expect(await store.get("k")).toBe("v");
+    expect(client.get).toHaveBeenCalledWith("k");
+  });
+
+  it("set without ttl issues a plain SET", async () => {
+    await store.set("k", "v");
+    expect(client.set).toHaveBeenCalledWith("k", "v");
+  });
+
+  it("set with ttl issues SET ... EX", async () => {
+    await store.set("k", "v", 90);
+    expect(client.set).toHaveBeenCalledWith("k", "v", "EX", 90);
+  });
+
+  it("incr issues the Lua eval with the ttl and returns the new count", async () => {
+    client.eval.mockResolvedValue(1);
+    const n = await store.incr("c", 60);
+    expect(n).toBe(1);
+
+    // Script text carries INCR + conditional EXPIRE; KEYS[1] is the key,
+    // ARGV[1] is the ttl. numkeys is 1.
+    const [script, numkeys, key, ttl] = client.eval.mock.calls[0]!;
+    expect(String(script)).toContain("INCR");
+    expect(String(script)).toContain("EXPIRE");
+    expect(numkeys).toBe(1);
+    expect(key).toBe("c");
+    expect(ttl).toBe("60");
+  });
+
+  it("incr without ttl passes an empty ARGV so no expiry is set", async () => {
+    client.eval.mockResolvedValue(5);
+    const n = await store.incr("c");
+    expect(n).toBe(5);
+    const args = client.eval.mock.calls[0]!;
+    expect(args[3]).toBe("");
+  });
+
+  it("the atomic script sets expiry only on the first increment (n == 1)", () => {
+    // The correctness of "first write sets the window, later writes do not
+    // reset it" lives in the Lua script itself: EXPIRE runs only when n == 1.
+    // Assert the script encodes that guard rather than requiring a live eval.
+    client.eval.mockResolvedValue(2);
+    return store.incr("c", 60).then(() => {
+      const script = String(client.eval.mock.calls[0]![0]);
+      expect(script).toContain("n == 1");
+      expect(script).toMatch(/if\s+n\s*==\s*1/);
+    });
+  });
+
+  it("expire delegates to client.expire", async () => {
+    await store.expire("k", 45);
+    expect(client.expire).toHaveBeenCalledWith("k", 45);
+  });
+
+  it("del delegates to client.del", async () => {
+    await store.del("k");
+    expect(client.del).toHaveBeenCalledWith("k");
+  });
+
+  it("mergeSketch reads via getBuffer, writes merged bytes, returns the estimate", async () => {
+    const a = createSketch();
+    const b = createSketch();
+    for (let i = 0; i < 400; i++) addHashed(a, hashForTesting(`a-${i}`));
+    for (let i = 0; i < 400; i++) addHashed(b, hashForTesting(`b-${i}`));
+
+    // Stored state is sketch `a`; the caller merges `b` on top.
+    client.getBuffer.mockResolvedValue(serialize(a));
+
+    const result = await store.mergeSketch("s", b, 120);
+
+    expect(client.getBuffer).toHaveBeenCalledWith("s");
+    // Wrote merged bytes with an EX ttl (not Redis PFMERGE).
+    const [key, bytes, ex, ttl] = client.set.mock.calls[0]!;
+    expect(key).toBe("s");
+    expect(Buffer.isBuffer(bytes) || bytes instanceof Uint8Array).toBe(true);
+    expect(ex).toBe("EX");
+    expect(ttl).toBe(120);
+    // The persisted bytes equal the domain merge, and so does the estimate.
+    expect(Buffer.from(bytes)).toEqual(serialize(merge(a, b)));
+    expect(result.estimate).toBe(estimate(merge(a, b)));
+  });
+
+  it("mergeSketch starts from an empty sketch when the key is absent", async () => {
+    const b = createSketch();
+    for (let i = 0; i < 100; i++) addHashed(b, hashForTesting(`b-${i}`));
+    client.getBuffer.mockResolvedValue(null);
+
+    const result = await store.mergeSketch("s", b);
+    expect(result.estimate).toBe(estimate(b));
+    // No ttl given => plain SET.
+    expect(client.set.mock.calls[0]!.length).toBe(2);
+  });
+});

--- a/packages/cache/src/redis-cache-store.ts
+++ b/packages/cache/src/redis-cache-store.ts
@@ -90,6 +90,13 @@ export class RedisCacheStore implements CacheStore {
     await this.client.del(key);
   }
 
+  async pttl(key: string): Promise<number> {
+    // Redis PTTL is the source these semantics were modelled on: it
+    // returns the remaining ttl in milliseconds, -2 when the key is
+    // absent and -1 when it exists with no expiry.
+    return this.client.pttl(key);
+  }
+
   async mergeSketch(
     key: string,
     sketch: Uint8Array,

--- a/packages/cache/src/redis-cache-store.ts
+++ b/packages/cache/src/redis-cache-store.ts
@@ -1,0 +1,110 @@
+import type { Redis } from "ioredis";
+import {
+  createSketch,
+  deserialize,
+  estimate,
+  merge,
+  serialize,
+} from "@snapurl/domain";
+import type { CacheStore } from "./cache-store.js";
+
+/* ============================================================
+   RedisCacheStore — the scaled-profile adapter (ioredis 6.0.0).
+
+   Redis is the most portable scaling primitive there is for a
+   self-hostable product: one container, runs anywhere, and it
+   covers caching, counters and sketch merging at once. This
+   adapter takes an ioredis client via its constructor so tests
+   can inject a mock and no live server is required to unit-test
+   the command shapes.
+
+   Two design choices are worth stating:
+
+     - incr uses a Lua script, not INCR followed by EXPIRE. A
+       plain INCR then EXPIRE has a window between the two calls
+       where a crash (or a lost EXPIRE) leaves an immortal
+       counter, and under the fixed-window rate-limit contract a
+       lost window is a correctness bug. The script does both in
+       one atomic step and only sets the expiry on the first
+       increment (n == 1), which is exactly the "first write sets
+       the window, later writes do not reset it" semantics of the
+       port.
+
+     - mergeSketch does NOT use Redis's native PFADD/PFMERGE.
+       Those operate on Redis's OWN HyperLogLog byte format, which
+       is not the @snapurl/domain layout the rest of the product
+       stores. To keep sketch bytes portable across all three
+       adapters we read our bytes (getBuffer), merge them in JS
+       with domain.merge, and write them back. Under concurrency
+       two mergeSketch calls can interleave, but because the merge
+       is a register-wise max (idempotent and commutative) a lost
+       update only ever drops a max that a later merge re-applies;
+       the hardening path, if a live workload ever needs it, is to
+       wrap the read-merge-write in a WATCH/MULTI optimistic loop
+       or a Lua script fed the merged bytes.
+   ============================================================ */
+
+/**
+ * Atomic fixed-window increment: INCR, and on the first increment
+ * (n == 1) set the expiry from ARGV[1]. An empty ARGV[1] means "no
+ * ttl", so a plain counter with no window is still supported.
+ */
+const INCR_WITH_EXPIRY = `
+local n = redis.call('INCR', KEYS[1])
+if n == 1 and ARGV[1] ~= '' then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return n
+`;
+
+export class RedisCacheStore implements CacheStore {
+  constructor(private readonly client: Redis) {}
+
+  async get(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    if (ttlSeconds === undefined) {
+      await this.client.set(key, value);
+    } else {
+      await this.client.set(key, value, "EX", ttlSeconds);
+    }
+  }
+
+  async incr(key: string, ttlSeconds?: number): Promise<number> {
+    const result = await this.client.eval(
+      INCR_WITH_EXPIRY,
+      1,
+      key,
+      ttlSeconds === undefined ? "" : String(ttlSeconds),
+    );
+    return Number(result);
+  }
+
+  async expire(key: string, ttlSeconds: number): Promise<void> {
+    await this.client.expire(key, ttlSeconds);
+  }
+
+  async del(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+
+  async mergeSketch(
+    key: string,
+    sketch: Uint8Array,
+    ttlSeconds?: number,
+  ): Promise<{ estimate: number }> {
+    // Read our sketch bytes as a raw Buffer (not decoded as utf-8).
+    const existing = await this.client.getBuffer(key);
+    const current = existing ? deserialize(existing) : createSketch();
+    const merged = merge(current, sketch);
+    const bytes = serialize(merged);
+    if (ttlSeconds === undefined) {
+      await this.client.set(key, bytes);
+    } else {
+      await this.client.set(key, bytes, "EX", ttlSeconds);
+    }
+    return { estimate: estimate(merged) };
+  }
+}

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "./dist", "rootDir": "./src" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/cache/vitest.config.ts
+++ b/packages/cache/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: { environment: "node", include: ["src/**/*.test.ts"] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,31 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/cache:
+    dependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.1121.0
+        version: 3.1121.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.1121.0
+        version: 3.1121.0(@aws-sdk/client-dynamodb@3.1121.0)
+      '@snapurl/domain':
+        specifier: workspace:*
+        version: link:../domain
+      ioredis:
+        specifier: ^6.0.0
+        version: 6.0.0(supports-color@8.1.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^22
+        version: 22.20.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+
   packages/contract:
     dependencies:
       zod:
@@ -366,6 +391,10 @@ packages:
       - jsonschema
       - semver
 
+  '@aws-sdk/client-dynamodb@3.1121.0':
+    resolution: {integrity: sha512-q8s4cKsn0TdQ+QByWEUeajZMFrmF2GzDovrlfWMA7Pv3GfG5sADjbWAZxJXA9JsLGb4QT5ovTpOdArNqjbojZw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-secrets-manager@3.1121.0':
     resolution: {integrity: sha512-kx66Imv5DomVdd5uwai10Dhf0zZg9Z3EODxJCYRGjmaD0GR08GkvuIPPIqE+ZmpHANCWbur9UKpgyXGJzk60pg==}
     engines: {node: '>=20.0.0'}
@@ -406,6 +435,24 @@ packages:
     resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/dynamodb-codec@3.973.44':
+    resolution: {integrity: sha512-eo27HNeBqMAfy9JBQug6ErU6DeG8OmOH6ou8+KmX3/fWdTmWUsHsfisz2tEQOG+GJ57bBC7kC6AjKAjpcxU4QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/endpoint-cache@3.972.11':
+    resolution: {integrity: sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-dynamodb@3.1121.0':
+    resolution: {integrity: sha512-6YwmAKw56x2+x3d7R9ho7CHoRuGWzM5yg0DAxdqvqBrRN8EZWJID+wCQB7XZUJWerO3M1ncznEny4lwPj29u8g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1121.0
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.30':
+    resolution: {integrity: sha512-0hmD7/NG2NoVOVHvUb6rtY5POQYr+/9gdHvrYhIBA1zmCqKOBd5Gz3dL+iZ15FHOJbs/5kLplGoePc8PHTlzYA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.44':
     resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
     engines: {node: '>=20.0.0'}
@@ -421,6 +468,12 @@ packages:
   '@aws-sdk/types@3.974.5':
     resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-dynamodb@3.996.9':
+    resolution: {integrity: sha512-16x2tRvl7OYpZ0W/DdFJieFriD13+RvuRBDbe5sj/tCEfK86HSGd7I2s5j0ivz8p6KWGkS+5wKRO9OliJkjUOQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1111.0
 
   '@aws-sdk/xml-builder@3.972.40':
     resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
@@ -1304,6 +1357,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/commands@2.0.0':
+    resolution: {integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2158,6 +2214,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2286,6 +2346,10 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2612,6 +2676,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ioredis@6.0.0:
+    resolution: {integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==}
+    engines: {node: '>=20.0.0'}
+
   ipaddr.js@2.5.0:
     resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
     engines: {node: '>= 10'}
@@ -2860,6 +2928,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2922,6 +2993,9 @@ packages:
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
+
+  obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -3109,6 +3183,10 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -3252,6 +3330,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -3683,6 +3764,19 @@ snapshots:
 
   '@aws-cdk/cloud-assembly-schema@54.21.0': {}
 
+  '@aws-sdk/client-dynamodb@3.1121.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/dynamodb-codec': 3.973.44
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.30
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-secrets-manager@3.1121.0':
     dependencies:
       '@aws-sdk/core': 3.977.9
@@ -3789,6 +3883,35 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/dynamodb-codec@3.973.44':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/endpoint-cache@3.972.11':
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-dynamodb@3.1121.0(@aws-sdk/client-dynamodb@3.1121.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1121.0
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/util-dynamodb': 3.996.9(@aws-sdk/client-dynamodb@3.1121.0)
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.30':
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.11
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.44':
     dependencies:
       '@aws-sdk/core': 3.977.9
@@ -3819,6 +3942,11 @@ snapshots:
   '@aws-sdk/types@3.974.5':
     dependencies:
       '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-dynamodb@3.996.9(@aws-sdk/client-dynamodb@3.1121.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1121.0
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.40':
@@ -4361,6 +4489,8 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@22.20.1)':
     optionalDependencies:
       '@types/node': 22.20.1
+
+  '@ioredis/commands@2.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5146,6 +5276,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5250,6 +5382,8 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -5555,6 +5689,17 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ioredis@6.0.0(supports-color@8.1.1):
+    dependencies:
+      '@ioredis/commands': 2.0.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@2.5.0: {}
 
   is-arrayish@0.2.1: {}
@@ -5755,6 +5900,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mnemonist@0.38.3:
+    dependencies:
+      obliterator: 1.6.1
+
   ms@2.1.3: {}
 
   mute-stream@2.0.0: {}
@@ -5804,6 +5953,8 @@ snapshots:
   node-gyp-build@4.8.4: {}
 
   node-releases@2.0.53: {}
+
+  obliterator@1.6.1: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -6013,6 +6164,8 @@ snapshots:
       - '@types/react'
       - redux
 
+  redis-errors@1.2.0: {}
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -6179,6 +6332,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@nestjs/throttler':
         specifier: ^6.4.0
         version: 6.5.0(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      '@snapurl/cache':
+        specifier: workspace:*
+        version: link:../../packages/cache
       '@snapurl/contract':
         specifier: workspace:*
         version: link:../../packages/contract
@@ -93,6 +96,9 @@ importers:
 
   apps/redirect:
     dependencies:
+      '@snapurl/cache':
+        specifier: workspace:*
+        version: link:../../packages/cache
       '@snapurl/contract':
         specifier: workspace:*
         version: link:../../packages/contract


### PR DESCRIPTION
Closes #285. Phase 4 of epic #267 (the second/last missing port). One port, three problems (hot-link caching, multi-instance rate-limit counters, HLL sketch merge).

## What shipped
- **New `@snapurl/cache` package** with a `CacheStore` port — `get`/`set(ttl?)`/`incr(ttl?)` (atomic, first-write stamps the fixed window)/`expire`/`del`/`mergeSketch`/`pttl` — and **three adapters**, chosen by `CACHE_DRIVER` (default `memory`):
  - **in-memory** (single-node/local/CI): Map + lazy expiry; atomic incr in one process.
  - **Redis** (scaled/self-host, `ioredis`): incr via a Lua INCR+conditional-EXPIRE for atomic fixed-window.
  - **DynamoDB** (AWS serverless, `@aws-sdk/lib-dynamodb`): incr via `UpdateCommand ADD` + TTL attribute; sketch via read-merge-conditional-write.
  - Heavy deps live **only** in `packages/cache` and are **dynamically imported**, so a memory-only deployment never loads ioredis/AWS SDK.
  - **mergeSketch portability:** all adapters merge OUR `@snapurl/domain` HLL bytes (register-wise max) — deliberately NOT Redis PFMERGE — so a sketch is byte-compatible across adapters.
- **Hot-link caching:** `CachingLinkResolver` decorates `PostgresLinkResolver`, keyed by host+slug, positive-hits only, short env TTL (`LINK_CACHE_TTL_SECONDS`, default 10) → the redirect serves a hot link without touching Postgres. Bounded staleness is the guarantee; edit-invalidation is documented as the projection/outbox follow-up (not silently broken). Click recording is per-request and untouched, so the exactly-one-click_events assertion is unaffected.
- **Throttler storage:** `CacheStoreThrottlerStorage implements ThrottlerStorage` over `CacheStore.incr`, selected by `CACHE_DRIVER` in `ThrottlerModule.forRootAsync`. Default memory = behaviourally identical to the stock in-memory storage; with `CACHE_DRIVER=redis`+`REDIS_URL` the counter is **shared across instances**, fixing the effective `limit × instances` bug. A test proves two storages over one backing store see a combined count.
- **DECISIONS.md** rewritten per-profile: single-node = in-memory; scaled/self-host = Redis (the portable primitive); AWS serverless = DynamoDB+SQS+CloudFront (original cost reasoning preserved, still correct).

## Scope
The DynamoDB **adapter** (code + mock tests) is built now; the **CDK DynamoDB cache table + `CACHE_DRIVER=dynamodb` stack wiring** are **Phase-7-deferred** (#288 territory) — `infra/` untouched. Documented.

## Done-when
- ✅ Multi-instance rate limiting correct in the scaled profile (shared Redis counter).
- ✅ Redirect serves a hot link without touching Postgres.
- ✅ DECISIONS.md records the Redis call per-profile with reasoning for each.

## How to test
- `corepack pnpm install --frozen-lockfile` clean; `corepack pnpm type-check` green; verified.
- `corepack pnpm test`: packages/cache 30 (memory: round-trip/TTL/atomic-incr-window/mergeSketch==domain; Redis+DynamoDB via **mocks** asserting the exact commands — live servers are deploy-phase-deferred); redirect caching-resolver 7 (hit-avoids-DB, miss-falls-through, no negative caching, case-insensitive keying, Date/null round-trip); api throttler shared-counter test. Existing rate-limit + smoke behavior unchanged under the memory default.
- CI `verify`+`integration` use the default memory driver → byte-identical behavior.

Deps (packages/cache only): `ioredis@^6.0.0`, `@aws-sdk/client-dynamodb@^3.1121.0`, `@aws-sdk/lib-dynamodb@^3.1121.0`.