### PR TITLE
Profile 2: Helm chart for the horizontally scaled deployment (#287)

### DIFF
--- a/.github/workflows/deploy-helm.yml
+++ b/.github/workflows/deploy-helm.yml
@@ -46,9 +46,22 @@ env:
   # the composed image ref is a bare `snapurl-<app>:ci` (no registry) that
   # matches exactly what `kind load` puts in the node's image store.
   IMAGE_TAG: ci
-  # The small, deterministic throttle limit used for the multi-replica 429
-  # assertion. Kept in env so the helm --set and the assertion step agree.
-  THROTTLE_LIMIT_CI: "5"
+  # The deployed API's GLOBAL throttle limit for this job. Set very high so the
+  # smoke suites (scripts/smoke.sh makes several hundred requests in a couple of
+  # minutes) never trip the global rate limiter — exactly what verify.yml does
+  # with THROTTLE_LIMIT: "100000" for the same reason. This does NOT weaken the
+  # multi-replica 429 proof below: that proof targets POST /api/v1/auth/login,
+  # which carries its OWN route-level @Throttle limit:5/60s in code
+  # (apps/api/src/auth/auth.controller.ts) that is INDEPENDENT of this global
+  # limit — so the login bucket still caps at 5 regardless of how high the
+  # global limit is. THROTTLE_LIMIT_PROOF below is that known route-level 5, the
+  # number the assertion step checks against.
+  THROTTLE_LIMIT_SMOKE: "100000"
+  # The deterministic per-client limit the multi-replica 429 assertion checks
+  # against. It equals the login route's hardcoded route-level @Throttle limit
+  # (5/60s) — NOT the global limit — so the assertion holds no matter what the
+  # global THROTTLE_LIMIT_SMOKE is set to.
+  THROTTLE_LIMIT_PROOF: "5"
   # The redirect host new links are created on. This MUST equal the API's
   # DEFAULT_DOMAIN and the Host the redirect resolver matches (see
   # scripts/smoke-redirect.sh header). We port-forward redirect to
@@ -252,7 +265,11 @@ jobs:
       # redis.url forces CACHE_DRIVER=redis for every service — the shared
       # counter the rate-limit proof depends on. secrets.existingSecret reuses
       # the Secret created above so no secret value appears on the helm command
-      # line. throttle.limit is the small CI limit. DEFAULT_DOMAIN /
+      # line. throttle.limit is set VERY HIGH (THROTTLE_LIMIT_SMOKE) so the
+      # smoke suites' several-hundred requests never trip the GLOBAL limiter —
+      # the multi-replica 429 proof still holds because it targets /auth/login,
+      # whose route-level @Throttle limit:5 is independent of this global value.
+      # DEFAULT_DOMAIN /
       # REDIRECT_ORIGIN / WEB_ORIGIN line up with the port-forward + smoke
       # scripts (LINK_HOST). ingress.enabled=false (we use port-forward).
       # hpa.enabled=false: kind has no metrics-server, so an enabled HPA would
@@ -271,7 +288,7 @@ jobs:
             --set-string postgres.url="postgres://snapurl:snapurl@ci-postgres.${NS}.svc:5432/snapurl" \
             --set-string redis.url="redis://ci-redis.${NS}.svc:6379" \
             --set secrets.existingSecret=snapurl-secrets \
-            --set throttle.limit="$THROTTLE_LIMIT_CI" \
+            --set throttle.limit="$THROTTLE_LIMIT_SMOKE" \
             --set-string defaultDomain="$LINK_HOST" \
             --set-string redirectOrigin="http://$LINK_HOST" \
             --set-string webOrigin="http://localhost:3000" \
@@ -387,11 +404,15 @@ jobs:
       #
       # WHY POST /api/v1/auth/login is the target, and why it is deterministic:
       #   * It carries a route-level @Throttle limit:5/60s
-      #     (apps/api/src/auth/auth.controller.ts), AND the global throttle is
-      #     also set to 5 here (throttle.limit=5) and applied to every route by
-      #     ProxyAwareThrottlerGuard (an APP_GUARD in app.module.ts). Both
-      #     buckets cap at 5, so the assertion holds regardless of which one
-      #     fires first.
+      #     (apps/api/src/auth/auth.controller.ts). This route-level bucket is
+      #     what the proof relies on: it is set in CODE and is INDEPENDENT of the
+      #     deployed global THROTTLE_LIMIT. The chart's global limit is set VERY
+      #     HIGH here (THROTTLE_LIMIT_SMOKE) so the earlier smoke suites don't
+      #     trip it, but the login route still caps at 5 — so this assertion
+      #     holds against THROTTLE_LIMIT_PROOF (=5) regardless of the global
+      #     value. The guard applied to every route (ProxyAwareThrottlerGuard, an
+      #     APP_GUARD in app.module.ts) enforces whichever bucket is tighter; for
+      #     /auth/login that is the route-level 5.
       #   * The throttler guard runs BEFORE the handler, so a request over the
       #     limit is 429 before any credential check — a well-formed login body
       #     with a bogus account returns 401 while under the limit and 429 once
@@ -437,7 +458,9 @@ jobs:
       - name: Assert the shared Redis rate-limit counter (429 across pods)
         run: |
           set -uo pipefail
-          LIMIT="$THROTTLE_LIMIT_CI"
+          # The login route's hardcoded route-level limit (5), NOT the deployed
+          # global THROTTLE_LIMIT_SMOKE — the login bucket is what bounds this.
+          LIMIT="$THROTTLE_LIMIT_PROOF"
           TOTAL=$((LIMIT + 10))       # send comfortably past the limit
           ok2xx=0; refused401=0; throttled429=0; other=0
           for i in $(seq 1 "$TOTAL"); do

--- a/.github/workflows/deploy-helm.yml
+++ b/.github/workflows/deploy-helm.yml
@@ -364,9 +364,22 @@ jobs:
       #     limit is 429 before any credential check — a well-formed login body
       #     with a bogus account returns 401 while under the limit and 429 once
       #     over it. It never mutates state and is side-effect-free.
-      #   * All requests come from the same source (the port-forward), so the
-      #     ProxyAwareThrottlerGuard tracker (clientIpFromXff) attributes them
-      #     to ONE counter key — one bucket.
+      #   * Every probe sends a FIXED X-Forwarded-For header so the throttler
+      #     tracker key is IDENTICAL across all 3 api pods BY CONSTRUCTION,
+      #     independent of cluster networking. ProxyAwareThrottlerGuard derives
+      #     the key via clientIpFromXff({ xff, socketIp, trustedHops:
+      #     TRUSTED_PROXY_HOPS }) and the chart default TRUSTED_PROXY_HOPS=1 is
+      #     LEFT INTACT in this install (we do NOT override trustedProxyHops).
+      #     clientIpFromXff with trustedHops=1 returns entries[len-1-1] — the
+      #     SECOND-from-right entry. With a 2-entry chain "203.0.113.7, 10.0.0.1"
+      #     that is entries[0] = 203.0.113.7 on EVERY pod, regardless of which
+      #     pod/socket kube-proxy routes the request to. So all requests land in
+      #     ONE Redis counter key by header construction — NOT by the fragile
+      #     assumption that all 3 pods observe the same SNAT'd socket peer IP
+      #     (they may not, which is precisely what would have made a socket-IP
+      #     key non-discriminating or flaky). See packages/domain/src/client-ip.ts
+      #     for the (trustedHops+1)th-from-right derivation, and
+      #     apps/api/src/common/proxy-aware-throttler.guard.ts for the guard.
       #   * With CACHE_DRIVER=redis every api pod shares that one Redis counter,
       #     so the (limit+1)th request across pods is 429. On the per-pod memory
       #     driver (the bug #285 fixes) the effective limit would be 5 x 3 = 15
@@ -398,11 +411,19 @@ jobs:
           for i in $(seq 1 "$TOTAL"); do
             # A well-formed login body for an account that does not exist. Under
             # the limit this is 401; once the shared counter crosses the limit
-            # the guard returns 429 before the handler runs. Same source => same
-            # throttler tracker key => one bucket shared by all 3 pods via Redis.
+            # the guard returns 429 before the handler runs.
+            #
+            # The FIXED 2-entry X-Forwarded-For makes the throttler tracker key
+            # constant across all 3 pods by construction: with the chart default
+            # TRUSTED_PROXY_HOPS=1, clientIpFromXff returns the second-from-right
+            # entry (203.0.113.7) on every pod, so all requests share ONE Redis
+            # counter key regardless of which pod (and which SNAT'd socket IP)
+            # serves each request. This removes any dependence on kube-proxy
+            # presenting a single stable client IP to every backend pod.
             code=$(curl -s -o /dev/null -w '%{http_code}' \
               -X POST "http://localhost:3001/api/v1/auth/login" \
               -H 'Content-Type: application/json' \
+              -H 'X-Forwarded-For: 203.0.113.7, 10.0.0.1' \
               -d '{"email":"ratelimit-probe@example.com","password":"a-long-enough-password-123"}')
             case "$code" in
               2*)  ok2xx=$((ok2xx+1)) ;;

--- a/.github/workflows/deploy-helm.yml
+++ b/.github/workflows/deploy-helm.yml
@@ -279,16 +279,48 @@ jobs:
             --set ingress.enabled=false
 
       # The migrate Job is the whole point of running migrations OUT of the app
-      # boot path. Assert the pre-install hook Job reached Complete. Its name is
-      # <fullname>-migrate; with release name == chart name the fullname is just
-      # the release name (see snapurl.fullname), so the Job is
-      # "$RELEASE-migrate". helm --wait already blocks on hooks, so this is a
-      # belt-and-braces assertion with a clear failure message.
-      - name: Assert the migrate hook Job completed
+      # boot path. Prove it RAN by querying DURABLE evidence in the database —
+      # the drizzle bookkeeping table — NOT the hook Job object.
+      #
+      # WHY NOT `kubectl wait` on the Job: the migrate Job carries
+      # `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`
+      # (templates/migrate-job.yaml), so Helm GARBAGE-COLLECTS the Job the
+      # instant it succeeds. By the time `helm install --wait` returns the Job
+      # is already gone, and `kubectl wait job/${RELEASE}-migrate` fails with
+      # `NotFound` even though migrations completed. The DB check below is
+      # independent of Helm's GC choice and of any timing.
+      #
+      # WHAT this proves: drizzle-orm's postgres-js migrator records every
+      # applied migration in `drizzle.__drizzle_migrations` (default schema
+      # `drizzle`, table `__drizzle_migrations`; see runMigrations in
+      # packages/database/src/migrate.ts, which passes no custom
+      # migrationsSchema/migrationsTable). A row count >= 1 means at least one
+      # migration was applied by the pre-install hook. If the migration had
+      # FAILED, `helm install --wait` would already have failed on the hook;
+      # and if somehow it did not run, this table would be empty (or absent)
+      # and the check exits non-zero — so a green step genuinely implies a
+      # migrated schema.
+      #
+      # HOW: exec psql INSIDE the throwaway ci-postgres pod (same in-cluster
+      # store the chart migrated against). Running inside the pod uses the
+      # container's local trust, so no password is passed or echoed on the
+      # command line — the same "no secret material in the log" discipline the
+      # Secret-creation step above follows.
+      - name: Assert migrations ran (durable DB check, not the ephemeral hook Job)
         run: |
-          kubectl wait --for=condition=complete "job/${RELEASE}-migrate" \
-            -n "$NS" --timeout=180s
-          echo "migrate Job completed"
+          set -euo pipefail
+          PG_POD="$(kubectl get pod -n "$NS" -l app=ci-postgres \
+            -o jsonpath='{.items[0].metadata.name}')"
+          # `-tAc` = tuples-only, unaligned, single command → a bare integer.
+          count="$(kubectl exec -n "$NS" "$PG_POD" -- \
+            psql -U snapurl -d snapurl -tAc \
+            'SELECT count(*) FROM drizzle.__drizzle_migrations')"
+          echo "applied migrations recorded in drizzle.__drizzle_migrations: $count"
+          if [ "${count:-0}" -lt 1 ]; then
+            echo "::error::the pre-install migrate hook left no rows in drizzle.__drizzle_migrations — migrations did NOT run before the pods rolled."
+            exit 1
+          fi
+          echo "migrate hook verified: schema is migrated (>=1 applied migration)"
 
       # api+redirect must be Available before smoke. --wait covered this, but an
       # explicit rollout status gives a precise failure if a Deployment is stuck.

--- a/.github/workflows/deploy-helm.yml
+++ b/.github/workflows/deploy-helm.yml
@@ -1,0 +1,468 @@
+name: Helm (kind) deploy
+
+# Profile 2 (the horizontally scaled Kubernetes deployment) has one artifact the
+# other CI jobs never touch: the Helm chart at deploy/helm/snapurl. `verify`
+# runs the compiled JS directly and `integration` runs docker compose, so
+# neither ever renders the chart, stands up a cluster, or proves the thing the
+# whole profile exists to prove — that with the Redis CacheStore the rate-limit
+# counter is SHARED across api replicas (#285). This job does exactly that:
+#   * builds the three runtime images from the repo Dockerfile,
+#   * stands up a kind cluster and kind-loads the images,
+#   * deploys a THROWAWAY in-cluster Postgres + Redis (the chart expects
+#     EXTERNAL stores, so CI provides them),
+#   * installs the chart with CACHE_DRIVER=redis, letting the pre-install
+#     migrate Job run before the pods roll,
+#   * runs the smoke suites against the in-cluster services (Done-when #1),
+#   * scales the API to >1 replica and asserts the (limit+1)th request across
+#     pods is 429, which only holds because the counter lives in Redis and is
+#     shared — on the per-pod memory driver the effective limit would be
+#     limit x pods and the assertion would fail (Done-when #2, proving #285).
+#
+# This job is heavy (three image builds + a cluster + a rollout), so it is a
+# separate workflow with its own concurrency group. It does NOT modify
+# verify.yml / publish-images.yml / smoke-deployed.yml.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A new push to the same branch makes the previous run irrelevant.
+concurrency:
+  group: helm-kind-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # The namespace and release name everything below shares. Kept in env so the
+  # kubectl/helm/port-forward steps cannot drift apart.
+  NS: snapurl
+  RELEASE: snapurl
+  # The local image tag the three images are built and kind-loaded under. The
+  # chart's per-service image.repository/image.tag overrides point at these, so
+  # the composed image ref is a bare `snapurl-<app>:ci` (no registry) that
+  # matches exactly what `kind load` puts in the node's image store.
+  IMAGE_TAG: ci
+  # The small, deterministic throttle limit used for the multi-replica 429
+  # assertion. Kept in env so the helm --set and the assertion step agree.
+  THROTTLE_LIMIT_CI: "5"
+  # The redirect host new links are created on. This MUST equal the API's
+  # DEFAULT_DOMAIN and the Host the redirect resolver matches (see
+  # scripts/smoke-redirect.sh header). We port-forward redirect to
+  # localhost:3002, so localhost:3002 satisfies all three by construction —
+  # exactly the single-node/CI convention verify.yml uses.
+  LINK_HOST: localhost:3002
+
+jobs:
+  helm-kind:
+    name: kind deploy + multi-replica rate-limit proof
+    runs-on: ubuntu-latest
+    # Heavy: three image builds, a kind cluster, a full rollout and two smoke
+    # suites. 40 minutes is generous headroom over the observed ~15-20m.
+    timeout-minutes: 40
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Build the three runtime images from the ONE repo Dockerfile, exactly as
+      # publish-images.yml invokes it: --build-arg APP=<app> --target runtime.
+      # Tagged locally as snapurl-<app>:ci so kind can load them. gha buildx
+      # cache keeps the three builds (which share every layer up to the app
+      # build) as fast as possible. NOTE: the runtime target is the plain
+      # container image; the lambda-* targets are not built here.
+      - name: Build the api image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          build-args: APP=api
+          tags: snapurl-api:${{ env.IMAGE_TAG }}
+          load: true
+          cache-from: type=gha,scope=snapurl-api
+          cache-to: type=gha,scope=snapurl-api,mode=max
+
+      - name: Build the redirect image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          build-args: APP=redirect
+          tags: snapurl-redirect:${{ env.IMAGE_TAG }}
+          load: true
+          cache-from: type=gha,scope=snapurl-redirect
+          cache-to: type=gha,scope=snapurl-redirect,mode=max
+
+      - name: Build the worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: runtime
+          build-args: APP=worker
+          tags: snapurl-worker:${{ env.IMAGE_TAG }}
+          load: true
+          cache-from: type=gha,scope=snapurl-worker
+          cache-to: type=gha,scope=snapurl-worker,mode=max
+
+      # Bring up the cluster. helm/kind-action creates a cluster named
+      # "chart-testing" by default (kind v0.31.0). Pin the action major and set
+      # the cluster name explicitly so the `kind load` below cannot target the
+      # wrong cluster.
+      - name: Set up kind
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: chart-testing
+
+      # Load the three locally-built images into the kind node's image store so
+      # pods can run them with imagePullPolicy: Never — nothing is ever pulled
+      # from GHCR. The tags here MUST match the chart's composed image refs
+      # (set via --set below to bare snapurl-<app>:ci).
+      - name: Load images into kind
+        run: |
+          kind load docker-image \
+            "snapurl-api:${IMAGE_TAG}" \
+            "snapurl-redirect:${IMAGE_TAG}" \
+            "snapurl-worker:${IMAGE_TAG}" \
+            --name chart-testing
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      # Throwaway in-cluster Postgres + Redis. The chart expects EXTERNAL
+      # stores, so CI stands up disposable ones. These credentials are
+      # CI-ONLY throwaway values (identical in spirit to verify.yml's postgres
+      # service block) — they never leave this ephemeral cluster and guard
+      # nothing real. postgres:18 is REQUIRED: the schema uses uuidv7(), native
+      # in 18 and absent in 17 (matches verify.yml's image choice). redis:7 is
+      # the CacheStore + click queue.
+      - name: Deploy throwaway Postgres and Redis
+        run: |
+          kubectl create namespace "$NS"
+          kubectl apply -n "$NS" -f - <<'EOF'
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: ci-postgres
+            labels: { app: ci-postgres }
+          spec:
+            replicas: 1
+            selector: { matchLabels: { app: ci-postgres } }
+            template:
+              metadata: { labels: { app: ci-postgres } }
+              spec:
+                containers:
+                  - name: postgres
+                    image: postgres:18-alpine
+                    # Throwaway CI-only credentials — this database lives and
+                    # dies with the ephemeral kind cluster and holds no real data.
+                    env:
+                      - { name: POSTGRES_USER,     value: snapurl }
+                      - { name: POSTGRES_PASSWORD, value: snapurl }
+                      - { name: POSTGRES_DB,       value: snapurl }
+                      # A writable data dir under an emptyDir; the container runs
+                      # as its default user, no securityContext hardening needed
+                      # for a throwaway.
+                      - { name: PGDATA, value: /var/lib/postgresql/data/pgdata }
+                    ports: [ { containerPort: 5432 } ]
+                    readinessProbe:
+                      exec: { command: ["pg_isready", "-U", "snapurl", "-d", "snapurl"] }
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+                    volumeMounts:
+                      - { name: data, mountPath: /var/lib/postgresql/data }
+                volumes:
+                  - { name: data, emptyDir: {} }
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: ci-postgres
+          spec:
+            selector: { app: ci-postgres }
+            ports: [ { port: 5432, targetPort: 5432 } ]
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: ci-redis
+            labels: { app: ci-redis }
+          spec:
+            replicas: 1
+            selector: { matchLabels: { app: ci-redis } }
+            template:
+              metadata: { labels: { app: ci-redis } }
+              spec:
+                containers:
+                  - name: redis
+                    image: redis:7-alpine
+                    ports: [ { containerPort: 6379 } ]
+                    readinessProbe:
+                      exec: { command: ["redis-cli", "ping"] }
+                      initialDelaySeconds: 3
+                      periodSeconds: 5
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: ci-redis
+          spec:
+            selector: { app: ci-redis }
+            ports: [ { port: 6379, targetPort: 6379 } ]
+          EOF
+          kubectl rollout status -n "$NS" deploy/ci-postgres --timeout=180s
+          kubectl rollout status -n "$NS" deploy/ci-redis    --timeout=120s
+
+      # Generate the two JWT signing secrets in-job and write them STRAIGHT into
+      # a Kubernetes Secret with the keys the chart expects when
+      # secrets.existingSecret is used. openssl output goes to kubectl over a
+      # pipe; it is never echoed, never written to $GITHUB_ENV, and never
+      # printed. This is the "throwaway values, clearly marked" pattern from
+      # verify.yml, adapted so no secret material touches the log.
+      #
+      # The chart's existingSecret contract (see templates/_helpers.tpl
+      # snapurl.secretName + values.yaml) requires these keys: jwt-access-secret,
+      # jwt-refresh-secret, database-url, redis-url. The two connection strings
+      # carry the throwaway CI Postgres/Redis credentials.
+      - name: Create the chart Secret (throwaway, never echoed)
+        run: |
+          # Two DIFFERENT secrets, each 64 hex chars (>=32 required by the API
+          # env schema). --from-literal reads the value as an argument, not via
+          # the log; set -x is NOT enabled anywhere in this job.
+          kubectl create secret generic snapurl-secrets \
+            -n "$NS" \
+            --from-literal=jwt-access-secret="$(openssl rand -hex 32)" \
+            --from-literal=jwt-refresh-secret="$(openssl rand -hex 32)" \
+            --from-literal=database-url="postgres://snapurl:snapurl@ci-postgres.${NS}.svc:5432/snapurl" \
+            --from-literal=redis-url="redis://ci-redis.${NS}.svc:6379"
+
+      # Install the chart. --wait blocks on api+redirect readiness AND on the
+      # pre-install migrate hook Job completing (Helm runs pre-install hooks and
+      # waits for them before the release resources). Image overrides make the
+      # composed ref a bare snapurl-<app>:ci (the helper drops the registry
+      # prefix when a per-service image.repository is set), and pullPolicy=Never
+      # forces kind to use the loaded image and never reach GHCR.
+      #
+      # postgres.url + redis.url point at the throwaway in-cluster stores;
+      # redis.url forces CACHE_DRIVER=redis for every service — the shared
+      # counter the rate-limit proof depends on. secrets.existingSecret reuses
+      # the Secret created above so no secret value appears on the helm command
+      # line. throttle.limit is the small CI limit. DEFAULT_DOMAIN /
+      # REDIRECT_ORIGIN / WEB_ORIGIN line up with the port-forward + smoke
+      # scripts (LINK_HOST). ingress.enabled=false (we use port-forward).
+      # hpa.enabled=false: kind has no metrics-server, so an enabled HPA would
+      # sit with "unknown" metrics — noise, not signal. The HPA template is
+      # already validated by `helm template` in FEAT-001; this job's purpose is
+      # the deploy + the rate-limit proof, not autoscaling.
+      - name: Install the chart
+        run: |
+          helm upgrade --install "$RELEASE" deploy/helm/snapurl \
+            --namespace "$NS" \
+            --wait --timeout 10m \
+            --set image.pullPolicy=Never \
+            --set api.image.repository=snapurl-api      --set api.image.tag="$IMAGE_TAG" \
+            --set redirect.image.repository=snapurl-redirect --set redirect.image.tag="$IMAGE_TAG" \
+            --set worker.image.repository=snapurl-worker --set worker.image.tag="$IMAGE_TAG" \
+            --set-string postgres.url="postgres://snapurl:snapurl@ci-postgres.${NS}.svc:5432/snapurl" \
+            --set-string redis.url="redis://ci-redis.${NS}.svc:6379" \
+            --set secrets.existingSecret=snapurl-secrets \
+            --set throttle.limit="$THROTTLE_LIMIT_CI" \
+            --set-string defaultDomain="$LINK_HOST" \
+            --set-string redirectOrigin="http://$LINK_HOST" \
+            --set-string webOrigin="http://localhost:3000" \
+            --set hpa.enabled=false \
+            --set ingress.enabled=false
+
+      # The migrate Job is the whole point of running migrations OUT of the app
+      # boot path. Assert the pre-install hook Job reached Complete. Its name is
+      # <fullname>-migrate; with release name == chart name the fullname is just
+      # the release name (see snapurl.fullname), so the Job is
+      # "$RELEASE-migrate". helm --wait already blocks on hooks, so this is a
+      # belt-and-braces assertion with a clear failure message.
+      - name: Assert the migrate hook Job completed
+        run: |
+          kubectl wait --for=condition=complete "job/${RELEASE}-migrate" \
+            -n "$NS" --timeout=180s
+          echo "migrate Job completed"
+
+      # api+redirect must be Available before smoke. --wait covered this, but an
+      # explicit rollout status gives a precise failure if a Deployment is stuck.
+      - name: Assert api and redirect are Available
+        run: |
+          kubectl rollout status -n "$NS" "deploy/${RELEASE}-api"      --timeout=120s
+          kubectl rollout status -n "$NS" "deploy/${RELEASE}-redirect" --timeout=120s
+          kubectl rollout status -n "$NS" "deploy/${RELEASE}-worker"   --timeout=120s
+
+      # Port-forward the two Services to the localhost ports the smoke scripts
+      # default to (api 3001, redirect 3002). Backgrounded; PIDs captured for
+      # cleanup. Then poll /api/v1/health and /health until they answer, exactly
+      # like verify.yml waits for the started processes.
+      - name: Port-forward api and redirect
+        run: |
+          kubectl port-forward -n "$NS" "svc/${RELEASE}-api" 3001:80 \
+            > /tmp/pf-api.log 2>&1 &
+          echo "PF_API_PID=$!" >> "$GITHUB_ENV"
+          kubectl port-forward -n "$NS" "svc/${RELEASE}-redirect" 3002:80 \
+            > /tmp/pf-redirect.log 2>&1 &
+          echo "PF_REDIRECT_PID=$!" >> "$GITHUB_ENV"
+          for name in "api:3001/api/v1/health" "redirect:3002/health"; do
+            label="${name%%:*}"; url="http://localhost:${name#*:}"
+            for i in $(seq 1 40); do
+              if curl -fsS "$url" >/dev/null 2>&1; then echo "$label is up"; break; fi
+              if [ "$i" = "40" ]; then
+                echo "::error::$label did not become reachable via port-forward within 40s"
+                echo "--- pf-api.log ---";      tail -50 /tmp/pf-api.log      || true
+                echo "--- pf-redirect.log ---"; tail -50 /tmp/pf-redirect.log || true
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
+      # Done-when #1: the integration harness passes against the chart. Same
+      # scripts verify.yml/integration run. LINK_DOMAIN == DEFAULT_DOMAIN ==
+      # the Host the redirect resolver matches (LINK_HOST), so link creation and
+      # the redirect resolver line up (see smoke-redirect.sh header).
+      - name: Smoke — dashboard API
+        run: bash scripts/smoke.sh
+        env:
+          API: http://localhost:3001/api/v1
+
+      - name: Smoke — redirect path
+        run: bash scripts/smoke-redirect.sh
+        env:
+          API: http://localhost:3001/api/v1
+          RD: http://localhost:3002
+          LINK_DOMAIN: ${{ env.LINK_HOST }}
+
+      # ---------------------------------------------------------------------
+      # Done-when #2 — the point of the whole issue.
+      # ---------------------------------------------------------------------
+      # Scale the API to 3 replicas and prove the rate-limit counter is SHARED
+      # across them via the Redis CacheStore (#285).
+      #
+      # WHY the API and not redirect: rate limiting is enforced by the API's
+      # @nestjs/throttler, whose storage is the CacheStore
+      # (apps/api/src/common/cache-throttler-storage.ts -> CacheStore.incr; the
+      # RedisCacheStore.incr is an atomic Lua INCR+EXPIRE). The redirect service
+      # uses the CacheStore only for hot-link caching, so scaling redirect would
+      # not exercise the throttler at all.
+      #
+      # WHY POST /api/v1/auth/login is the target, and why it is deterministic:
+      #   * It carries a route-level @Throttle limit:5/60s
+      #     (apps/api/src/auth/auth.controller.ts), AND the global throttle is
+      #     also set to 5 here (throttle.limit=5) and applied to every route by
+      #     ProxyAwareThrottlerGuard (an APP_GUARD in app.module.ts). Both
+      #     buckets cap at 5, so the assertion holds regardless of which one
+      #     fires first.
+      #   * The throttler guard runs BEFORE the handler, so a request over the
+      #     limit is 429 before any credential check — a well-formed login body
+      #     with a bogus account returns 401 while under the limit and 429 once
+      #     over it. It never mutates state and is side-effect-free.
+      #   * All requests come from the same source (the port-forward), so the
+      #     ProxyAwareThrottlerGuard tracker (clientIpFromXff) attributes them
+      #     to ONE counter key — one bucket.
+      #   * With CACHE_DRIVER=redis every api pod shares that one Redis counter,
+      #     so the (limit+1)th request across pods is 429. On the per-pod memory
+      #     driver (the bug #285 fixes) the effective limit would be 5 x 3 = 15
+      #     and this assertion would NOT see a 429 within the first ~15 requests
+      #     — so the test genuinely proves the shared Redis counter.
+      #
+      # DETERMINISM: send exactly limit + K requests (5 + 10 = 15), count 2xx/4xx
+      # buckets, and assert (a) at least one 429 appeared and (b) no more than
+      # `limit` non-429 responses got through before the limit was crossed. On
+      # the memory driver 3 pods would give up to 15 non-429s and zero 429s, so
+      # both halves fail — which is exactly what makes this a proof of #285.
+      - name: Scale the API to 3 replicas
+        run: |
+          kubectl scale deployment "${RELEASE}-api" -n "$NS" --replicas=3
+          kubectl rollout status -n "$NS" "deploy/${RELEASE}-api" --timeout=180s
+          # Confirm all 3 are Ready before hammering, so the round-robin really
+          # spans 3 pods (the whole point — a shared counter across all of them).
+          kubectl wait --for=condition=ready pod \
+            -n "$NS" -l app.kubernetes.io/component=api --timeout=120s
+          echo "api replicas ready:"
+          kubectl get pods -n "$NS" -l app.kubernetes.io/component=api --no-headers | wc -l
+
+      - name: Assert the shared Redis rate-limit counter (429 across pods)
+        run: |
+          set -uo pipefail
+          LIMIT="$THROTTLE_LIMIT_CI"
+          TOTAL=$((LIMIT + 10))       # send comfortably past the limit
+          ok2xx=0; refused401=0; throttled429=0; other=0
+          for i in $(seq 1 "$TOTAL"); do
+            # A well-formed login body for an account that does not exist. Under
+            # the limit this is 401; once the shared counter crosses the limit
+            # the guard returns 429 before the handler runs. Same source => same
+            # throttler tracker key => one bucket shared by all 3 pods via Redis.
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -X POST "http://localhost:3001/api/v1/auth/login" \
+              -H 'Content-Type: application/json' \
+              -d '{"email":"ratelimit-probe@example.com","password":"a-long-enough-password-123"}')
+            case "$code" in
+              2*)  ok2xx=$((ok2xx+1)) ;;
+              401) refused401=$((refused401+1)) ;;
+              429) throttled429=$((throttled429+1)) ;;
+              *)   other=$((other+1)); echo "unexpected status $code on request $i" ;;
+            esac
+          done
+          # "Allowed" = anything the throttler let reach the handler (2xx or the
+          # 401 the bogus login yields). Everything else at this endpoint under
+          # this load is the 429 we are proving.
+          allowed=$((ok2xx + refused401))
+          echo "sent=$TOTAL allowed(non-429)=$allowed throttled(429)=$throttled429 other=$other"
+          if [ "$throttled429" -lt 1 ]; then
+            echo "::error::no 429 seen across $TOTAL requests to 3 api pods — the rate-limit counter is NOT shared (memory driver / #285 regression). Redis CacheStore would have returned 429 after the ${LIMIT}th request."
+            exit 1
+          fi
+          if [ "$allowed" -gt "$LIMIT" ]; then
+            echo "::error::$allowed requests were allowed but the shared limit is $LIMIT — the counter is per-pod, not shared (effective limit became limit x pods)."
+            exit 1
+          fi
+          if [ "$other" -ne 0 ]; then
+            echo "::error::$other requests returned an unexpected status (not 2xx/401/429)."
+            exit 1
+          fi
+          echo "shared Redis rate-limit counter verified: $allowed <= $LIMIT allowed, $throttled429 throttled across 3 pods"
+
+      # Debuggability, mirroring verify.yml/integration: on ANY failure dump the
+      # cluster state, describes, logs for every workload, and helm status.
+      # Guarded with if: failure() so it only runs when something above failed.
+      # No secret values are printed — logs are app logs (which redact secrets)
+      # and object metadata, never `kubectl get secret -o yaml` or env dumps.
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "===== get all ====="
+          kubectl get pods,svc,deploy,jobs -n "$NS" -o wide || true
+          echo "===== describe pods ====="
+          kubectl describe pods -n "$NS" || true
+          echo "===== api logs ====="
+          kubectl logs -n "$NS" -l app.kubernetes.io/component=api --all-containers --tail=200 || true
+          echo "===== redirect logs ====="
+          kubectl logs -n "$NS" -l app.kubernetes.io/component=redirect --all-containers --tail=200 || true
+          echo "===== worker logs ====="
+          kubectl logs -n "$NS" -l app.kubernetes.io/component=worker --all-containers --tail=200 || true
+          echo "===== migrate hook Job logs ====="
+          kubectl logs -n "$NS" "job/${RELEASE}-migrate" --tail=200 || true
+          echo "===== ci-postgres / ci-redis logs ====="
+          kubectl logs -n "$NS" -l app=ci-postgres --tail=100 || true
+          kubectl logs -n "$NS" -l app=ci-redis --tail=100 || true
+          echo "===== port-forward logs ====="
+          tail -50 /tmp/pf-api.log      || true
+          tail -50 /tmp/pf-redirect.log || true
+          echo "===== helm status ====="
+          helm status "$RELEASE" -n "$NS" || true
+
+      # Stop the background port-forwards regardless of outcome. The kind cluster
+      # itself is torn down by helm/kind-action's post step, so no explicit
+      # cluster teardown is needed and the job stays idempotent.
+      - name: Stop port-forwards
+        if: always()
+        run: |
+          kill "${PF_API_PID:-0}" "${PF_REDIRECT_PID:-0}" 2>/dev/null || true

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -180,6 +180,35 @@ To move to a new release:
 Take a backup first (see [Backup](#7-backup)). Pin `SNAPURL_TAG` to a specific
 release in production rather than tracking `latest`, so upgrades are deliberate.
 
+## Profile 2: horizontally scaled (Kubernetes/Helm)
+
+Everything above is Profile 1: one host, one Postgres, an in-process cache, and
+Caddy for TLS. It is the right default for most self-hosters.
+
+Profile 2 is the horizontally scaled deployment for when a single node is not
+enough. It runs the **same GHCR images** as independent Kubernetes Deployments
+with per-service replica counts, an autoscaler on the bursty redirect service, a
+shared Redis-backed cache that keeps rate limiting correct across API replicas,
+and migrations applied by a pre-upgrade Job rather than by the app pods at boot.
+
+The trade-off is what you have to bring:
+
+| | Profile 1 (single-node) | Profile 2 (Kubernetes/Helm) |
+| --- | --- | --- |
+| Runtime | `docker compose` on one host | A Kubernetes cluster (1.23+) |
+| Postgres | Bundled in the compose stack | External managed Postgres 18 (you provide) |
+| Cache | In-process (`CACHE_DRIVER=memory`) | External Redis (`CACHE_DRIVER=redis`, shared counter) |
+| TLS | Caddy on the host | Ingress + cert-manager (or your LB) |
+| Scaling | Single node | Independent replicas + HPA on redirect |
+| Migrations | `migrate` compose profile | Pre-upgrade Helm hook Job |
+
+Choose Profile 2 when you need to scale the API and the redirect hot path
+independently behind a real ingress with external state. Otherwise stay on
+Profile 1: it is simpler and cheaper.
+
+The full operator walk-through, values reference, and install/upgrade commands
+live in [`deploy/helm/README.md`](./deploy/helm/README.md).
+
 ## What is CI-verified vs. what needs a real domain
 
 Being honest about this matters, so here is the split:

--- a/apps/api/src/links/links.controller.test.ts
+++ b/apps/api/src/links/links.controller.test.ts
@@ -1,0 +1,71 @@
+import "reflect-metadata";
+import { BadRequestException, ParseUUIDPipe } from "@nestjs/common";
+import { ROUTE_ARGS_METADATA } from "@nestjs/common/constants";
+import { describe, expect, it } from "vitest";
+import { LinksController } from "./links.controller.js";
+
+/* ============================================================
+   Every :id route on the links controller parses its id as a UUID at the
+   edge (@Param("id", ParseUUIDPipe)).
+
+   The bug this pins: POST /api/v1/links//clone sent an EMPTY id straight into
+   a Drizzle `where links.id = $1` query, and Postgres raised
+   `invalid input syntax for type uuid: ""` (SQLSTATE 22P02). That code is not
+   in PostgresErrorFilter's map, so it surfaced as a 500 for what is really a
+   malformed request. ParseUUIDPipe rejects an empty or malformed id with a
+   clean 400 BEFORE it can reach the database.
+
+   These are pure metadata/pipe assertions — no DB, no Nest bootstrap — so they
+   run in the normal (non-DB-gated) unit suite.
+   ============================================================ */
+
+/** @nestjs/throttler/pipes store a param's extra pipes on the controller's
+    __routeArguments__ metadata, keyed "<paramtype>:<index>". Each entry holds
+    a `pipes` array. This returns the pipe classes/instances attached to the
+    :id @Param of a given handler, or undefined if the handler has no such
+    param. */
+function paramPipesFor(methodName: keyof LinksController): unknown[] {
+  const meta =
+    Reflect.getMetadata(ROUTE_ARGS_METADATA, LinksController, methodName as string) ?? {};
+  const entries = Object.values(meta) as Array<{ pipes?: unknown[] }>;
+  return entries.flatMap((entry) => entry.pipes ?? []);
+}
+
+/** True when ParseUUIDPipe is among a handler's param pipes, whether it was
+    supplied as the class (Nest instantiates it) or as an instance. */
+function hasParseUuidPipe(methodName: keyof LinksController): boolean {
+  return paramPipesFor(methodName).some(
+    (pipe) => pipe === ParseUUIDPipe || pipe instanceof ParseUUIDPipe,
+  );
+}
+
+describe("LinksController :id routes reject a non-UUID before the DB", () => {
+  for (const route of ["get", "clone", "update", "remove"] as const) {
+    it(`${route} parses its :id with ParseUUIDPipe`, () => {
+      expect(hasParseUuidPipe(route)).toBe(true);
+    });
+  }
+});
+
+describe("ParseUUIDPipe turns an empty or malformed id into a 400, not a 500", () => {
+  const pipe = new ParseUUIDPipe();
+  const metadata = { type: "param" as const, data: "id" };
+
+  it("rejects the empty id from POST /links//clone with a 400", async () => {
+    await expect(pipe.transform("", metadata)).rejects.toBeInstanceOf(BadRequestException);
+    await expect(pipe.transform("", metadata)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("rejects a non-UUID id with a 400", async () => {
+    await expect(pipe.transform("not-a-uuid", metadata)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it("passes a well-formed UUID straight through", async () => {
+    const id = "018f3e2a-1b2c-7d3e-8f90-123456789abc";
+    await expect(pipe.transform(id, metadata)).resolves.toBe(id);
+  });
+});

--- a/apps/api/src/links/links.controller.ts
+++ b/apps/api/src/links/links.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Header, HttpCode, Param, Patch, Post, Query, Res } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Header, HttpCode, Param, ParseUUIDPipe, Patch, Post, Query, Res } from "@nestjs/common";
 import type { FastifyReply } from "fastify";
 import { BulkCreateLinksInput, CloneLinkInput, CreateLinkInput, ListLinksQuery, UpdateLinkInput } from "@snapurl/contract";
 import { zodBody, zodQuery } from "../common/zod.pipe.js";
@@ -41,9 +41,15 @@ export class LinksController {
     reply.raw.end();
   }
 
+  /* Every :id route below parses the param as a UUID at the edge. Link ids are
+     uuidv7 columns, so an empty ("/links//clone") or malformed id is a client
+     mistake, not a lookup that happens to miss. ParseUUIDPipe turns it into a
+     clean 400 BEFORE the value reaches a Drizzle `where id = $1` query — where
+     Postgres would otherwise raise `invalid input syntax for type uuid: ""`
+     (22P02), which the PostgresErrorFilter cannot map and surfaces as a 500. */
   @Get(":id")
   @Scope("links:read")
-  get(@Actor() actor: RequestActor, @Param("id") id: string) {
+  get(@Actor() actor: RequestActor, @Param("id", ParseUUIDPipe) id: string) {
     return this.links.get(actor.workspaceId, id);
   }
 
@@ -73,7 +79,7 @@ export class LinksController {
   @Scope("links:write")
   clone(
     @Actor() actor: RequestActor,
-    @Param("id") id: string,
+    @Param("id", ParseUUIDPipe) id: string,
     @Body(zodBody(CloneLinkInput)) input: CloneLinkInput,
   ) {
     return this.links.clone(actor.workspaceId, id, toActor(actor), input);
@@ -85,7 +91,7 @@ export class LinksController {
   @Scope("links:write")
   update(
     @Actor() actor: RequestActor,
-    @Param("id") id: string,
+    @Param("id", ParseUUIDPipe) id: string,
     @Body(zodBody(UpdateLinkInput)) input: UpdateLinkInput,
   ) {
     return this.links.update(actor.workspaceId, id, toActor(actor), input);
@@ -95,7 +101,7 @@ export class LinksController {
   @Roles("editor")
   @Scope("links:write")
   @HttpCode(204)
-  async remove(@Actor() actor: RequestActor, @Param("id") id: string) {
+  async remove(@Actor() actor: RequestActor, @Param("id", ParseUUIDPipe) id: string) {
     await this.links.remove(actor.workspaceId, id, toActor(actor));
   }
 }

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -364,4 +364,95 @@ connection strings. You have two options:
    - `database-ca-cert` (optional)
 
 The render fails if you provide neither inline secrets nor an existing Secret,
-so you cannot accidentally deploy with no secret.
+so you cannot accidentally deploy with no secret. When you provide inline
+secrets, the chart also enforces the advertised contract **at `helm install`
+time** (not late at app boot): `helm install`/`helm template` fails if either
+JWT secret is shorter than 32 characters or if the two are identical.
+
+> **Required keys when using `secrets.existingSecret`.** The chart does not (and
+> for an externally-managed Secret cannot) validate the contents of a Secret it
+> did not create. A missing key surfaces only as a pod `CrashLoopBackOff` with a
+> `secretKeyRef` error, not as a render failure. Before you deploy with
+> `secrets.existingSecret`, make sure your Secret carries **exactly** these
+> keys: `jwt-access-secret`, `jwt-refresh-secret`, `database-url` (all
+> required), plus `redis-url`, `database-replica-url` and `database-ca-cert`
+> where those features are enabled. The `redis-url` key is required for any
+> multi-replica deployment (see [Why Redis is
+> required](#why-redis-is-required-multi-replica-rate-limiting)).
+
+## Lifecycle of the chart-managed Secret and ConfigMap
+
+The chart-managed `<release>-secrets` Secret and `<release>-config` ConfigMap
+are registered as `helm.sh/hook: pre-install,pre-upgrade` hooks (weight `-10`)
+carrying `helm.sh/resource-policy: keep`. This is deliberate: the migrate Job is
+itself a pre-install hook (weight `-5`), and on a fresh install Helm creates
+normal release resources only **after** pre-install hooks have run. Making the
+Secret a hook at an earlier weight guarantees `database-url` exists in the
+cluster before the migrate Job tries to read it.
+
+That choice has two consequences an operator should know about:
+
+1. **`helm uninstall` orphans them.** Because they are hook resources with
+   `resource-policy: keep`, `helm uninstall snapurl` removes the Deployments,
+   Services, HPA and PDBs but **leaves `<release>-secrets` and
+   `<release>-config` behind**. A later reinstall with the same release name
+   inherits those stale objects. Clean them up explicitly when you tear a
+   release down for good:
+
+   ```bash
+   helm uninstall snapurl --namespace snapurl
+   # the Secret and ConfigMap are NOT removed by uninstall — delete them too:
+   kubectl delete secret,configmap \
+     -n snapurl snapurl-secrets snapurl-config --ignore-not-found
+   ```
+
+   (Substitute your release name for `snapurl` if you installed under a
+   different one; the object names are `<release>-secrets` and
+   `<release>-config`.)
+
+2. **Their update path on `helm upgrade` differs from a normal resource.**
+   Because they are re-applied as `pre-upgrade` hooks, a changed value (for
+   example a rotated `redis.url`) is re-applied to the in-cluster object on
+   `helm upgrade`. The app pods pick up a changed **ConfigMap** value
+   automatically because every Deployment carries a `checksum/config` annotation
+   over the rendered ConfigMap, so a config change rolls the pods. The Secret is
+   deliberately **not** hashed into an annotation (to keep secret material out
+   of pod metadata), so a rotated credential in the Secret does not by itself
+   roll the pods — see [Rotating credentials](#rotating-credentials).
+
+**Why not make the migrate Job read a normally-managed Secret instead?** That
+would remove the hook/`keep` semantics, but the create-ordering problem is real:
+on a fresh install the Secret would not exist when the pre-install migrate hook
+runs. The alternatives (a Job-scoped throwaway Secret, or leaning on hook
+weights without making the long-lived Secret a hook) each add moving parts to a
+security-sensitive path for a one-time ordering concern. The current design is a
+deliberate, documented tradeoff: predictable ordering in exchange for two
+objects you clean up by hand on teardown. (The ConfigMap does not strictly need
+to be a hook — the migrate Job inlines the two env values it needs rather than
+reading the ConfigMap — but it is kept symmetric with the Secret for a single,
+consistent lifecycle story.)
+
+### Rotating credentials
+
+To rotate a credential-bearing value (`postgres.url`, `redis.url`,
+`postgres.replicaUrl`, `postgres.caCert`, or either JWT secret):
+
+- **With `secrets.existingSecret` (recommended for production):** rotate the
+  value in the Secret you manage (via your external secrets operator or
+  `kubectl`), then roll the consuming Deployments so pods pick up the new value:
+
+  ```bash
+  kubectl rollout restart -n snapurl \
+    deploy/snapurl-api deploy/snapurl-redirect deploy/snapurl-worker
+  ```
+
+- **With inline chart-managed secrets:** run `helm upgrade` with the new value
+  (for example `--set-string redis.url=...`). The `pre-upgrade` hook re-applies
+  the Secret, but because the Secret is not hashed into the pod template you
+  must then roll the Deployments with the same `kubectl rollout restart` as
+  above so running pods read the rotated value.
+
+  If you would rather have Helm delete and recreate the object outright,
+  `helm uninstall` + the `kubectl delete` cleanup above, then a fresh
+  `helm upgrade --install`, guarantees a clean Secret — at the cost of a brief
+  outage. For zero-downtime rotation, prefer the `existingSecret` path.

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,367 @@
+# SnapURL Profile 2: the horizontally scaled Kubernetes deployment
+
+This is the operator walk-through for running SnapURL on Kubernetes with the
+Helm chart under [`snapurl/`](./snapurl). It is Profile 2 from the architecture
+epic: the three server images run as independent Deployments with per-service
+replica counts, an autoscaler on the bursty redirect service, a shared
+Redis-backed cache so rate limiting stays correct across API replicas, and
+migrations applied by a pre-upgrade Job rather than by the app pods at boot.
+
+One chart covers EKS, GKE, AKS, k3s and bare-metal Kubernetes. There is no
+per-cloud IaC module to maintain.
+
+## Profile 1 or Profile 2?
+
+Pick the profile that matches how much you need to scale, not the biggest one.
+
+- **Profile 1 (single-node, compose + Caddy).** One host, one Postgres, an
+  in-process cache, in-process click batching, and Caddy for TLS. This is the
+  right default: it is simpler, cheaper, and it is the profile most self-hosters
+  want. See [`../../SELF-HOSTING.md`](../../SELF-HOSTING.md).
+- **Profile 2 (this chart).** Choose it when a single node is not enough: you
+  need to scale the API and the redirect hot path independently, run multiple
+  replicas behind a real ingress, and let an external Postgres and Redis carry
+  the state. It expects you to bring your own managed Postgres and Redis and a
+  Kubernetes cluster to run on.
+
+The two profiles run the **same GHCR images**. The difference is topology, not
+code.
+
+## Prerequisites
+
+Profile 2 does not ship a database or a cache. Both are external and required
+before the chart will deploy:
+
+- A **Kubernetes cluster, version 1.23 or newer**. The chart uses
+  `autoscaling/v2` (HPA), `policy/v1` (PodDisruptionBudget) and
+  `networking.k8s.io/v1` (Ingress), all GA from 1.23. This is the floor declared
+  in [`snapurl/Chart.yaml`](./snapurl/Chart.yaml) (`kubeVersion: ">=1.23.0-0"`).
+- **Helm 3**.
+- An **external managed Postgres 18 primary** reachable from the cluster (RDS,
+  Cloud SQL, Neon, and so on). Postgres 18 is required because the schema uses
+  `uuidv7()`, which is native in 18. Optionally a read replica for
+  `postgres.replicaUrl`.
+- An **external Redis** reachable from the cluster. Redis is what makes
+  multi-replica rate limiting correct (see
+  [Why Redis is required](#why-redis-is-required-multi-replica-rate-limiting)).
+
+The chart ships no Postgres and no Redis on purpose. If you want an in-cluster
+Postgres for testing, add a subchart such as `bitnami/postgresql` yourself and
+point `postgres.url` at its Service DNS. Production should use a managed primary
+with backups you did not have to build.
+
+## Install
+
+Provide the three things the chart cannot default: the Postgres URL, the Redis
+URL, and the two JWT signing secrets (or an existing Secret that holds them).
+This is a `helm install` (expressed as `helm upgrade --install`, which is
+idempotent and works for both the first install and later upgrades):
+
+```bash
+helm upgrade --install snapurl deploy/helm/snapurl \
+  --namespace snapurl --create-namespace \
+  --set-string postgres.url="postgres://user:pass@db-host:5432/snapurl" \
+  --set-string redis.url="redis://redis-host:6379" \
+  --set secrets.jwtAccessSecret="REPLACE_WITH_A_32_PLUS_CHAR_SECRET" \
+  --set secrets.jwtRefreshSecret="REPLACE_WITH_A_DIFFERENT_32_PLUS_CHAR_SECRET" \
+  --set ingress.enabled=true \
+  --set-string ingress.className=nginx \
+  --set-string ingress.apiHost=app.example.com \
+  --set-string ingress.redirectHost=s.example.com \
+  --set ingress.tls.enabled=true \
+  --set-string ingress.tls.clusterIssuer=letsencrypt-prod
+```
+
+The hostnames and secrets above are placeholders. Use your own, and never commit
+real secret values into a values file. For production, prefer
+`secrets.existingSecret` over inline secrets (see [Secrets](#secrets)).
+
+`helm upgrade --install` runs the migrate Job as a pre-install hook and waits
+for it before the app pods roll. When the release completes the chart prints
+post-install notes (`snapurl/templates/NOTES.txt`) with the workload counts, how
+to reach the services, and a reminder about `TRUSTED_PROXY_HOPS`.
+
+If you leave `ingress.enabled=false`, reach the services with `kubectl
+port-forward` (the notes print the exact commands).
+
+## Values reference
+
+Every key below exists in [`snapurl/values.yaml`](./snapurl/values.yaml), which
+is heavily commented and is the authoritative contract. This table summarizes
+the top-level stanzas.
+
+### Images
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `image.registry` | `ghcr.io` | Registry for all three images. |
+| `image.repositoryPrefix` | `dhananjaythomble/snapurl-` | Composed as `registry/prefix<component>:tag`. |
+| `image.tag` | `latest` | Pin to a release (e.g. `v2.0.0`) in production. |
+| `image.pullPolicy` | `IfNotPresent` | |
+| `imagePullSecrets` | `[]` | Only needed for a private registry. |
+
+### api
+
+The NestJS control plane (auth, links CRUD, analytics reads). This is where
+rate limiting is enforced.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `api.replicaCount` | `2` | Scales independently; safe to raise once Redis is set. |
+| `api.image.repository` / `api.image.tag` | `""` | Per-service overrides; blank uses the global image. |
+| `api.resources.requests` / `api.resources.limits` | `250m`/`256Mi` req | Sensible starting requests and limits. |
+| `api.probes` | `initialDelaySeconds: 10`, etc. | Probe path is fixed at `/api/v1/health` on port 3001. |
+| `api.service.port` | `3001` | |
+
+### redirect
+
+The Fastify hot path (three routes). The only bursty deployment, so it is the
+only one with an HPA.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `redirect.replicaCount` | `3` | Seed only when `hpa.enabled` (the HPA then owns the count). |
+| `redirect.image.repository` / `redirect.image.tag` | `""` | Per-service overrides. |
+| `redirect.resources.requests` / `redirect.resources.limits` | `100m`/`128Mi` req | |
+| `redirect.probes` | `initialDelaySeconds: 10`, etc. | Probe path is fixed at `/health` on port 3002. |
+| `redirect.service.port` | `3002` | |
+
+### worker
+
+The in-process rollup/maintenance loop. No HTTP surface, no Service, no probes,
+no PDB.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `worker.replicaCount` | `1` | Keep small and fixed (see [Scaling](#scaling)). |
+| `worker.image.repository` / `worker.image.tag` | `""` | Per-service overrides. |
+| `worker.resources.requests` / `worker.resources.limits` | `100m`/`128Mi` req | |
+
+### ingress
+
+Routes the two public hostnames to the api and redirect Services.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `ingress.enabled` | `false` | When off, use `kubectl port-forward`. |
+| `ingress.className` | `""` | e.g. `nginx`, `traefik`; empty uses the cluster default. |
+| `ingress.annotations` | `{}` | Extra annotations (cert-manager is merged in from `tls`). |
+| `ingress.apiHost` | `""` | Dashboard/API hostname to the api Service. |
+| `ingress.redirectHost` | `""` | Short-link hostname to the redirect Service. |
+| `ingress.tls.enabled` | `false` | |
+| `ingress.tls.secretName` | `""` | A single TLS Secret covering both hosts. |
+| `ingress.tls.clusterIssuer` | `""` | cert-manager ClusterIssuer; adds the `cluster-issuer` annotation. |
+
+### postgres (external)
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `postgres.url` | `""` (required) | `postgres://USER:PASSWORD@HOST:5432/DBNAME`; goes to the Secret. |
+| `postgres.replicaUrl` | `""` | Optional read-replica string; absent means reads use the primary. |
+| `postgres.ssl` | `false` | Enable TLS to the database. |
+| `postgres.sslNoVerify` | `false` | Skip cert checks (VPC/self-signed only; insecure otherwise). |
+| `postgres.caCert` | `""` | PEM CA bundle to verify the server cert; goes to the Secret. |
+| `postgres.poolMax` | `10` | Max pool connections per pod. |
+
+### redis (external)
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `redis.url` | `""` | `redis://[:PASSWORD@]HOST:6379`. When set, forces `CACHE_DRIVER=redis` for every service. |
+
+### throttle
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `throttle.ttlSeconds` | `60` | Global throttle window (`THROTTLE_TTL_SECONDS`). |
+| `throttle.limit` | `120` | Requests per window (`THROTTLE_LIMIT`). |
+
+### App env (non-secret)
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `webOrigin` | `""` | Dashboard origin (CORS + email links). |
+| `defaultDomain` | `""` | Default short domain for new workspaces. |
+| `redirectOrigin` | `""` | Where redirects are served from (for building short URLs). |
+| `trustedProxyHops` | `1` | Proxy hop count that appends `X-Forwarded-For` (see [below](#trusted_proxy_hops-and-your-ingress)). |
+| `mail.transport` | `outbox` | `outbox` writes messages to a file; `ses` uses SES. |
+| `mail.from` | `""` | e.g. `SnapURL <no-reply@example.com>`. |
+| `logLevel` | `info` | `trace`, `debug`, `info`, `warn`, `error`. |
+
+### secrets
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `secrets.jwtAccessSecret` | `""` | Inline JWT access secret (>=32 chars). |
+| `secrets.jwtRefreshSecret` | `""` | Inline JWT refresh secret (>=32 chars; must differ). |
+| `secrets.existingSecret` | `""` | Name of a Secret you manage instead (see [Secrets](#secrets)). |
+
+### hpa (redirect only)
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `hpa.enabled` | `true` | Autoscales the redirect Deployment only. |
+| `hpa.minReplicas` | `3` | |
+| `hpa.maxReplicas` | `10` | |
+| `hpa.targetCPUUtilizationPercentage` | `70` | `autoscaling/v2` CPU target. |
+
+### pdb (api and redirect only)
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `pdb.enabled` | `true` | No PDB for the single-replica worker. |
+| `pdb.api.minAvailable` | `1` | |
+| `pdb.redirect.minAvailable` | `1` | |
+
+### analytics
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `analytics.reader` | `postgres` | The only reader that exists today. |
+| `analytics.columnar.enabled` | `false` | Future seam; wires env only (see [below](#the-analyticsreader-columnar-seam-future)). |
+| `analytics.columnar.driver` | `""` | Future, e.g. `clickhouse`. |
+| `analytics.columnar.url` | `""` | Future columnar store connection string. |
+
+### migrateJob
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `migrateJob.enabled` | `true` | Set `false` if migrations are managed out of band (see [Upgrades](#upgrades-and-migrations)). |
+| `migrateJob.backoffLimit` | `3` | |
+| `migrateJob.activeDeadlineSeconds` | `600` | |
+
+### Other
+
+`serviceAccount`, `podSecurityContext`, `securityContext`, `nodeSelector`,
+`tolerations`, and `affinity` follow the usual chart conventions; see
+`snapurl/values.yaml` for their defaults. The security contexts match the
+Dockerfile's non-root `node` user (uid 1000).
+
+## Scaling
+
+The three services scale independently because their load profiles differ
+sharply.
+
+- **api** runs a fixed `api.replicaCount` (default 2). It is not autoscaled by
+  the chart. Raise it as your control-plane traffic grows. This is safe only
+  because Redis makes the rate-limit counter shared across pods; see below.
+- **redirect** is the only bursty deployment (a short link can go viral), so it
+  is the only one with an **HPA** (`autoscaling/v2`, CPU target). When
+  `hpa.enabled` is true the **HPA owns redirect's replica count** between
+  `hpa.minReplicas` and `hpa.maxReplicas`, so `redirect.replicaCount` is only
+  the initial seed. Set `hpa.enabled=false` to pin the count with
+  `redirect.replicaCount` instead (for example on a cluster with no
+  metrics-server, where an HPA would sit with unknown metrics).
+- **worker** stays at a **small fixed count** (default 1). Its rollup loop
+  drains `click_events` then marks them consumed on the primary handle; running
+  many concurrent workers would just have them contend on the same rows for no
+  throughput gain. It is deliberately not autoscaled and has no Service, no
+  probes, and no PDB.
+
+`PodDisruptionBudget`s guard api and redirect (`minAvailable: 1` each) so at
+least one pod stays up during a voluntary node drain while still letting the
+drain proceed. There is no PDB on the worker: a `minAvailable` on a one-replica
+Deployment would block node drains entirely.
+
+## Why Redis is required (multi-replica rate limiting)
+
+Rate limiting is enforced by the **API**, not the redirect service. The API
+backs `@nestjs/throttler` with the `CacheStore`. When `redis.url` is set the
+chart forces `CACHE_DRIVER=redis` for every service, so the throttler's counter
+lives in Redis and is **shared across all API replicas**. The effective limit is
+then the configured limit, not the limit multiplied by the number of pods.
+
+This is the correctness property Profile 2 exists to guarantee (issue #285).
+Without Redis, `CACHE_DRIVER` falls back to the per-instance `memory` driver,
+which is only correct for a single API replica: with N replicas each pod keeps
+its own counter and the effective limit becomes `limit x N`.
+
+**Set `redis.url` for any multi-replica deployment.** The redirect service uses
+the cache only for hot-link caching (a short TTL), not for throttling, so it is
+scaling the API that depends on the shared counter.
+
+The kind CI job ([`.github/workflows/deploy-helm.yml`](../../.github/workflows/deploy-helm.yml))
+proves this end to end: it deploys the chart with `CACHE_DRIVER=redis`, scales
+the API to 3 replicas, sends more requests than the limit at a throttled
+endpoint, and asserts that a 429 appears and that no more than `limit` requests
+get through. On the per-pod memory driver that assertion would fail, so the test
+genuinely proves the shared Redis counter.
+
+## Upgrades and migrations
+
+The app pods **never migrate at boot**. Migrations run in a dedicated Job that
+the chart registers as a `helm.sh/hook: pre-install,pre-upgrade` hook. Helm runs
+that hook and waits for it to complete **before** the new app pods roll. The Job
+reuses the worker image and calls the same `runMigrations` entry point the
+single-node compose migrate service uses.
+
+Running migrations out of the boot path is deliberate: if every app pod tried to
+migrate as it started, concurrent boots would race on the schema. The
+pre-upgrade Job applies pending migrations exactly once, then the rollout
+proceeds.
+
+To upgrade, point `image.tag` at the new release and run the same command:
+
+```bash
+helm upgrade --install snapurl deploy/helm/snapurl \
+  --namespace snapurl \
+  --set-string image.tag=v2.0.0 \
+  --reuse-values
+```
+
+Take a database backup first, and pin `image.tag` to a specific release rather
+than tracking `latest` so upgrades are deliberate.
+
+If you manage migrations out of band (for example a separate CD step or a DBA
+process), set `migrateJob.enabled=false` and the chart will not create the hook.
+
+## TRUSTED_PROXY_HOPS and your ingress
+
+`trustedProxyHops` (env `TRUSTED_PROXY_HOPS`, default `1`) is the number of
+proxies in front of the services that **append** their edge IP to
+`X-Forwarded-For`. The throttler and the visitor hash derive the real client IP
+as the `(trustedProxyHops + 1)`th entry from the right of the chain, so a client
+cannot forge it.
+
+This value **must match your actual ingress topology**, or client-IP-derived
+rate limiting and visitor hashing key off the wrong IP:
+
+- **nginx-ingress alone in front of the services:** `1` (the default).
+- **nginx-ingress behind a cloud load balancer that also appends XFF:** `2`.
+
+Add 1 for each additional appending hop. If you are unsure whether your cloud LB
+appends to `X-Forwarded-For`, check its documentation before changing this.
+
+## The AnalyticsReader columnar seam (future)
+
+Only the **Postgres** `AnalyticsReader` exists in code today (issue #284). The
+`analytics.columnar` stanza is a documented **future** plumbing seam: it is
+`enabled: false` by default, and when enabled it wires environment only. **No
+columnar adapter ships with this chart.** Leave `analytics.columnar.enabled`
+false unless and until a columnar reader exists. The seam is here so the env
+contract is ready when that adapter lands; see
+[`../../docs/DECISIONS.md`](../../docs/DECISIONS.md) for the analytics-store
+rationale.
+
+## Secrets
+
+The chart needs the two JWT signing secrets, plus the credential-bearing
+connection strings. You have two options:
+
+1. **Inline** `secrets.jwtAccessSecret` and `secrets.jwtRefreshSecret`. Each
+   must be at least 32 characters, and the two must differ. The chart then
+   creates a Secret that also holds `database-url`, `redis-url`, and (if set)
+   `database-ca-cert`. Do not commit real inline secrets to a values file.
+2. **`secrets.existingSecret`** (preferred for production). Set it to the name
+   of a Secret you manage, for example via an external secrets operator. The
+   chart then creates no Secret of its own and expects these keys in yours:
+
+   - `jwt-access-secret`
+   - `jwt-refresh-secret`
+   - `database-url`
+   - `redis-url`
+   - `database-replica-url` (optional)
+   - `database-ca-cert` (optional)
+
+The render fails if you provide neither inline secrets nor an existing Secret,
+so you cannot accidentally deploy with no secret.

--- a/deploy/helm/snapurl/.helmignore
+++ b/deploy/helm/snapurl/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when packaging the chart (helm package / helm install).
+# Mirrors the default `helm create` .helmignore plus this repo's task metadata.
+.DS_Store
+# Version control
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+# Common backup/temporary files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+*.tmpl.bak
+# IDE / editor
+.idea/
+.vscode/
+# CI / build artifacts
+*.log
+# Repo agent/task metadata — never part of a packaged chart
+.tasks/
+.agents/
+.kiro/

--- a/deploy/helm/snapurl/Chart.yaml
+++ b/deploy/helm/snapurl/Chart.yaml
@@ -1,0 +1,35 @@
+# Profile 2 — the horizontally scaled Kubernetes deployment.
+#
+# One chart for every Kubernetes: EKS, GKE, AKS, k3s and bare-metal. It runs
+# the same three GHCR images the single-node compose runs (api, redirect,
+# worker), but as independent Deployments with per-service replica counts, an
+# HPA on the bursty redirect service, a Redis-backed CacheStore so rate limiting
+# stays correct across API replicas, and migrations as a pre-upgrade Job rather
+# than something the apps race to run at boot. See deploy/helm/README.md and the
+# Profile 2 section of SELF-HOSTING.md for the operator walk-through.
+apiVersion: v2
+name: snapurl
+description: SnapURL — the horizontally scaled Kubernetes deployment (Profile 2)
+type: application
+
+# Chart SemVer: bumped when the templates/values change, independent of the app.
+version: 0.1.0
+
+# The default application version this chart deploys. Matches values.yaml
+# image.tag: pin it to a release tag (e.g. "v2.0.0") in production; "latest"
+# follows the newest published build.
+appVersion: "latest"
+
+# autoscaling/v2 and policy/v1 are GA from k8s 1.23, and networking.k8s.io/v1
+# Ingress has been GA far longer. 1.23 is the floor this chart supports.
+kubeVersion: ">=1.23.0-0"
+
+home: https://github.com/DhananjayThomble/URL-Shortener-App
+sources:
+  - https://github.com/DhananjayThomble/URL-Shortener-App
+keywords:
+  - url-shortener
+  - snapurl
+maintainers:
+  - name: SnapURL maintainers
+    url: https://github.com/DhananjayThomble/URL-Shortener-App

--- a/deploy/helm/snapurl/templates/NOTES.txt
+++ b/deploy/helm/snapurl/templates/NOTES.txt
@@ -1,0 +1,37 @@
+SnapURL (Profile 2 — horizontally scaled) has been {{ if .Release.IsInstall }}installed{{ else }}upgraded{{ end }} as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Schema migrations ran as a pre-{{ if .Release.IsInstall }}install{{ else }}upgrade{{ end }} Job BEFORE the app pods rolled — the apps never migrate at boot, so there is no concurrent-boot migration race to worry about.
+
+Workloads:
+  * api      x {{ .Values.api.replicaCount }}   (Service :80 -> :{{ .Values.api.service.port }}, health /api/v1/health)
+  * redirect x {{ if .Values.hpa.enabled }}{{ .Values.hpa.minReplicas }}-{{ .Values.hpa.maxReplicas }} (HPA){{ else }}{{ .Values.redirect.replicaCount }}{{ end }}   (Service :80 -> :{{ .Values.redirect.service.port }}, health /health)
+  * worker   x {{ .Values.worker.replicaCount }}   (no Service, no HTTP)
+
+{{- if .Values.ingress.enabled }}
+
+Reach it via the ingress:
+{{- if .Values.ingress.apiHost }}
+  API/dashboard: http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.apiHost }}
+{{- end }}
+{{- if .Values.ingress.redirectHost }}
+  Short links:   http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.redirectHost }}
+{{- end }}
+  Make sure TRUSTED_PROXY_HOPS (currently {{ .Values.trustedProxyHops }}) matches how many proxies in front of these services append to X-Forwarded-For, or rate limiting keys off the wrong client IP.
+{{- else }}
+
+Ingress is DISABLED. Reach the services with kubectl port-forward, e.g.:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "snapurl.fullname" . }}-api 3001:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "snapurl.fullname" . }}-redirect 3002:80
+{{- end }}
+
+{{- if not .Values.redis.url }}
+
+WARNING: redis.url is NOT set, so CACHE_DRIVER falls back to "memory" (a
+per-instance counter). With more than one api replica the rate limit is applied
+PER POD, not globally. Set redis.url to make multi-replica rate limiting correct.
+{{- end }}
+
+Reminders:
+  * postgres.url must point at an EXTERNAL managed Postgres primary (this chart ships no database).
+  * redis.url makes multi-replica rate limiting correct (shared throttle counter).
+  * Provide secrets.jwtAccessSecret + secrets.jwtRefreshSecret (>=32 chars each), OR set secrets.existingSecret.

--- a/deploy/helm/snapurl/templates/_helpers.tpl
+++ b/deploy/helm/snapurl/templates/_helpers.tpl
@@ -1,0 +1,114 @@
+{{/*
+Standard Helm helpers for the snapurl chart.
+*/}}
+
+{{/* The base name, overridable with nameOverride. */}}
+{{- define "snapurl.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* The fully qualified app name (release-scoped), overridable with fullnameOverride. */}}
+{{- define "snapurl.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* chart name + version, for the helm.sh/chart label. */}}
+{{- define "snapurl.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common labels applied to every object. */}}
+{{- define "snapurl.labels" -}}
+helm.sh/chart: {{ include "snapurl.chart" . }}
+{{ include "snapurl.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: snapurl
+{{- end -}}
+
+{{/* Selector labels shared by the whole release. */}}
+{{- define "snapurl.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "snapurl.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Per-component labels. Call with a dict: (dict "root" . "component" "api").
+Includes the common labels plus the component label so api/redirect/worker
+objects are distinguishable while still sharing the release labels.
+*/}}
+{{- define "snapurl.componentLabels" -}}
+{{- $root := .root -}}
+{{ include "snapurl.labels" $root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Per-component selector labels. Call with (dict "root" . "component" "api").
+These are the immutable selector keys a Deployment/Service/PDB matches on.
+*/}}
+{{- define "snapurl.componentSelectorLabels" -}}
+{{- $root := .root -}}
+{{ include "snapurl.selectorLabels" $root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/* The ServiceAccount name to use. */}}
+{{- define "snapurl.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "snapurl.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The name of the Secret holding credentials. Returns existingSecret when set,
+else the chart-managed Secret name.
+*/}}
+{{- define "snapurl.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "snapurl.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* The ConfigMap name holding non-secret env. */}}
+{{- define "snapurl.configMapName" -}}
+{{- printf "%s-config" (include "snapurl.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Compose the image ref for a component. Call with:
+  (dict "root" . "component" "api")
+Uses the per-service repository/tag override when set, else the global
+registry + repositoryPrefix + component + global tag.
+*/}}
+{{- define "snapurl.image" -}}
+{{- $root := .root -}}
+{{- $component := .component -}}
+{{- $svc := index $root.Values $component -}}
+{{- $globalTag := $root.Values.image.tag -}}
+{{- if and $svc $svc.image $svc.image.repository -}}
+{{- $tag := default $globalTag $svc.image.tag -}}
+{{- printf "%s:%s" $svc.image.repository $tag -}}
+{{- else -}}
+{{- $tag := $globalTag -}}
+{{- if and $svc $svc.image $svc.image.tag -}}
+{{- $tag = $svc.image.tag -}}
+{{- end -}}
+{{- printf "%s/%s%s:%s" $root.Values.image.registry $root.Values.image.repositoryPrefix $component $tag -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/snapurl/templates/configmap.yaml
+++ b/deploy/helm/snapurl/templates/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "snapurl.configMapName" . }}
+  labels:
+    {{- include "snapurl.labels" . | nindent 4 }}
+  annotations:
+    # Also a pre-install/pre-upgrade hook (weight -10) so the DATABASE_SSL /
+    # non-secret toggles the migrate Job reads exist before it runs — same
+    # ordering reason as the Secret. Kept around for the Deployments too.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/resource-policy": keep
+data:
+  # Non-secret env shared by all services. Credential-bearing values
+  # (DATABASE_URL, REDIS_URL, DATABASE_CA_CERT, JWT secrets) live in the Secret,
+  # NOT here — only non-credential toggles and public origins are in the ConfigMap.
+  NODE_ENV: "production"
+  WEB_ORIGIN: {{ .Values.webOrigin | quote }}
+  DEFAULT_DOMAIN: {{ .Values.defaultDomain | quote }}
+  REDIRECT_ORIGIN: {{ .Values.redirectOrigin | quote }}
+  TRUSTED_PROXY_HOPS: {{ .Values.trustedProxyHops | quote }}
+  # CACHE_DRIVER is forced to "redis" whenever redis.url is set, so every API
+  # replica shares one throttle counter (correct multi-replica rate limiting).
+  # With no redis.url it falls back to the per-instance "memory" driver.
+  CACHE_DRIVER: {{ if .Values.redis.url }}"redis"{{ else }}"memory"{{ end }}
+  THROTTLE_TTL_SECONDS: {{ .Values.throttle.ttlSeconds | quote }}
+  THROTTLE_LIMIT: {{ .Values.throttle.limit | quote }}
+  MAIL_TRANSPORT: {{ .Values.mail.transport | quote }}
+  {{- if .Values.mail.from }}
+  MAIL_FROM: {{ .Values.mail.from | quote }}
+  {{- end }}
+  LOG_LEVEL: {{ .Values.logLevel | quote }}
+  # Database toggles (non-credential). DATABASE_URL/replica/CA live in the Secret.
+  DATABASE_SSL: {{ .Values.postgres.ssl | quote }}
+  DATABASE_SSL_NO_VERIFY: {{ .Values.postgres.sslNoVerify | quote }}
+  DATABASE_POOL_MAX: {{ .Values.postgres.poolMax | quote }}
+  {{- if .Values.analytics.columnar.enabled }}
+  # FUTURE seam (#284): only the postgres reader exists today. When the
+  # columnar branch is enabled we plumb the env, but no columnar adapter ships
+  # in this chart — the app must gain one for these to do anything.
+  ANALYTICS_READER: {{ .Values.analytics.reader | quote }}
+  ANALYTICS_COLUMNAR_DRIVER: {{ .Values.analytics.columnar.driver | quote }}
+  ANALYTICS_COLUMNAR_URL: {{ .Values.analytics.columnar.url | quote }}
+  {{- end }}

--- a/deploy/helm/snapurl/templates/deployment-api.yaml
+++ b/deploy/helm/snapurl/templates/deployment-api.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "snapurl.fullname" . }}-api
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "api") | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "snapurl.componentLabels" (dict "root" . "component" "api") | nindent 8 }}
+      annotations:
+        # Roll pods when the non-secret config changes. The Secret is not hashed
+        # here on purpose (avoid rendering secret material into an annotation).
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "snapurl.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: api
+          image: {{ include "snapurl.image" (dict "root" . "component" "api") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # CMD is inherited from the image (node dist/main.js).
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "snapurl.configMapName" . }}
+          env:
+            - name: PORT
+              value: {{ .Values.api.service.port | quote }}
+            # The API needs BOTH JWT secrets: it signs access AND refresh tokens.
+            - name: JWT_ACCESS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: jwt-access-secret
+            - name: JWT_REFRESH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: jwt-refresh-secret
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-url
+            {{- if .Values.postgres.replicaUrl }}
+            - name: DATABASE_REPLICA_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-replica-url
+            {{- end }}
+            {{- if .Values.redis.url }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: redis-url
+            {{- end }}
+            {{- if .Values.postgres.caCert }}
+            - name: DATABASE_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-ca-cert
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: {{ .Values.api.service.port }}
+            initialDelaySeconds: {{ .Values.api.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.probes.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.probes.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: {{ .Values.api.service.port }}
+            initialDelaySeconds: {{ .Values.api.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.probes.periodSeconds }}
+            timeoutSeconds: {{ .Values.api.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.api.probes.failureThreshold }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/snapurl/templates/deployment-redirect.yaml
+++ b/deploy/helm/snapurl/templates/deployment-redirect.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "snapurl.fullname" . }}-redirect
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "redirect") | nindent 4 }}
+spec:
+  # NOTE: when hpa.enabled the HPA owns this count — replicaCount is only the
+  # initial value. Omitted from the manifest when the HPA is enabled so it does
+  # not fight the autoscaler on every `helm upgrade`.
+  {{- if not .Values.hpa.enabled }}
+  replicas: {{ .Values.redirect.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "redirect") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "snapurl.componentLabels" (dict "root" . "component" "redirect") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "snapurl.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redirect
+          image: {{ include "snapurl.image" (dict "root" . "component" "redirect") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.redirect.service.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "snapurl.configMapName" . }}
+          env:
+            - name: PORT
+              value: {{ .Values.redirect.service.port | quote }}
+            # Least-privilege: the redirect verifies unlock tokens the API
+            # SIGNED, so it needs ONLY the access secret — NOT the refresh secret.
+            - name: JWT_ACCESS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: jwt-access-secret
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-url
+            {{- if .Values.postgres.replicaUrl }}
+            - name: DATABASE_REPLICA_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-replica-url
+            {{- end }}
+            {{- if .Values.redis.url }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: redis-url
+            {{- end }}
+            {{- if .Values.postgres.caCert }}
+            - name: DATABASE_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-ca-cert
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.redirect.service.port }}
+            initialDelaySeconds: {{ .Values.redirect.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redirect.probes.periodSeconds }}
+            timeoutSeconds: {{ .Values.redirect.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.redirect.probes.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.redirect.service.port }}
+            initialDelaySeconds: {{ .Values.redirect.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redirect.probes.periodSeconds }}
+            timeoutSeconds: {{ .Values.redirect.probes.timeoutSeconds }}
+            failureThreshold: {{ .Values.redirect.probes.failureThreshold }}
+          resources:
+            {{- toYaml .Values.redirect.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/snapurl/templates/deployment-worker.yaml
+++ b/deploy/helm/snapurl/templates/deployment-worker.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "snapurl.fullname" . }}-worker
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "worker") | nindent 4 }}
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "worker") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "snapurl.componentLabels" (dict "root" . "component" "worker") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "snapurl.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: worker
+          image: {{ include "snapurl.image" (dict "root" . "component" "worker") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # CMD is inherited (node dist/main.js runs the rollup/maintenance loop).
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          # No Service, no ports and NO HTTP probes: the worker serves no HTTP.
+          # Its liveness shows in the rollup tables, not on a port. An exec/TCP
+          # probe would be a guess with no endpoint behind it, so it is omitted.
+          envFrom:
+            - configMapRef:
+                name: {{ include "snapurl.configMapName" . }}
+          env:
+            # The worker needs NEITHER JWT secret — it does no auth. Only the DB.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-url
+            {{- if .Values.postgres.caCert }}
+            - name: DATABASE_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-ca-cert
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/snapurl/templates/hpa-redirect.yaml
+++ b/deploy/helm/snapurl/templates/hpa-redirect.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.hpa.enabled }}
+{{- /*
+  The redirect service is the ONLY bursty deployment, so it is the only one
+  autoscaled. api and worker are not. When this HPA is enabled it OWNS the
+  redirect replica count, which is why deployment-redirect.yaml omits `replicas`
+  in that case — otherwise every `helm upgrade` would reset the count and fight
+  the autoscaler.
+*/}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "snapurl.fullname" . }}-redirect
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "redirect") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "snapurl.fullname" . }}-redirect
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/snapurl/templates/ingress.yaml
+++ b/deploy/helm/snapurl/templates/ingress.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.ingress.enabled }}
+{{- /*
+  Routes the two public hostnames to the api and redirect Services.
+
+  TRUSTED_PROXY_HOPS (values.trustedProxyHops) must match how many proxies in
+  front of these services APPEND to X-Forwarded-For: the ingress controller is
+  one hop; a cloud LB that also appends XFF makes it two. Set it wrong and rate
+  limiting / visitor hashing key off the wrong client IP.
+*/}}
+{{- $fullName := include "snapurl.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "snapurl.labels" . | nindent 4 }}
+  {{- if or .Values.ingress.annotations .Values.ingress.tls.clusterIssuer }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingress.tls.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- if .Values.ingress.apiHost }}
+        - {{ .Values.ingress.apiHost | quote }}
+        {{- end }}
+        {{- if .Values.ingress.redirectHost }}
+        - {{ .Values.ingress.redirectHost | quote }}
+        {{- end }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+      {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.apiHost }}
+    - host: {{ .Values.ingress.apiHost | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-api
+                port:
+                  number: 80
+    {{- end }}
+    {{- if .Values.ingress.redirectHost }}
+    - host: {{ .Values.ingress.redirectHost | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-redirect
+                port:
+                  number: 80
+    {{- end }}
+{{- end }}

--- a/deploy/helm/snapurl/templates/migrate-job.yaml
+++ b/deploy/helm/snapurl/templates/migrate-job.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.migrateJob.enabled }}
+{{- /*
+  THE POINT OF THIS JOB: the apps do NOT migrate at boot. Running the schema
+  migration inside every pod's start-up would have N replicas racing to apply
+  the same migrations concurrently — the exact failure mode this Job prevents.
+  Instead this runs ONCE, as a Helm pre-install/pre-upgrade hook, before the new
+  pods roll.
+
+  It reuses the WORKER image because that image ships the drizzle/*.sql folder
+  (packages/database lists "drizzle" in its files) and bundles @snapurl/database
+  under node_modules, so the bare `require('@snapurl/database').runMigrations`
+  resolves — exactly like the single-node compose `migrate` service.
+
+  The command below is byte-identical to deploy/single-node/docker-compose.yml.
+
+  Uses the default ServiceAccount (not the chart's) on purpose: the chart SA is
+  a normal resource created AFTER pre-install hooks, so it does not yet exist
+  when this hook runs on a fresh install.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "snapurl.fullname" . }}-migrate
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "migrate") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrateJob.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrateJob.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "migrate") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          image: {{ include "snapurl.image" (dict "root" . "component" "worker") }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - node
+            - -e
+            - "require('@snapurl/database').runMigrations(process.env.DATABASE_URL, process.env.DATABASE_SSL==='true').then(r=>{console.log('migrations applied',r.folder);process.exit(0)}).catch(e=>{console.error(e);process.exit(1)})"
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel | quote }}
+            - name: DATABASE_SSL
+              value: {{ .Values.postgres.ssl | quote }}
+            - name: DATABASE_SSL_NO_VERIFY
+              value: {{ .Values.postgres.sslNoVerify | quote }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-url
+            {{- if .Values.postgres.caCert }}
+            - name: DATABASE_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "snapurl.secretName" . }}
+                  key: database-ca-cert
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/snapurl/templates/pdb.yaml
+++ b/deploy/helm/snapurl/templates/pdb.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.pdb.enabled }}
+{{- /*
+  PDBs for api and redirect only. The worker is deliberately excluded: it runs
+  a single replica, and a PDB with minAvailable on a 1-replica Deployment blocks
+  voluntary node drains outright (the node can never be emptied without evicting
+  the only pod, which the budget forbids). api and redirect run multiple
+  replicas, so minAvailable=1 lets a drain proceed while keeping one pod up.
+*/}}
+{{- if .Values.pdb.api.minAvailable }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "snapurl.fullname" . }}-api
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "api") | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.api.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "api") | nindent 6 }}
+{{- end }}
+{{- if .Values.pdb.redirect.minAvailable }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "snapurl.fullname" . }}-redirect
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "redirect") | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.redirect.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "redirect") | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/snapurl/templates/secret.yaml
+++ b/deploy/helm/snapurl/templates/secret.yaml
@@ -10,6 +10,25 @@
   operator (External Secrets, Sealed Secrets, Vault). These inline values are a
   convenience for testing — never commit real secrets to a values file.
 */}}
+{{- /*
+  Enforce the JWT-secret contract the values file and README advertise
+  (">=32 chars each, and they MUST differ") at RENDER time, next to the
+  `required` guards below, instead of letting it fail late at app boot against
+  the env schema. `required` alone only rejects a BLANK secret; a 4-char or an
+  identical pair would render cleanly and only crash the pods. These `fail`s
+  move that failure back to `helm install`/`helm template`. Only reachable when
+  no existingSecret is set (the whole file is), so an externally-managed Secret
+  is never second-guessed here.
+*/}}
+{{- if lt (len .Values.secrets.jwtAccessSecret) 32 }}
+{{- fail "secrets.jwtAccessSecret must be at least 32 characters (set a longer secret or use secrets.existingSecret)" }}
+{{- end }}
+{{- if lt (len .Values.secrets.jwtRefreshSecret) 32 }}
+{{- fail "secrets.jwtRefreshSecret must be at least 32 characters (set a longer secret or use secrets.existingSecret)" }}
+{{- end }}
+{{- if eq .Values.secrets.jwtAccessSecret .Values.secrets.jwtRefreshSecret }}
+{{- fail "secrets.jwtAccessSecret and secrets.jwtRefreshSecret must differ (they sign different token types)" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/snapurl/templates/secret.yaml
+++ b/deploy/helm/snapurl/templates/secret.yaml
@@ -1,0 +1,43 @@
+{{- if not .Values.secrets.existingSecret }}
+{{- /*
+  Rendered ONLY when no existingSecret is referenced. Holds every
+  credential-bearing value: the two JWT secrets and the connection strings.
+  The `required` calls below FAIL the render if the JWT secrets are blank, so
+  an operator cannot deploy with no secret (and cannot silently fall back to an
+  empty signing key).
+
+  For production prefer secrets.existingSecret managed by an external secrets
+  operator (External Secrets, Sealed Secrets, Vault). These inline values are a
+  convenience for testing — never commit real secrets to a values file.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "snapurl.secretName" . }}
+  labels:
+    {{- include "snapurl.labels" . | nindent 4 }}
+  annotations:
+    # Also a pre-install/pre-upgrade hook (weight -10, lower than the migrate
+    # Job's -5) so the credentials this Secret carries exist BEFORE the migrate
+    # hook Job runs — on a fresh install, normal resources are created only
+    # AFTER pre-install hooks, so without this the migrate Job would have no
+    # Secret to read DATABASE_URL from. resource-policy:keep + no delete policy
+    # keep the same object around for the Deployments that reference it.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/resource-policy": keep
+type: Opaque
+stringData:
+  jwt-access-secret: {{ required "secrets.jwtAccessSecret is required (>=32 chars) unless secrets.existingSecret is set" .Values.secrets.jwtAccessSecret | quote }}
+  jwt-refresh-secret: {{ required "secrets.jwtRefreshSecret is required (>=32 chars) unless secrets.existingSecret is set" .Values.secrets.jwtRefreshSecret | quote }}
+  database-url: {{ required "postgres.url is required (external Postgres primary connection string)" .Values.postgres.url | quote }}
+  {{- if .Values.postgres.replicaUrl }}
+  database-replica-url: {{ .Values.postgres.replicaUrl | quote }}
+  {{- end }}
+  {{- if .Values.redis.url }}
+  redis-url: {{ .Values.redis.url | quote }}
+  {{- end }}
+  {{- if .Values.postgres.caCert }}
+  database-ca-cert: {{ .Values.postgres.caCert | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/snapurl/templates/service-api.yaml
+++ b/deploy/helm/snapurl/templates/service-api.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "snapurl.fullname" . }}-api
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "api") | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "api") | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.api.service.port }}
+      protocol: TCP

--- a/deploy/helm/snapurl/templates/service-redirect.yaml
+++ b/deploy/helm/snapurl/templates/service-redirect.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "snapurl.fullname" . }}-redirect
+  labels:
+    {{- include "snapurl.componentLabels" (dict "root" . "component" "redirect") | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "snapurl.componentSelectorLabels" (dict "root" . "component" "redirect") | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.redirect.service.port }}
+      protocol: TCP
+{{- /* No Service for the worker: it serves no HTTP. */}}

--- a/deploy/helm/snapurl/templates/serviceaccount.yaml
+++ b/deploy/helm/snapurl/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "snapurl.serviceAccountName" . }}
+  labels:
+    {{- include "snapurl.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/snapurl/values.yaml
+++ b/deploy/helm/snapurl/values.yaml
@@ -212,7 +212,10 @@ logLevel: info
 #
 # NEVER commit real secret values to a values file. For production prefer
 # existingSecret. The render FAILS if neither inline secrets nor existingSecret
-# are provided, so you cannot accidentally deploy with no secret.
+# are provided, so you cannot accidentally deploy with no secret. When inline
+# secrets ARE provided, the render also FAILS if either is shorter than 32
+# characters or if the two are identical — the ">=32 chars, must differ"
+# contract is enforced at `helm install` time, not late at app boot.
 secrets:
   jwtAccessSecret: ""
   jwtRefreshSecret: ""

--- a/deploy/helm/snapurl/values.yaml
+++ b/deploy/helm/snapurl/values.yaml
@@ -1,0 +1,306 @@
+# SnapURL Profile 2 — the horizontally scaled Kubernetes deployment.
+#
+# This file is the whole contract. Nothing here carries a working secret or a
+# localhost default: like the single-node compose, every value an operator must
+# set is either blank (and `required` at render time) or a documented default.
+#
+# The three things you MUST set before this deploys:
+#   * postgres.url               — an EXTERNAL managed Postgres primary
+#   * redis.url                  — an EXTERNAL Redis (what makes multi-replica
+#                                  rate limiting correct, see below)
+#   * secrets.jwtAccessSecret +  — the two JWT signing secrets (>=32 chars each)
+#     secrets.jwtRefreshSecret     OR reference secrets.existingSecret
+#
+# See deploy/helm/README.md for the full walk-through.
+
+# Override the generated resource-name prefix. Empty means it derives from the
+# release name (see templates/_helpers.tpl snapurl.fullname).
+nameOverride: ""
+fullnameOverride: ""
+
+# ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+# The three images are published by publish-images.yml on v*.*.* tags as
+# ghcr.io/dhananjaythomble/snapurl-{api,redirect,worker}. The image for a
+# service is composed as: registry/repositoryPrefix<component>:tag
+# e.g. ghcr.io/dhananjaythomble/snapurl-api:latest
+# Per-service `image.repository`/`image.tag` overrides below win over these.
+image:
+  registry: ghcr.io
+  repositoryPrefix: dhananjaythomble/snapurl-
+  # Pin to a release (e.g. "v2.0.0") in production; "latest" follows newest.
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Extra image pull secrets (names of existing docker-registry Secrets), if the
+# registry is private. GHCR public images need none.
+imagePullSecrets: []
+
+# ---------------------------------------------------------------------------
+# API service — the NestJS control plane (auth, links CRUD, analytics reads).
+# ---------------------------------------------------------------------------
+# The API is where rate limiting is ENFORCED: @nestjs/throttler is backed by the
+# CacheStore (CACHE_DRIVER/REDIS_URL below). With redis.url set, ALL api
+# replicas share ONE counter, so the effective limit is the configured limit,
+# not limit x replicas. That is why the api scales safely.
+api:
+  replicaCount: 2
+  # Optional per-service image overrides. Leave blank to use the global image.
+  image:
+    repository: "" # e.g. ghcr.io/dhananjaythomble/snapurl-api
+    tag: "" # e.g. v2.0.0
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  # readiness/liveness probe tuning. Probe path is fixed at /api/v1/health:3001.
+  probes:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  service:
+    port: 3001
+
+# ---------------------------------------------------------------------------
+# Redirect service — the hot path (plain Fastify, three routes).
+# ---------------------------------------------------------------------------
+# The only bursty deployment, so it is the only one with an HPA (see hpa below).
+# Its CacheStore is used ONLY for hot-link caching (10s TTL), NOT for throttling.
+redirect:
+  replicaCount: 3
+  image:
+    repository: ""
+    tag: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # Probe path is fixed at /health:3002.
+  probes:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  service:
+    port: 3002
+
+# ---------------------------------------------------------------------------
+# Worker — the in-process rollup/maintenance loop. No HTTP surface.
+# ---------------------------------------------------------------------------
+# Keep this at 1 (or a small fixed count). The rollup loop drains click_events
+# then marks them consumed on the PRIMARY handle; running many concurrent
+# workers would have them contend on the same rows for no throughput gain. It is
+# deliberately NOT autoscaled and has NO Service, NO probes and NO PDB.
+worker:
+  replicaCount: 1
+  image:
+    repository: ""
+    tag: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+# ---------------------------------------------------------------------------
+# Ingress — routes the two public hostnames to the api and redirect Services.
+# ---------------------------------------------------------------------------
+# Disabled by default: with no ingress, reach the services with
+# `kubectl port-forward`. Enable it and set the two hosts for a real deploy.
+ingress:
+  enabled: false
+  # e.g. "nginx", "traefik", or the cloud LB class. Empty uses the cluster default.
+  className: ""
+  # Extra annotations (e.g. nginx body size, cert-manager is merged in from tls).
+  annotations: {}
+  # The dashboard/API hostname -> api Service.
+  apiHost: ""
+  # The short-link hostname -> redirect Service.
+  redirectHost: ""
+  tls:
+    enabled: false
+    # A single TLS Secret covering BOTH hosts. If you use cert-manager, set
+    # clusterIssuer instead and the controller creates this Secret for you.
+    secretName: ""
+    # cert-manager ClusterIssuer name. When set, the
+    # cert-manager.io/cluster-issuer annotation is added automatically.
+    clusterIssuer: ""
+
+# ---------------------------------------------------------------------------
+# Postgres — EXTERNAL. This chart does NOT ship a database.
+# ---------------------------------------------------------------------------
+# Point this at a managed primary (RDS/Cloud SQL/Neon/…). If you want an
+# in-cluster Postgres for testing, add the bitnami/postgresql subchart yourself
+# and set postgres.url to its Service DNS — but production should use a managed
+# primary with backups you did not have to build.
+postgres:
+  # postgres://USER:PASSWORD@HOST:5432/DBNAME  (carries credentials -> Secret)
+  url: ""
+  # Optional read-replica connection string. Absent means reads use the primary.
+  replicaUrl: ""
+  # TLS to the database. ssl=true enables it; sslNoVerify skips cert checks
+  # (VPC/self-signed only, insecure over untrusted networks); caCert is the PEM
+  # of a CA bundle to verify the server cert (goes to the Secret).
+  ssl: false
+  sslNoVerify: false
+  caCert: ""
+  poolMax: 10
+
+# ---------------------------------------------------------------------------
+# Redis — the CacheStore and click queue.
+# ---------------------------------------------------------------------------
+# THIS IS THE POINT OF PROFILE 2. When redis.url is set, CACHE_DRIVER is forced
+# to "redis" for every service, so the API throttler's counter lives in Redis
+# and is shared across ALL api replicas. That makes multi-replica rate limiting
+# correct (#285): the (limit+1)th request across pods is 429, not limit x pods.
+# Leave blank to fall back to the per-instance "memory" driver (only correct for
+# a single api replica).
+redis:
+  # redis://[:PASSWORD@]HOST:6379  (may carry credentials -> Secret)
+  url: ""
+
+# ---------------------------------------------------------------------------
+# Rate limiting — the API's global throttle (THROTTLE_TTL_SECONDS/THROTTLE_LIMIT).
+# ---------------------------------------------------------------------------
+throttle:
+  ttlSeconds: 60
+  limit: 120
+
+# ---------------------------------------------------------------------------
+# Non-secret app env.
+# ---------------------------------------------------------------------------
+# webOrigin: where the dashboard lives (CORS + email links).
+webOrigin: ""
+# defaultDomain: the default short domain new workspaces get.
+defaultDomain: ""
+# redirectOrigin: where redirects are served from (for building short URLs).
+redirectOrigin: ""
+# trustedProxyHops: how many proxies in front of the services APPEND their edge
+# IP to X-Forwarded-For. The throttler/visitor-hash derive the real client IP as
+# the (trustedProxyHops+1)th entry from the right, so a client cannot forge it.
+# Behind an ingress controller this is usually 1 (the controller). Add 1 per
+# extra appending hop (e.g. a cloud LB that appends XFF -> 2). Match it to your
+# actual ingress topology or rate limits key off the wrong IP.
+trustedProxyHops: 1
+
+mail:
+  # "outbox" writes each message to a file instead of sending; "ses" uses SES.
+  transport: outbox
+  # e.g. "SnapURL <no-reply@example.com>". Empty uses the app default.
+  from: ""
+
+# trace | debug | info | warn | error
+logLevel: info
+
+# ---------------------------------------------------------------------------
+# Secrets — the JWT signing secrets and credential-bearing connection strings.
+# ---------------------------------------------------------------------------
+# Provide the two JWT secrets inline (each >=32 chars; they MUST differ) OR set
+# existingSecret to the name of a Secret you manage (e.g. via an external
+# secrets operator). The chart-managed Secret ALSO holds database-url, redis-url
+# and database-ca-cert since those carry credentials.
+#
+# NEVER commit real secret values to a values file. For production prefer
+# existingSecret. The render FAILS if neither inline secrets nor existingSecret
+# are provided, so you cannot accidentally deploy with no secret.
+secrets:
+  jwtAccessSecret: ""
+  jwtRefreshSecret: ""
+  # Name of an existing Secret. When set, the chart does NOT create its own
+  # Secret and expects THESE keys in yours:
+  #   jwt-access-secret, jwt-refresh-secret, database-url,
+  #   (optional) database-replica-url, redis-url, database-ca-cert
+  existingSecret: ""
+
+# ---------------------------------------------------------------------------
+# Horizontal Pod Autoscaler — redirect only.
+# ---------------------------------------------------------------------------
+# The redirect service is the only bursty deployment. api and worker are NOT
+# autoscaled. NOTE: when hpa.enabled is true the HPA OWNS redirect's replica
+# count, so redirect.replicaCount above is only the initial value — the HPA
+# takes over between minReplicas and maxReplicas.
+hpa:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+# ---------------------------------------------------------------------------
+# PodDisruptionBudgets — api and redirect only.
+# ---------------------------------------------------------------------------
+# No PDB for the worker: it runs a single replica, and a PDB with minAvailable
+# on a 1-replica Deployment blocks voluntary node drains (the node can never be
+# emptied). api and redirect run multiple replicas, so a minAvailable of 1
+# keeps at least one pod up during a drain while still allowing it to proceed.
+pdb:
+  enabled: true
+  api:
+    minAvailable: 1
+  redirect:
+    minAvailable: 1
+
+# ---------------------------------------------------------------------------
+# Analytics reader — the AnalyticsReader seam (#284).
+# ---------------------------------------------------------------------------
+# Only the "postgres" reader exists in code today. The columnar branch is a
+# documented FUTURE seam: the env is plumbed when enabled, but no columnar
+# adapter is invented here. Leave columnar.enabled false.
+analytics:
+  reader: postgres
+  columnar:
+    enabled: false
+    driver: "" # e.g. "clickhouse" (future)
+    url: "" # columnar store connection string (future)
+
+# ---------------------------------------------------------------------------
+# Migrate Job — the pre-install/pre-upgrade migration hook.
+# ---------------------------------------------------------------------------
+# This is the whole point of running migrations OUT of the app boot path: the
+# apps do NOT migrate at boot, so this Job runs ONCE before the new pods roll
+# and prevents the concurrent-boot migration race. It reuses the worker image
+# (which ships drizzle/*.sql and re-exports runMigrations).
+migrateJob:
+  enabled: true
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
+
+# ---------------------------------------------------------------------------
+# ServiceAccount
+# ---------------------------------------------------------------------------
+serviceAccount:
+  create: true
+  # If empty and create=true, a name is derived from the fullname.
+  name: ""
+  annotations: {}
+
+# ---------------------------------------------------------------------------
+# Security context — matches the Dockerfile's `node` user (uid 1000).
+# ---------------------------------------------------------------------------
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# Optional scheduling controls applied to all workloads.
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Closes #287. Phase 6 of epic #267 — the scaled/Kubernetes profile. One Helm chart covers EKS/GKE/AKS/k3s/bare-metal (no per-cloud IaC sprawl). All additive.

## The chart (`deploy/helm/snapurl/`)
- **Per-service Deployments** for api / redirect / worker, each with independent `replicaCount` (their scaling profiles differ). api+redirect have readiness/liveness probes (`/api/v1/health`, `/health`); worker has none (it's the long-running rollup loop, no HTTP).
- **Ingress** (networking.k8s.io/v1) with configurable `className`, hosts, TLS, annotations — routes the app host to api and the short domain to redirect.
- **External Postgres** via `postgres.url` + optional `postgres.replicaUrl` (`DATABASE_REPLICA_URL`, #271) + SSL knobs; the chart ships no database (documented).
- **Redis as the CacheStore** via `redis.url` → sets `CACHE_DRIVER=redis` (#285) for every service, which is what makes rate limiting correct across replicas.
- **HPA on redirect only** (autoscaling/v2) — the one bursty deployment.
- **Migrations as a pre-install/pre-upgrade Helm Job** (`helm.sh/hook`, weight -5, before-hook-creation+hook-succeeded) — runs ONCE before the new pods roll; the apps do NOT migrate at boot, so concurrent-boot migration races can't happen.
- **PodDisruptionBudget** (policy/v1) for api+redirect, and sensible resource requests/limits in values.
- **Secrets** via a chart Secret or `existingSecret`; **optional columnar AnalyticsReader** stanza off by default — a documented seam (#284 shipped only the Postgres adapter; no columnar adapter is invented here).
- Standard Helm hygiene: `_helpers.tpl` labels, `NOTES.txt`, `serviceaccount`, `.helmignore`, `deploy/helm/README.md` + a SELF-HOSTING.md section.

## Done-when — proven by a new CI job (`deploy-helm.yml`)
Separate workflow (verify/publish/smoke jobs untouched). It: builds the three runtime images and `kind load`s them, stands up throwaway in-cluster **Postgres 18** + **Redis 7**, installs the chart with `CACHE_DRIVER=redis` (letting the **pre-install migrate hook** run before pods roll), runs the smoke suites against the in-cluster services (Done-when #1), then **scales the API to >1 replica and asserts the (limit+1)th request across pods returns 429** — which only holds because the throttler counter lives in shared Redis, proving #285's CacheStore adapter (Done-when #2). Dumps pod logs/describe on failure.

## How to test
- Static YAML parses (Chart.yaml, values.yaml, the workflow); templates are Go-templated so validated by `helm`/kind in CI (helm isn't in the dev sandbox — the kind job is the arbiter).
- CI-safety: the new workflow has no env dumps (a comment even notes `set -x` is not enabled), generates JWT test secrets in-job, touches no other workflow.
- Existing verify/integration/restore-test jobs unchanged.

Note: the kind CI job is heavy (3 image builds + a cluster + full rollout) — expected for the profile that can only be proven on a real cluster.