### PR TITLE
Profile 3: finish the AWS serverless projection and click pipeline (#288)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -252,6 +252,205 @@ jobs:
         if: always()
         run: docker compose --profile full down -v
 
+  # Done-when #1 of #288: "the smoke suite passes with LINK_PROJECTION=dynamo".
+  #
+  # The `verify` and `integration` jobs above run the DEFAULT topology —
+  # LINK_PROJECTION unset (=none) and CLICK_SINK unset (=postgres) — so the
+  # redirect uses PostgresLinkResolver + PostgresClickSink there and those jobs
+  # are byte-for-byte unaffected by this one. This ADDITIONAL job is the only
+  # place LINK_PROJECTION=dynamo runs.
+  #
+  # It proves the AWS-profile resolution path end to end against a real (local)
+  # DynamoDB: a dynamodb-local service container stands in for the CDK-created
+  # table, the worker (LINK_PROJECTION=dynamo) drains the projection_outbox the
+  # API wrote into it, and the redirect (LINK_PROJECTION=dynamo) resolves every
+  # smoke assertion out of DynamoDB — no Postgres in its resolve path. The
+  # adapters point at localhost:8000 via AWS_ENDPOINT_URL_DYNAMODB, the optional
+  # endpoint override main.ts reads (unset in production => real AWS endpoint).
+  #
+  # What this job does NOT prove and why: the SQS click path stays on the
+  # Postgres default here (CLICK_SINK unset). Standing up an SQS emulator would
+  # only re-test what the SqsClickSink + worker-consumer unit tests already
+  # cover; the freeze/thaw survival of an awaited SQS send is a unit-test
+  # assertion, and the real no-VPC / real-SQS behaviours are deploy-deferred
+  # (see docs/DECISIONS.md, Profile 3). So the API still writes click_events to
+  # Postgres in this job, exactly as the default path does; only link
+  # RESOLUTION moves to DynamoDB, which is what Done-when #1 names.
+  dynamo-smoke:
+    name: LINK_PROJECTION=dynamo smoke (dynamodb-local)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        # Same image and shape as `verify` — the API + worker still use Postgres
+        # (the API writes links + the outbox; the worker reads a link's config
+        # for an upsert and writes click_events). uuidv7() needs Postgres 18.
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: snapurl
+          POSTGRES_PASSWORD: snapurl
+          POSTGRES_DB: snapurl
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U snapurl -d snapurl"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+      # The real (local) DynamoDB the projection is written to and read from.
+      # GitHub Actions runs Docker, so a service container is the simplest way
+      # to get a durable-for-the-job DynamoDB on localhost:8000.
+      dynamodb:
+        image: amazon/dynamodb-local:latest
+        ports:
+          - 8000:8000
+
+    env:
+      DATABASE_URL: postgres://snapurl:snapurl@localhost:5433/snapurl
+      DATABASE_SSL: "false"
+      NODE_ENV: test
+      JWT_ACCESS_SECRET: ci-access-secret-not-used-anywhere-real-0000
+      JWT_REFRESH_SECRET: ci-refresh-secret-not-used-anywhere-real-000
+      WEB_ORIGIN: http://localhost:3000
+      DEFAULT_DOMAIN: localhost:3002
+      REDIRECT_ORIGIN: http://localhost:3002
+      MAIL_TRANSPORT: outbox
+      THROTTLE_LIMIT: "100000"
+      LOG_LEVEL: warn
+      SNAPURL_ALLOW_UNCONFIGURED_BUILD: "true"
+      # The AWS-profile switch under test. Only this job sets it.
+      LINK_PROJECTION: dynamo
+      LINK_PROJECTION_TABLE: snapurl-link-projection
+      # dynamodb-local needs a region + (dummy) credentials to accept requests,
+      # and the endpoint override the adapters read so they target it rather
+      # than the real regional endpoint. AWS_ENDPOINT_URL_DYNAMODB is the
+      # service-specific override dynamoEndpoint() prefers.
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_ACCESS_KEY: dummy
+      AWS_ENDPOINT_URL_DYNAMODB: http://localhost:8000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm type-check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Migrate
+        run: pnpm db:migrate
+
+      # Create the projection table + linkId GSI in dynamodb-local. In
+      # production the CDK stack creates this table (PAY_PER_REQUEST + PITR);
+      # here we recreate only the SHAPE the adapters depend on. The key,
+      # attribute and index names below are the ones the shared mapper in
+      # packages/database/src/link-projection.ts uses — PK/SK (from domainPk /
+      # linkSk / domainMetaKey), the linkId attribute (LINK_ID_ATTR) and the
+      # linkId-index GSI (LINK_ID_GSI) the delete path queries. The AWS CLI is
+      # preinstalled on the runner and honours AWS_ENDPOINT_URL_DYNAMODB + the
+      # dummy creds set in the job env, so no extra tooling is needed.
+      - name: Create the DynamoDB projection table
+        run: |
+          set -euo pipefail
+          aws dynamodb create-table \
+            --table-name "$LINK_PROJECTION_TABLE" \
+            --billing-mode PAY_PER_REQUEST \
+            --attribute-definitions \
+              AttributeName=PK,AttributeType=S \
+              AttributeName=SK,AttributeType=S \
+              AttributeName=linkId,AttributeType=S \
+            --key-schema \
+              AttributeName=PK,KeyType=HASH \
+              AttributeName=SK,KeyType=RANGE \
+            --global-secondary-indexes \
+              'IndexName=linkId-index,KeySchema=[{AttributeName=linkId,KeyType=HASH}],Projection={ProjectionType=ALL}'
+          aws dynamodb wait table-exists --table-name "$LINK_PROJECTION_TABLE"
+          echo "dynamodb-local: table $LINK_PROJECTION_TABLE ready with linkId-index GSI"
+
+      - name: Start the API, redirect and worker
+        run: |
+          # The API writes links + projection_outbox rows to Postgres. It does
+          # NOT read LINK_PROJECTION, so it needs no DynamoDB env — but the
+          # shared job env is harmless to it.
+          PORT=3001 node apps/api/dist/main.js > /tmp/api.log 2>&1 &
+          echo "API_PID=$!" >> "$GITHUB_ENV"
+
+          # The redirect resolves from DynamoDB (LINK_PROJECTION=dynamo). Its
+          # click sink stays on Postgres (CLICK_SINK unset), so it keeps a
+          # Postgres handle for clicks + salts, but every /:slug resolve is a
+          # DynamoDB GetItem. A short link-cache TTL keeps a transient miss
+          # (a slug queried a beat before the worker projects it) self-healing
+          # within a second rather than caching a 404 for the default 10s.
+          LINK_CACHE_TTL_SECONDS=1 PORT=3002 node apps/redirect/dist/main.js > /tmp/redirect.log 2>&1 &
+          echo "REDIRECT_PID=$!" >> "$GITHUB_ENV"
+
+          # The worker drains the projection_outbox into dynamodb-local. Run it
+          # as its normal loop with a fast (1s) frequent interval so links the
+          # smoke script creates up front are projected before it starts firing
+          # redirect assertions. The smoke script creates all 12 fixtures in its
+          # setup phase, THEN asserts, so a 1s drain loop has the outbox emptied
+          # into DynamoDB well before the first assertion.
+          ROLLUP_INTERVAL_SECONDS=1 node apps/worker/dist/main.js > /tmp/worker.log 2>&1 &
+          echo "WORKER_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for both HTTP services to be healthy
+        run: |
+          for name in "api:3001/api/v1/health" "redirect:3002/health"; do
+            label="${name%%:*}"; url="http://localhost:${name#*:}"
+            for i in $(seq 1 40); do
+              if curl -fsS "$url" >/dev/null 2>&1; then
+                echo "$label is up"; break
+              fi
+              if [ "$i" = "40" ]; then
+                echo "::error::$label did not become healthy within 40s"
+                echo "--- api.log ---";      tail -50 /tmp/api.log      || true
+                echo "--- redirect.log ---"; tail -50 /tmp/redirect.log || true
+                echo "--- worker.log ---";   tail -50 /tmp/worker.log   || true
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
+      # The proof: every redirect assertion resolved out of DynamoDB. The script
+      # creates its fixtures via the API (which writes the outbox), the worker
+      # loop drains them into dynamodb-local, and the redirect 302s/404s are all
+      # served from the projection. Its direct-DB privacy/click checks still read
+      # Postgres (click_events is still written there under the default sink).
+      - name: Smoke — redirect path (resolving from DynamoDB)
+        run: bash scripts/smoke-redirect.sh
+        env:
+          DATABASE_URL: postgres://snapurl:snapurl@localhost:5433/snapurl
+
+      - name: Service logs
+        if: failure()
+        run: |
+          echo "--- api ---";      tail -200 /tmp/api.log      || true
+          echo "--- redirect ---"; tail -200 /tmp/redirect.log || true
+          echo "--- worker ---";   tail -200 /tmp/worker.log   || true
+
+      - name: Stop services
+        if: always()
+        run: kill "$API_PID" "$REDIRECT_PID" "$WORKER_PID" 2>/dev/null || true
+
   # The one thing self-hosted Postgres on a single volume gets wrong is the
   # restore. A backup script that is never restored is a backup that does not
   # exist. This job exercises the real deploy/single-node/backup.sh and

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -320,7 +320,14 @@ jobs:
       REDIRECT_ORIGIN: http://localhost:3002
       MAIL_TRANSPORT: outbox
       THROTTLE_LIMIT: "100000"
-      LOG_LEVEL: warn
+      # debug (not warn) FOR THIS JOB ONLY: the projection writer's failures are
+      # logged by drainOutbox at info level (projectionFailures) and a swallowed
+      # per-op error is logged by the worker at debug/error — at warn they are
+      # invisible, which is exactly why a projection that wrote nothing looked
+      # silent. debug surfaces the resolver GetItem and writer BatchWrite errors
+      # in worker.log / redirect.log so a future failure localises immediately.
+      # The other jobs keep warn; this does not change any app default.
+      LOG_LEVEL: debug
       SNAPURL_ALLOW_UNCONFIGURED_BUILD: "true"
       # The AWS-profile switch under test. Only this job sets it.
       LINK_PROJECTION: dynamo
@@ -446,6 +453,31 @@ jobs:
           echo "--- api ---";      tail -200 /tmp/api.log      || true
           echo "--- redirect ---"; tail -200 /tmp/redirect.log || true
           echo "--- worker ---";   tail -200 /tmp/worker.log   || true
+
+      # The single most decisive diagnostic when the smoke step fails: dump what
+      # the worker actually projected into dynamodb-local. This localises the
+      # fault to ONE side with no guessing:
+      #   * empty / missing LINK items  -> the WRITER never projected (e.g. a
+      #     BatchWrite that threw — a marshalling error on an undefined attribute,
+      #     an endpoint the writer did not honour). Cross-check with worker.log.
+      #   * populated with the expected PK=d#localhost:3002 / SK=s#<run>-<name>
+      #     items -> the writer is fine and the READER is the bug (endpoint,
+      #     key derivation, or unmarshalling). Cross-check with redirect.log.
+      # AWS_ENDPOINT_URL_DYNAMODB + the dummy creds are already in the job env,
+      # so the preinstalled AWS CLI targets dynamodb-local directly. The creds
+      # are the literal string "dummy" (not a secret), so nothing sensitive is
+      # printed. --max-items caps the dump so a large table cannot flood the log.
+      - name: DynamoDB projection contents (diagnostic)
+        if: failure()
+        run: |
+          echo "--- item count (projected LINK + domain-meta items) ---"
+          aws dynamodb scan --table-name "$LINK_PROJECTION_TABLE" \
+            --select COUNT --output json || true
+          echo "--- first 20 projected items (PK/SK/linkId + destination) ---"
+          aws dynamodb scan --table-name "$LINK_PROJECTION_TABLE" \
+            --max-items 20 \
+            --projection-expression "PK, SK, linkId, destination" \
+            --output json || true
 
       - name: Stop services
         if: always()

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -410,12 +410,28 @@ jobs:
           echo "REDIRECT_PID=$!" >> "$GITHUB_ENV"
 
           # The worker drains the projection_outbox into dynamodb-local. Run it
-          # as its normal loop with a fast (1s) frequent interval so links the
-          # smoke script creates up front are projected before it starts firing
-          # redirect assertions. The smoke script creates all 12 fixtures in its
-          # setup phase, THEN asserts, so a 1s drain loop has the outbox emptied
-          # into DynamoDB well before the first assertion.
-          ROLLUP_INTERVAL_SECONDS=1 node apps/worker/dist/main.js > /tmp/worker.log 2>&1 &
+          # as its normal loop with a SUB-SECOND (0.25s) frequent interval so a
+          # link is projected within a quarter second of the API writing its
+          # outbox row. runFrequent multiplies ROLLUP_INTERVAL_SECONDS by 1000
+          # for setInterval, so a fractional value is a valid 250ms tick.
+          #
+          # Why 0.25s and not 1s. The smoke script creates all 12 fixtures in
+          # its setup phase, THEN asserts. $RUN-plain is the FIRST fixture
+          # created and the FIRST asserted, so between its create and its
+          # assertion the script still issues the other 11 create round-trips —
+          # comfortably more than 250ms of wall time. A 250ms drain tick
+          # therefore always fires (and projects $RUN-plain into DynamoDB)
+          # before the first "302 to the destination" assertion runs, which
+          # removes the create-then-immediately-assert race. A 1s tick could, on
+          # a fast runner, land the whole create phase inside a single tick
+          # window and leave $RUN-plain unprojected when the first assertion
+          # fires — exactly the 404 this job was seeing.
+          #
+          # Belt and suspenders: the redirect above runs with
+          # LINK_CACHE_TTL_SECONDS=1 and the resolver never negative-caches, so
+          # even a sub-tick miss self-heals on the very next request within 1s
+          # rather than sticking for the default 10s.
+          ROLLUP_INTERVAL_SECONDS=0.25 node apps/worker/dist/main.js > /tmp/worker.log 2>&1 &
           echo "WORKER_PID=$!" >> "$GITHUB_ENV"
 
       - name: Wait for both HTTP services to be healthy
@@ -435,6 +451,46 @@ jobs:
               fi
               sleep 1
             done
+          done
+
+      # Barrier: prove the worker is actually draining the projection_outbox
+      # before the smoke assertions run. This does two things.
+      #
+      #   1. Liveness. It fails fast, with a clear message, if the worker never
+      #      came up or is not draining (e.g. a bad LINK_PROJECTION_TABLE or a
+      #      DynamoDB endpoint it cannot reach) — instead of that surfacing as
+      #      an opaque 404 inside the smoke run.
+      #   2. A clean starting line. It confirms projection_outbox has no
+      #      unprocessed rows at the moment smoke begins, so the run starts from
+      #      a fully-drained state.
+      #
+      # It does NOT (and cannot) cover the fixtures smoke creates INSIDE its own
+      # run: the script registers a user and creates all 12 links in its setup
+      # phase, then asserts. That race is closed by the sub-second (0.25s) worker
+      # drain interval set above (a link is projected within 250ms of its outbox
+      # row, far inside the create->assert gap) plus LINK_CACHE_TTL_SECONDS=1 and
+      # the resolver never negative-caching. This barrier is the determinism
+      # backstop around those.
+      #
+      # psql is preinstalled on the runner; DATABASE_URL points at the postgres
+      # service on 5433. The condition is the outbox drained: no row with
+      # processed_at IS NULL. 60s budget at 1s poll; a timeout is a hard error.
+      - name: Wait for the projection worker to drain the outbox
+        run: |
+          set -uo pipefail
+          for i in $(seq 1 60); do
+            pending="$(psql "$DATABASE_URL" -tAc \
+              'select count(*) from projection_outbox where processed_at is null' 2>/dev/null | tr -d '[:space:]')"
+            if [ "${pending:-}" = "0" ]; then
+              echo "projection worker is draining: 0 unprocessed outbox rows after ${i}s"
+              exit 0
+            fi
+            if [ "$i" = "60" ]; then
+              echo "::error::projection_outbox still had unprocessed rows (pending=${pending:-unknown}) after 60s — the worker is not draining"
+              echo "--- worker.log ---"; tail -80 /tmp/worker.log || true
+              exit 1
+            fi
+            sleep 1
           done
 
       # The proof: every redirect assertion resolved out of DynamoDB. The script

--- a/apps/redirect/package.json
+++ b/apps/redirect/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1121.0",
+    "@aws-sdk/client-sqs": "^3.1121.0",
     "@aws-sdk/lib-dynamodb": "^3.1121.0",
     "@snapurl/cache": "workspace:*",
     "@snapurl/contract": "workspace:*",

--- a/apps/redirect/package.json
+++ b/apps/redirect/package.json
@@ -12,6 +12,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1121.0",
+    "@aws-sdk/lib-dynamodb": "^3.1121.0",
     "@snapurl/cache": "workspace:*",
     "@snapurl/contract": "workspace:*",
     "@snapurl/database": "workspace:*",

--- a/apps/redirect/src/click-sink.ts
+++ b/apps/redirect/src/click-sink.ts
@@ -1,4 +1,10 @@
-import { clickEvents, type Database } from "@snapurl/database";
+import {
+  insertClickEvents,
+  serializeClickEvent,
+  type ClickEvent,
+  type Database,
+} from "@snapurl/database";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 
 /* Where a click goes after the visitor has already been redirected.
 
@@ -7,25 +13,14 @@ import { clickEvents, type Database } from "@snapurl/database";
    batches. Locally it writes straight to Postgres, which keeps the whole
    pipeline runnable with one container and no AWS account.
 
-   Both are fire-and-forget from the caller's point of view. */
+   Both are fire-and-forget from the caller's point of view.
 
-export interface ClickEvent {
-  linkId: string;
-  workspaceId: string;
-  occurredAt: Date;
-  visitorHash: string;
-  country: string | null;
-  city: string | null;
-  device: string | null;
-  browser: string | null;
-  os: string | null;
-  referrerHost: string | null;
-  isQr: boolean;
-  isBot: boolean;
-  blockedReason: string | null;
-  matchedRuleId: string | null;
-  variant: string | null;
-}
+   The ClickEvent type and the single click_events INSERT now live in
+   @snapurl/database so the worker's SQS consumer can drain the queue back into
+   the SAME table with byte-for-byte identical rows without depending on this
+   app. ClickEvent is re-exported here so existing redirect importers are
+   unchanged. */
+export type { ClickEvent };
 
 export interface ClickSink {
   record(event: ClickEvent): Promise<void>;
@@ -35,22 +30,41 @@ export class PostgresClickSink implements ClickSink {
   constructor(private readonly db: Database) {}
 
   async record(event: ClickEvent): Promise<void> {
-    await this.db.insert(clickEvents).values({
-      linkId: event.linkId,
-      workspaceId: event.workspaceId,
-      occurredAt: event.occurredAt,
-      visitorHash: event.visitorHash,
-      country: event.country,
-      city: event.city,
-      device: event.device,
-      browser: event.browser,
-      os: event.os,
-      referrerHost: event.referrerHost,
-      isQr: event.isQr,
-      isBot: event.isBot,
-      blockedReason: event.blockedReason,
-      matchedRuleId: event.matchedRuleId,
-      variant: event.variant,
-    });
+    await insertClickEvents(this.db, [event]);
+  }
+}
+
+/* The production click sink: an SQS SendMessage.
+
+   record() AWAITS the send. That await is the freeze-safe write #277 wants: an
+   SQS HTTP send is a request that completes and is acknowledged before the
+   Lambda Web Adapter sandbox freezes on the response, so the click is durably
+   on the queue by the time the invocation ends. A Postgres INSERT does not
+   survive that freeze the same way — a fire-and-forget query is suspended
+   mid-flight and pins a backend the pool cannot reclaim (see the record()
+   comment in main.ts). Awaiting one same-region HTTPS round trip is cheap and
+   the write is durable.
+
+   One SendMessage per click is correct here: main.ts awaits exactly one
+   record() per request, so there is no batch to build. SendMessageBatch (the
+   10-message batch API) would only help a caller buffering many clicks before
+   flushing, which the request-scoped hot path never does.
+
+   The client and queue URL are injected via the constructor so a unit test can
+   drive it with a mocked SQSClient.send keyed by command name, mirroring
+   DynamoDbCacheStore. */
+export class SqsClickSink implements ClickSink {
+  constructor(
+    private readonly client: SQSClient,
+    private readonly queueUrl: string,
+  ) {}
+
+  async record(event: ClickEvent): Promise<void> {
+    await this.client.send(
+      new SendMessageCommand({
+        QueueUrl: this.queueUrl,
+        MessageBody: serializeClickEvent(event),
+      }),
+    );
   }
 }

--- a/apps/redirect/src/dynamo-resolver.test.ts
+++ b/apps/redirect/src/dynamo-resolver.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { toLinkItem, toDomainItem, type ProjectedLink, type ProjectedDomain } from "@snapurl/database";
+import { DynamoLinkResolver } from "./resolver.js";
+
+/* MOCK-based unit tests, mirroring packages/cache/dynamodb-cache-store.test.ts:
+   no live DynamoDB in-sandbox or in CI, so a fake DynamoDBDocumentClient whose
+   `send` is stubbed by command constructor name asserts the RIGHT command and
+   Key are issued and that the stored item maps back to a ResolvedLink. */
+
+const TABLE = "snapurl-link-projection";
+
+function commandName(command: unknown): string {
+  return (command as { constructor: { name: string } }).constructor.name;
+}
+
+function makeResolver(handlers: Record<string, (input: any) => unknown>) {
+  const send = vi.fn(async (command: unknown) => {
+    const name = commandName(command);
+    const handler = handlers[name];
+    if (!handler) throw new Error(`unexpected command ${name}`);
+    return handler((command as { input: any }).input);
+  });
+  const client = { send } as unknown as DynamoDBDocumentClient;
+  return { resolver: new DynamoLinkResolver(client, TABLE), send };
+}
+
+const storedLink: ProjectedLink = {
+  id: "11111111-1111-1111-1111-111111111111",
+  workspaceId: "22222222-2222-2222-2222-222222222222",
+  destination: "https://example.com/dest",
+  redirectType: "307",
+  rules: [],
+  expiresAt: new Date("2030-01-02T03:04:05.000Z"),
+  expiresTo: null,
+  activatesAt: null,
+  scheduledTo: null,
+  clickLimit: 5,
+  clicks: 1,
+  hasPassword: false,
+  forwardQuery: true,
+  deepLink: false,
+  hideReferrer: false,
+  publicPreview: true,
+  archived: false,
+  safeBrowsingStatus: "safe",
+  utm: null,
+};
+
+describe("DynamoLinkResolver.resolve", () => {
+  it("issues a GetCommand with the normalised (host, slug) key and maps the item back", async () => {
+    let captured: any;
+    const { resolver } = makeResolver({
+      GetCommand: (input) => {
+        captured = input;
+        return { Item: toLinkItem(storedLink, "snap.to", "foo") };
+      },
+    });
+
+    // A printed SNAP.TO/Foo must resolve — the key is normalised the same way
+    // the Postgres lookup normalises.
+    const link = await resolver.resolve("SNAP.TO", "Foo");
+
+    expect(captured.TableName).toBe(TABLE);
+    expect(captured.Key).toEqual({ PK: "d#snap.to", SK: "s#foo" });
+    expect(link).toEqual(storedLink);
+    // Dates are revived, not left as ISO strings.
+    expect(link!.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("returns null when the item is absent", async () => {
+    const { resolver } = makeResolver({ GetCommand: () => ({}) });
+    expect(await resolver.resolve("snap.to", "missing")).toBeNull();
+  });
+});
+
+describe("DynamoLinkResolver.resolveDomain", () => {
+  it("issues a GetCommand with the domain-meta key and maps it back", async () => {
+    const domain: ProjectedDomain = {
+      id: "44444444-4444-4444-4444-444444444444",
+      rootRedirect: "https://example.com/root",
+      notFoundRedirect: "https://example.com/404",
+    };
+    let captured: any;
+    const { resolver } = makeResolver({
+      GetCommand: (input) => {
+        captured = input;
+        return { Item: toDomainItem("snap.to", domain) };
+      },
+    });
+
+    const resolved = await resolver.resolveDomain("SNAP.TO");
+    expect(captured.Key).toEqual({ PK: "d#snap.to", SK: "d#meta" });
+    expect(resolved).toEqual(domain);
+  });
+
+  it("returns null when the domain-meta item is absent", async () => {
+    const { resolver } = makeResolver({ GetCommand: () => ({}) });
+    expect(await resolver.resolveDomain("snap.to")).toBeNull();
+  });
+});

--- a/apps/redirect/src/dynamo-resolver.test.ts
+++ b/apps/redirect/src/dynamo-resolver.test.ts
@@ -68,6 +68,49 @@ describe("DynamoLinkResolver.resolve", () => {
     expect(link!.expiresAt).toBeInstanceOf(Date);
   });
 
+  it("round-trips a populated rules[] and a non-null utm verbatim", async () => {
+    /* storedLink above uses rules: [] and utm: null, so it never exercises the
+       mapper's copy of a populated routing chain or a UTM object. A projected
+       link that carries both must map back field-for-field identical, or the
+       DynamoDB-resolved link would hit evaluateRouting / buildDestination
+       differently from the Postgres-resolved one. */
+    const withRulesAndUtm: ProjectedLink = {
+      ...storedLink,
+      rules: [
+        {
+          id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          when: { device: "mobile", country: null, language: null },
+          then: "https://example.com/mobile",
+          weight: null,
+        },
+        {
+          id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          when: { country: "US", device: null, language: null },
+          then: "https://example.com/us",
+          weight: 30,
+        },
+      ],
+      utm: { source: "newsletter", medium: "email", campaign: "launch", content: "cta" },
+    };
+
+    const { resolver } = makeResolver({
+      GetCommand: () => ({ Item: toLinkItem(withRulesAndUtm, "snap.to", "foo") }),
+    });
+
+    const link = await resolver.resolve("snap.to", "foo");
+
+    expect(link).toEqual(withRulesAndUtm);
+    // The rule order and every field survive the item round-trip.
+    expect(link!.rules).toHaveLength(2);
+    expect(link!.rules.map((r) => r.then)).toEqual([
+      "https://example.com/mobile",
+      "https://example.com/us",
+    ]);
+    expect(link!.rules[1]!.weight).toBe(30);
+    // The UTM object is non-null and copied verbatim.
+    expect(link!.utm).toEqual({ source: "newsletter", medium: "email", campaign: "launch", content: "cta" });
+  });
+
   it("returns null when the item is absent", async () => {
     const { resolver } = makeResolver({ GetCommand: () => ({}) });
     expect(await resolver.resolve("snap.to", "missing")).toBeNull();

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -19,10 +19,11 @@ import {
 import { createCacheStore, type CacheDriver } from "@snapurl/cache";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { SQSClient } from "@aws-sdk/client-sqs";
 import { DynamoLinkResolver, PostgresLinkResolver, type LinkResolver, type ResolvedLink } from "./resolver.js";
 import { CachingLinkResolver } from "./caching-resolver.js";
-import { PostgresClickSink, type ClickSink } from "./click-sink.js";
-import { DailySaltCache } from "./salt.js";
+import { PostgresClickSink, SqsClickSink, type ClickSink } from "./click-sink.js";
+import { CacheStoreSaltCache, PostgresSaltCache, type SaltSource } from "./salt.js";
 
 /* ============================================================
    The redirect service.
@@ -82,6 +83,17 @@ const REDIS_URL = process.env.REDIS_URL;
    DynamoDB table on the 'dynamo' path. */
 const LINK_PROJECTION = process.env.LINK_PROJECTION ?? "none";
 const LINK_PROJECTION_TABLE = process.env.LINK_PROJECTION_TABLE;
+
+/* Where a click goes after the redirect, keyed on CLICK_SINK:
+   'sqs' sends an awaited SendMessage to CLICK_QUEUE_URL (the AWS profile — the
+   worker drains it back into click_events); anything else / unset writes
+   straight to Postgres, which is what local dev, compose, the single-node and
+   Kubernetes profiles all use — byte-for-byte the behaviour before this switch.
+   Under LINK_PROJECTION=dynamo + CLICK_SINK=sqs the redirect touches only
+   DynamoDB + SQS (public AWS endpoints) and opens NO Postgres connection, which
+   is what lets it leave the VPC (#288 3b). */
+const CLICK_SINK = process.env.CLICK_SINK ?? "postgres";
+const CLICK_QUEUE_URL = process.env.CLICK_QUEUE_URL;
 /* A short bounded-staleness window: an edited link stops serving its old
    destination within this many seconds even before edit-invalidation lands.
    Ten seconds keeps the database out of the hot path for the common repeated
@@ -104,39 +116,56 @@ const app = Fastify({ logger: { level: process.env.LOG_LEVEL ?? "info" }, trustP
 let close: () => Promise<void> = async () => {};
 let resolver: LinkResolver;
 let clicks: ClickSink;
-let salts: DailySaltCache;
+let salts: SaltSource;
 let JWT_SECRET = JWT_SECRET_DEFAULT;
 
 /** Resolve secrets, open the connection and wire up the adapters. Called once
  *  at the start of main(), before the server starts accepting requests. */
 async function init(): Promise<void> {
-  const url =
-    (await resolveDatabaseUrl()) ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
   JWT_SECRET = (await resolveJwtSecret("JWT_ACCESS_SECRET_ARN", "JWT_ACCESS_SECRET")) ?? "";
 
-  const database = createDatabase({
-    url,
-    replicaUrl: process.env.DATABASE_REPLICA_URL,
-    ssl: process.env.DATABASE_SSL === "true",
-    sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
-    sslCaCert: process.env.DATABASE_CA_CERT,
-    max: POOL_MAX,
-  });
-  close = database.close;
+  /* Which of the three hot-path stores each adapter reads from decides whether
+     the redirect needs Postgres at all:
+
+       - the resolver reads Postgres UNLESS LINK_PROJECTION=dynamo;
+       - the click sink writes Postgres UNLESS CLICK_SINK=sqs;
+       - the salt source reads Postgres only when the db handle exists,
+         otherwise it reads the shared CacheStore (DynamoDB on the AWS profile).
+
+     So Postgres is opened only when the resolver or the sink needs it. Under
+     LINK_PROJECTION=dynamo + CLICK_SINK=sqs both are off Postgres and the
+     redirect opens NO connection — no pool, no ENI, no ~109-connection RDS
+     ceiling — which is exactly what lets it leave the VPC (#288 3b). We never
+     resolve DATABASE_URL or build a pool on that path. */
+  const resolverUsesPostgres = LINK_PROJECTION !== "dynamo";
+  const sinkUsesPostgres = CLICK_SINK !== "sqs";
+  const needsPostgres = resolverUsesPostgres || sinkUsesPostgres;
+
+  let database: ReturnType<typeof createDatabase> | undefined;
+  if (needsPostgres) {
+    const url =
+      (await resolveDatabaseUrl()) ?? "postgres://snapurl:snapurl@localhost:5433/snapurl";
+    database = createDatabase({
+      url,
+      replicaUrl: process.env.DATABASE_REPLICA_URL,
+      ssl: process.env.DATABASE_SSL === "true",
+      sslNoVerify: process.env.DATABASE_SSL_NO_VERIFY === "true",
+      sslCaCert: process.env.DATABASE_CA_CERT,
+      max: POOL_MAX,
+    });
+    close = database.close;
+  }
+
   /* The base resolver: DynamoDB projection on the AWS profile, Postgres
      everywhere else. Under 'dynamo' the redirect does NOT need Postgres to
-     RESOLVE a link — the projection carries everything — though it still opens
-     the connection below for the click sink (CLICK_SINK=postgres) and the
-     daily salt cache; moving those off Postgres (and the redirect out of the
-     VPC) is FEAT-003. The real payoff of the projection — the redirect leaving
-     the VPC entirely — lands there, once the SQS click sink exists. */
+     RESOLVE a link — the projection carries everything. */
   let baseResolver: LinkResolver;
   if (LINK_PROJECTION === "dynamo") {
     if (!LINK_PROJECTION_TABLE) throw new Error("LINK_PROJECTION=dynamo requires LINK_PROJECTION_TABLE to be set.");
     const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({ region: process.env.AWS_REGION }));
     baseResolver = new DynamoLinkResolver(dynamo, LINK_PROJECTION_TABLE);
   } else {
-    baseResolver = new PostgresLinkResolver(database.db);
+    baseResolver = new PostgresLinkResolver(database!.db);
   }
   /* Wrap the base resolver in the short-lived cache. With the default 'memory'
      driver this is a per-instance cache with a 10s TTL — a safe optimization
@@ -147,8 +176,20 @@ async function init(): Promise<void> {
      PostgresLinkResolver exactly as before. */
   const cacheStore = await createCacheStore({ driver: CACHE_DRIVER, redisUrl: REDIS_URL });
   resolver = new CachingLinkResolver(baseResolver, cacheStore, LINK_CACHE_TTL_SECONDS);
-  clicks = new PostgresClickSink(database.db);
-  salts = new DailySaltCache(database.db);
+
+  /* The click sink: an awaited SQS SendMessage on the AWS profile (freeze-safe,
+     drained by the worker), a Postgres INSERT everywhere else. */
+  if (CLICK_SINK === "sqs") {
+    if (!CLICK_QUEUE_URL) throw new Error("CLICK_SINK=sqs requires CLICK_QUEUE_URL to be set.");
+    clicks = new SqsClickSink(new SQSClient({ region: process.env.AWS_REGION }), CLICK_QUEUE_URL);
+  } else {
+    clicks = new PostgresClickSink(database!.db);
+  }
+
+  /* The salt source: the daily_salts table when a Postgres handle exists,
+     otherwise the shared CacheStore so a redirect that has left Postgres can
+     still salt its visitor hashes without a connection. */
+  salts = database ? new PostgresSaltCache(database.db) : new CacheStoreSaltCache(cacheStore);
 }
 
 app.get("/health", async () => ({ status: "ok" }));

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -17,7 +17,9 @@ import {
   clientIpFromXff,
 } from "@snapurl/domain";
 import { createCacheStore, type CacheDriver } from "@snapurl/cache";
-import { PostgresLinkResolver, type LinkResolver, type ResolvedLink } from "./resolver.js";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { DynamoLinkResolver, PostgresLinkResolver, type LinkResolver, type ResolvedLink } from "./resolver.js";
 import { CachingLinkResolver } from "./caching-resolver.js";
 import { PostgresClickSink, type ClickSink } from "./click-sink.js";
 import { DailySaltCache } from "./salt.js";
@@ -71,6 +73,15 @@ const TRUSTED_PROXY_HOPS = Number(process.env.TRUSTED_PROXY_HOPS ?? 0);
    docs/DECISIONS.md for the per-profile reasoning. */
 const CACHE_DRIVER = (process.env.CACHE_DRIVER ?? "memory") as CacheDriver;
 const REDIS_URL = process.env.REDIS_URL;
+
+/* Which store the redirect resolves link config from, keyed on LINK_PROJECTION:
+   'dynamo' reads the DynamoDB projection the worker writes (the AWS profile);
+   anything else / unset reads Postgres directly, which is what local dev,
+   compose, the single-node and the Kubernetes profiles all use — byte-for-byte
+   the behaviour before this switch existed. LINK_PROJECTION_TABLE names the
+   DynamoDB table on the 'dynamo' path. */
+const LINK_PROJECTION = process.env.LINK_PROJECTION ?? "none";
+const LINK_PROJECTION_TABLE = process.env.LINK_PROJECTION_TABLE;
 /* A short bounded-staleness window: an edited link stops serving its old
    destination within this many seconds even before edit-invalidation lands.
    Ten seconds keeps the database out of the hot path for the common repeated
@@ -112,13 +123,30 @@ async function init(): Promise<void> {
     max: POOL_MAX,
   });
   close = database.close;
-  const postgresResolver = new PostgresLinkResolver(database.db);
-  /* Wrap the Postgres resolver in the short-lived cache. With the default
-     'memory' driver this is a per-instance cache with a 10s TTL — a safe
-     optimization that never changes redirect correctness: a hot link still
-     302s to the right place and the click is still recorded per request. */
+  /* The base resolver: DynamoDB projection on the AWS profile, Postgres
+     everywhere else. Under 'dynamo' the redirect does NOT need Postgres to
+     RESOLVE a link — the projection carries everything — though it still opens
+     the connection below for the click sink (CLICK_SINK=postgres) and the
+     daily salt cache; moving those off Postgres (and the redirect out of the
+     VPC) is FEAT-003. The real payoff of the projection — the redirect leaving
+     the VPC entirely — lands there, once the SQS click sink exists. */
+  let baseResolver: LinkResolver;
+  if (LINK_PROJECTION === "dynamo") {
+    if (!LINK_PROJECTION_TABLE) throw new Error("LINK_PROJECTION=dynamo requires LINK_PROJECTION_TABLE to be set.");
+    const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({ region: process.env.AWS_REGION }));
+    baseResolver = new DynamoLinkResolver(dynamo, LINK_PROJECTION_TABLE);
+  } else {
+    baseResolver = new PostgresLinkResolver(database.db);
+  }
+  /* Wrap the base resolver in the short-lived cache. With the default 'memory'
+     driver this is a per-instance cache with a 10s TTL — a safe optimization
+     that never changes redirect correctness: a hot link still 302s to the
+     right place and the click is still recorded per request. DynamoDB is
+     already fast, but the wrap is kept uniform (it cuts read cost and keeps hit
+     and miss returning an identical link); the 'none' path wraps
+     PostgresLinkResolver exactly as before. */
   const cacheStore = await createCacheStore({ driver: CACHE_DRIVER, redisUrl: REDIS_URL });
-  resolver = new CachingLinkResolver(postgresResolver, cacheStore, LINK_CACHE_TTL_SECONDS);
+  resolver = new CachingLinkResolver(baseResolver, cacheStore, LINK_CACHE_TTL_SECONDS);
   clicks = new PostgresClickSink(database.db);
   salts = new DailySaltCache(database.db);
 }

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -187,8 +187,15 @@ async function init(): Promise<void> {
   let baseResolver: LinkResolver;
   if (LINK_PROJECTION === "dynamo") {
     if (!LINK_PROJECTION_TABLE) throw new Error("LINK_PROJECTION=dynamo requires LINK_PROJECTION_TABLE to be set.");
+    /* removeUndefinedValues mirrors the worker's writer client. The resolver
+       only reads (GetItem/Query), but keeping the marshall options identical on
+       both sides means the reader and writer never disagree about how an
+       optional/absent field is represented, and a future write on this client
+       (none today) could not reintroduce the undefined-marshalling throw that
+       silently emptied the projection. */
     const dynamo = DynamoDBDocumentClient.from(
       new DynamoDBClient({ region: process.env.AWS_REGION, endpoint: dynamoEndpoint() }),
+      { marshallOptions: { removeUndefinedValues: true } },
     );
     baseResolver = new DynamoLinkResolver(dynamo, LINK_PROJECTION_TABLE);
   } else {

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -67,13 +67,23 @@ const POOL_MAX = Number(process.env.DATABASE_POOL_MAX ?? 5);
    behind CloudFront sets it to 1 (or higher for additional appending hops). */
 const TRUSTED_PROXY_HOPS = Number(process.env.TRUSTED_PROXY_HOPS ?? 0);
 
-/* Which CacheStore backs the hot-link cache. 'memory' (the default) is a
-   per-instance in-memory cache, which is all local/CI/compose and any
-   single-node deployment needs. The scaled profile sets 'redis' + REDIS_URL so
-   the cache is shared across instances; the AWS profile uses 'dynamodb'. See
-   docs/DECISIONS.md for the per-profile reasoning. */
+/* Which CacheStore backs the hot-link cache and the daily-salt cache. 'memory'
+   (the default) is a per-instance in-memory cache, which is all local/CI/compose
+   and any single-node deployment needs. The scaled profile sets 'redis' +
+   REDIS_URL so the cache is shared across instances; the AWS profile sets
+   'dynamodb' + CACHE_DYNAMO_TABLE so it is shared via DynamoDB — which is what
+   lets the out-of-VPC redirect share one daily salt across instances instead of
+   each holding its own. See docs/DECISIONS.md for the per-profile reasoning. */
 const CACHE_DRIVER = (process.env.CACHE_DRIVER ?? "memory") as CacheDriver;
 const REDIS_URL = process.env.REDIS_URL;
+/* The cache table name, required only when CACHE_DRIVER=dynamodb (the AWS
+   profile). It backs both the hot-link cache and — crucially — the shared
+   daily-salt cache: with the redirect out of the VPC, this shared DynamoDB
+   store is what lets every instance agree on today's salt instead of each
+   holding its own per-instance value. The factory throws if the driver is
+   'dynamodb' and this is unset, so a misconfigured deploy fails loudly at boot
+   rather than silently falling back to a per-instance store. */
+const CACHE_DYNAMO_TABLE = process.env.CACHE_DYNAMO_TABLE;
 
 /* Which store the redirect resolves link config from, keyed on LINK_PROJECTION:
    'dynamo' reads the DynamoDB projection the worker writes (the AWS profile);
@@ -191,7 +201,11 @@ async function init(): Promise<void> {
      already fast, but the wrap is kept uniform (it cuts read cost and keeps hit
      and miss returning an identical link); the 'none' path wraps
      PostgresLinkResolver exactly as before. */
-  const cacheStore = await createCacheStore({ driver: CACHE_DRIVER, redisUrl: REDIS_URL });
+  const cacheStore = await createCacheStore({
+    driver: CACHE_DRIVER,
+    redisUrl: REDIS_URL,
+    dynamoTable: CACHE_DYNAMO_TABLE,
+  });
   resolver = new CachingLinkResolver(baseResolver, cacheStore, LINK_CACHE_TTL_SECONDS);
 
   /* The click sink: an awaited SQS SendMessage on the AWS profile (freeze-safe,

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -94,6 +94,21 @@ const LINK_PROJECTION_TABLE = process.env.LINK_PROJECTION_TABLE;
    is what lets it leave the VPC (#288 3b). */
 const CLICK_SINK = process.env.CLICK_SINK ?? "postgres";
 const CLICK_QUEUE_URL = process.env.CLICK_QUEUE_URL;
+
+/* OPTIONAL endpoint-url overrides for the AWS SDK clients. Both return
+   undefined in production, so the DynamoDB and SQS clients resolve their real
+   regional endpoints and `endpoint` is simply omitted — a genuine no-op. CI
+   sets AWS_ENDPOINT_URL_DYNAMODB (a dynamodb-local container) and, if it ever
+   runs an SQS emulator, AWS_ENDPOINT_URL_SQS, so the same adapters can be
+   exercised against local emulators without any code change. The
+   service-specific env wins over the service-agnostic AWS_ENDPOINT_URL,
+   matching the SDK's own precedence. */
+function dynamoEndpoint(): string | undefined {
+  return process.env.AWS_ENDPOINT_URL_DYNAMODB ?? process.env.AWS_ENDPOINT_URL ?? undefined;
+}
+function sqsEndpoint(): string | undefined {
+  return process.env.AWS_ENDPOINT_URL_SQS ?? process.env.AWS_ENDPOINT_URL ?? undefined;
+}
 /* A short bounded-staleness window: an edited link stops serving its old
    destination within this many seconds even before edit-invalidation lands.
    Ten seconds keeps the database out of the hot path for the common repeated
@@ -162,7 +177,9 @@ async function init(): Promise<void> {
   let baseResolver: LinkResolver;
   if (LINK_PROJECTION === "dynamo") {
     if (!LINK_PROJECTION_TABLE) throw new Error("LINK_PROJECTION=dynamo requires LINK_PROJECTION_TABLE to be set.");
-    const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({ region: process.env.AWS_REGION }));
+    const dynamo = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: process.env.AWS_REGION, endpoint: dynamoEndpoint() }),
+    );
     baseResolver = new DynamoLinkResolver(dynamo, LINK_PROJECTION_TABLE);
   } else {
     baseResolver = new PostgresLinkResolver(database!.db);
@@ -181,7 +198,10 @@ async function init(): Promise<void> {
      drained by the worker), a Postgres INSERT everywhere else. */
   if (CLICK_SINK === "sqs") {
     if (!CLICK_QUEUE_URL) throw new Error("CLICK_SINK=sqs requires CLICK_QUEUE_URL to be set.");
-    clicks = new SqsClickSink(new SQSClient({ region: process.env.AWS_REGION }), CLICK_QUEUE_URL);
+    clicks = new SqsClickSink(
+      new SQSClient({ region: process.env.AWS_REGION, endpoint: sqsEndpoint() }),
+      CLICK_QUEUE_URL,
+    );
   } else {
     clicks = new PostgresClickSink(database!.db);
   }

--- a/apps/redirect/src/resolver.ts
+++ b/apps/redirect/src/resolver.ts
@@ -1,5 +1,28 @@
-import { and, domains, eq, linkCounters, links, routingRules, sql, type Database } from "@snapurl/database";
+import {
+  and,
+  domains,
+  domainMetaKey,
+  eq,
+  fromDomainItem,
+  fromLinkItem,
+  linkCounters,
+  linkKey,
+  links,
+  normaliseHost,
+  routingRules,
+  sql,
+  type Database,
+  type DomainItem,
+  type LinkItem,
+} from "@snapurl/database";
+import { GetCommand, type DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import type { RoutingRule } from "@snapurl/contract";
+
+/* normaliseHost lives in @snapurl/database's link-projection module now — the
+   single source of truth shared by the Postgres lookup here and the DynamoDB
+   projection key-builders — and is re-exported so existing importers
+   (main.ts, caching-resolver.ts, the tests) keep importing it from here. */
+export { normaliseHost };
 
 /* ============================================================
    Resolving (host, slug) to everything the redirect needs.
@@ -51,12 +74,6 @@ export interface ResolvedDomain {
 export interface LinkResolver {
   resolve(host: string, slug: string): Promise<ResolvedLink | null>;
   resolveDomain(host: string): Promise<ResolvedDomain | null>;
-}
-
-/** Strips the port so links created against "localhost:3002" resolve when the
- *  request arrives with a Host header of "localhost:3002" or "localhost". */
-export function normaliseHost(host: string): string {
-  return host.toLowerCase().trim();
 }
 
 export class PostgresLinkResolver implements LinkResolver {
@@ -146,10 +163,40 @@ export class PostgresLinkResolver implements LinkResolver {
   }
 }
 
-/* The DynamoDB adapter is deliberately not written yet.
+/* ============================================================
+   DynamoLinkResolver — the AWS-serverless-profile adapter.
 
-   Writing it against a table that does not exist would be code nobody has run.
-   The API already emits the projection_outbox rows it needs (see
-   LinksService.enqueueProjection), so the remaining work is: create the table
-   in CDK, have the worker drain the outbox into it, and implement this
-   interface over GetItem. The shape above is exactly what one item holds. */
+   Reads the projection the worker writes (see the worker's
+   DynamoProjection and @snapurl/database/link-projection). One
+   GetItem per resolve, no connection pool, which is what makes the
+   redirect viable on Lambda without the ~109-connection RDS
+   ceiling — and, in FEAT-003, lets it leave the VPC entirely.
+
+   The DynamoDBDocumentClient and table name are injected via the
+   constructor so the command shapes can be unit-tested against a
+   mocked client, exactly like DynamoDbCacheStore. The item shape
+   and the Date revival are the shared mapper's, so a field this
+   returns cannot drift from a field the worker projected.
+   ============================================================ */
+export class DynamoLinkResolver implements LinkResolver {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly table: string,
+  ) {}
+
+  async resolve(host: string, slug: string): Promise<ResolvedLink | null> {
+    const result = await this.client.send(
+      new GetCommand({ TableName: this.table, Key: linkKey(host, slug) }),
+    );
+    if (!result.Item) return null;
+    return fromLinkItem(result.Item as LinkItem);
+  }
+
+  async resolveDomain(host: string): Promise<ResolvedDomain | null> {
+    const result = await this.client.send(
+      new GetCommand({ TableName: this.table, Key: domainMetaKey(host) }),
+    );
+    if (!result.Item) return null;
+    return fromDomainItem(result.Item as DomainItem);
+  }
+}

--- a/apps/redirect/src/salt.ts
+++ b/apps/redirect/src/salt.ts
@@ -80,23 +80,35 @@ export const DailySaltCache = PostgresSaltCache;
 /* The salt in the shared CacheStore (DynamoDB on the AWS profile).
 
    The key is namespaced and dated ("salt#<day>") and the value carries a TTL
-   that comfortably outlives one day. Once written, every instance that reads
-   the key before writing its own gets the shared value, and each instance
-   caches it in memory for the rest of the day. The salt is discarded when the
+   that comfortably outlives one day. This is a SHARED store on the AWS profile
+   (DynamoDB, provisioned by the CDK as CacheTable with CACHE_DRIVER=dynamodb on
+   the redirect), so once today's salt is written every instance reads the same
+   value back — load() re-reads after its own write to converge even on a race
+   (see below) — and each instance caches it in memory for the rest of the day.
+   That shared invariant is the whole reason the redirect can leave the VPC
+   without fragmenting the salt per-instance. The salt is discarded when the
    key expires, preserving the privacy promise — yesterday's hashes stay
    un-recomputable — and the TTL is what retires an old day's salt here (the
    worker's rotateSalts still governs the Postgres daily_salts table on the
    profiles that use it).
 
    The one race is the first request of a new day arriving at two cold
-   instances at once: both find the key absent and each writes its own salt, so
-   for that brief window a visitor could be hashed under two different salts and
-   counted twice. That is the SAME bounded imprecision the "no cookies" promise
-   already documents ("a visitor who changes network counts twice"), it only
-   affects unique counting (never a redirect's correctness), and it closes the
-   instant the key is populated. A true SETNX would remove even that window, but
-   the CacheStore port has no atomic first-write primitive and adding one for a
-   once-a-day cold-start window is not worth the surface area. */
+   instances at once: both find the key absent and each writes its own salt.
+   load() closes this the same way PostgresSaltCache.load does — it re-reads the
+   key AFTER writing and returns whatever value the store now holds, so both
+   racers converge on the SAME salt (the store keeps whichever set() it applied,
+   and every instance reads that one back) rather than each keeping its own for
+   the day. The residual window is only the instant between the two sets, and it
+   is the SAME bounded imprecision the "no cookies" promise already documents
+   ("a visitor who changes network counts twice"): it only affects unique
+   counting, never a redirect's correctness.
+
+   The re-read is best-effort convergence, not a lock: set() is a last-write-wins
+   overwrite (not an atomic SETNX — the CacheStore port has no first-write
+   primitive), so two sets racing to the microsecond can still land in either
+   order, but both instances then read back the surviving value and agree. A
+   true SETNX would make the winner deterministic, but adding one for a
+   once-a-day cold-start window is not worth the port surface area. */
 const SALT_KEY_PREFIX = "salt#";
 /* Two days: long enough that a salt written just before midnight is still
    present for the whole of its own day even accounting for clock skew, short
@@ -115,6 +127,14 @@ export class CacheStoreSaltCache extends CachingSaltSource {
 
     const salt = generateDailySalt();
     await this.store.set(key, salt, SALT_TTL_SECONDS);
-    return salt;
+
+    /* Re-read after the write so every instance converges on the shared value,
+       mirroring PostgresSaltCache's re-read after onConflictDoNothing: if
+       another instance's set() for this key landed, we read theirs back and
+       agree rather than keeping our own for the day. Falls back to our own salt
+       only if the read somehow returns empty (never expected right after a
+       write), so a new day always yields a usable salt. */
+    const shared = await this.store.get(key);
+    return shared ?? salt;
   }
 }

--- a/apps/redirect/src/salt.ts
+++ b/apps/redirect/src/salt.ts
@@ -1,48 +1,120 @@
 import { dailySalts, eq, type Database } from "@snapurl/database";
 import { generateDailySalt, saltDateKey } from "@snapurl/domain";
+import type { CacheStore } from "@snapurl/cache";
 
 /* The rotating salt behind every visitor hash.
 
-   Cached in memory for the process lifetime of the current day: this is read
-   on every single redirect, and a database round trip per click would defeat
-   the point of keeping the hot path off Postgres.
+   Every redirect needs today's salt to compute a visitorHash, so this is on
+   the hot path of every single click. There are two sources, chosen by the
+   same profile split as the resolver and the click sink:
 
-   The row is created on first use rather than by a scheduled job, so a fresh
-   deployment works on its first request with nothing to set up. */
-export class DailySaltCache {
+     - PostgresSaltCache: the daily_salts table (single-node / k8s / compose,
+       and the AWS profile whenever the redirect still holds a Postgres handle).
+       This is the original behaviour, unchanged.
+     - CacheStoreSaltCache: the shared CacheStore, which on the AWS profile is
+       DynamoDB. This is what lets the redirect leave the VPC: under
+       LINK_PROJECTION=dynamo + CLICK_SINK=sqs the redirect resolves from
+       DynamoDB, sends clicks to SQS and reads the salt from DynamoDB — all
+       public AWS endpoints — so it opens no Postgres connection at all.
+
+   Both cache the salt in memory for the process lifetime of the current day:
+   this is read on every single redirect, and a round trip per click would
+   defeat the point of keeping the hot path off the backing store. The
+   in-memory day cache + single-flight stampede guard are shared by both via
+   the base class; only the load-from-store step differs. */
+export interface SaltSource {
+  today(): Promise<string>;
+}
+
+abstract class CachingSaltSource implements SaltSource {
   private cachedDay: string | null = null;
   private cachedSalt: string | null = null;
   private inFlight: Promise<string> | null = null;
-
-  constructor(private readonly db: Database) {}
 
   async today(): Promise<string> {
     const day = saltDateKey();
     if (this.cachedDay === day && this.cachedSalt) return this.cachedSalt;
 
     // Collapse the stampede when many requests cross midnight together.
-    this.inFlight ??= this.load(day).finally(() => {
-      this.inFlight = null;
-    });
+    this.inFlight ??= this.load(day)
+      .then((salt) => {
+        this.cachedDay = day;
+        this.cachedSalt = salt;
+        return salt;
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
     return this.inFlight;
   }
 
-  private async load(day: string): Promise<string> {
+  /** Read (creating on first use) today's salt from the backing store. */
+  protected abstract load(day: string): Promise<string>;
+}
+
+export class PostgresSaltCache extends CachingSaltSource {
+  constructor(private readonly db: Database) {
+    super();
+  }
+
+  /* The row is created on first use rather than by a scheduled job, so a fresh
+     deployment works on its first request with nothing to set up. */
+  protected async load(day: string): Promise<string> {
     const [existing] = await this.db.select().from(dailySalts).where(eq(dailySalts.day, day)).limit(1);
-    if (existing) {
-      this.cachedDay = day;
-      this.cachedSalt = existing.salt;
-      return existing.salt;
-    }
+    if (existing) return existing.salt;
 
     const salt = generateDailySalt();
     await this.db.insert(dailySalts).values({ day, salt }).onConflictDoNothing();
 
     // Another instance may have won the race; re-read so every instance agrees.
     const [row] = await this.db.select().from(dailySalts).where(eq(dailySalts.day, day)).limit(1);
-    const winner = row?.salt ?? salt;
-    this.cachedDay = day;
-    this.cachedSalt = winner;
-    return winner;
+    return row?.salt ?? salt;
+  }
+}
+
+/* Backwards-compatible alias: DailySaltCache was the only salt source before
+   the AWS profile could leave Postgres, and main.ts / any test that named it
+   keeps working. */
+export const DailySaltCache = PostgresSaltCache;
+
+/* The salt in the shared CacheStore (DynamoDB on the AWS profile).
+
+   The key is namespaced and dated ("salt#<day>") and the value carries a TTL
+   that comfortably outlives one day. Once written, every instance that reads
+   the key before writing its own gets the shared value, and each instance
+   caches it in memory for the rest of the day. The salt is discarded when the
+   key expires, preserving the privacy promise — yesterday's hashes stay
+   un-recomputable — and the TTL is what retires an old day's salt here (the
+   worker's rotateSalts still governs the Postgres daily_salts table on the
+   profiles that use it).
+
+   The one race is the first request of a new day arriving at two cold
+   instances at once: both find the key absent and each writes its own salt, so
+   for that brief window a visitor could be hashed under two different salts and
+   counted twice. That is the SAME bounded imprecision the "no cookies" promise
+   already documents ("a visitor who changes network counts twice"), it only
+   affects unique counting (never a redirect's correctness), and it closes the
+   instant the key is populated. A true SETNX would remove even that window, but
+   the CacheStore port has no atomic first-write primitive and adding one for a
+   once-a-day cold-start window is not worth the surface area. */
+const SALT_KEY_PREFIX = "salt#";
+/* Two days: long enough that a salt written just before midnight is still
+   present for the whole of its own day even accounting for clock skew, short
+   enough that a day's salt does not linger past its usefulness. */
+const SALT_TTL_SECONDS = 2 * 24 * 60 * 60;
+
+export class CacheStoreSaltCache extends CachingSaltSource {
+  constructor(private readonly store: CacheStore) {
+    super();
+  }
+
+  protected async load(day: string): Promise<string> {
+    const key = SALT_KEY_PREFIX + day;
+    const existing = await this.store.get(key);
+    if (existing) return existing;
+
+    const salt = generateDailySalt();
+    await this.store.set(key, salt, SALT_TTL_SECONDS);
+    return salt;
   }
 }

--- a/apps/redirect/src/sqs-click-sink.test.ts
+++ b/apps/redirect/src/sqs-click-sink.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import { deserializeClickEvent, type ClickEvent } from "@snapurl/database";
+import { SqsClickSink } from "./click-sink.js";
+
+/* MOCK-based unit tests, mirroring packages/cache/dynamodb-cache-store.test.ts:
+   no live SQS in-sandbox or in CI, so a fake SQSClient whose `send` is stubbed
+   by command constructor name asserts record() issues the RIGHT command to the
+   configured queue with a JSON body that round-trips the ClickEvent. */
+
+const QUEUE_URL = "https://sqs.ap-south-1.amazonaws.com/123456789012/snapurl-clicks";
+
+function commandName(command: unknown): string {
+  return (command as { constructor: { name: string } }).constructor.name;
+}
+
+const clickEvent: ClickEvent = {
+  linkId: "11111111-1111-1111-1111-111111111111",
+  workspaceId: "22222222-2222-2222-2222-222222222222",
+  occurredAt: new Date("2025-01-02T03:04:05.678Z"),
+  visitorHash: "abcdef0123456789abcdef0123456789",
+  country: "IN",
+  city: "Pune",
+  device: "android",
+  browser: "Chrome",
+  os: "Android",
+  referrerHost: "example.com",
+  isQr: false,
+  isBot: false,
+  blockedReason: null,
+  matchedRuleId: null,
+  variant: null,
+};
+
+describe("SqsClickSink", () => {
+  it("issues a SendMessageCommand whose JSON body round-trips the ClickEvent to the configured queue", async () => {
+    let captured: any;
+    const send = vi.fn(async (command: unknown) => {
+      expect(commandName(command)).toBe("SendMessageCommand");
+      captured = (command as { input: any }).input;
+      return {};
+    });
+    const client = { send } as unknown as SQSClient;
+
+    const sink = new SqsClickSink(client, QUEUE_URL);
+    await sink.record(clickEvent);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(captured.QueueUrl).toBe(QUEUE_URL);
+    // occurredAt is serialised as an ISO string on the wire...
+    expect(JSON.parse(captured.MessageBody).occurredAt).toBe("2025-01-02T03:04:05.678Z");
+    // ...and deserializeClickEvent (the worker's path) revives the exact event.
+    expect(deserializeClickEvent(captured.MessageBody)).toEqual(clickEvent);
+  });
+
+  it("awaits the send: record() resolves only after send resolves", async () => {
+    let sendResolved = false;
+    const send = vi.fn(async () => {
+      // Defer to a later microtask so an un-awaited record() would resolve first.
+      await Promise.resolve();
+      sendResolved = true;
+      return {};
+    });
+    const client = { send } as unknown as SQSClient;
+
+    const sink = new SqsClickSink(client, QUEUE_URL);
+    await sink.record(clickEvent);
+
+    // If record() did not await the send, this would still be false here.
+    expect(sendResolved).toBe(true);
+  });
+});

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1121.0",
+    "@aws-sdk/lib-dynamodb": "^3.1121.0",
     "@snapurl/contract": "workspace:*",
     "@snapurl/database": "workspace:*",
     "@snapurl/domain": "workspace:*",

--- a/apps/worker/src/jobs/dynamo-projection.test.ts
+++ b/apps/worker/src/jobs/dynamo-projection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import type { Database } from "@snapurl/database";
 import { DynamoProjection } from "./dynamo-projection.js";
 
@@ -210,5 +211,80 @@ describe("DynamoProjection.apply (batching)", () => {
     expect(results[1]!.ok).toBe(false);
     // Sanity: the healthy client fixture is unused here but proves the harness.
     void client;
+  });
+});
+
+describe("DynamoProjection marshalling of optional/absent fields", () => {
+  /* Regression guard for the dynamo-smoke failure (#288): a real link carries
+     a PARTIAL utm object (e.g. {source, campaign} with medium/content absent)
+     and routing rules whose when.device / when.language / weight are absent.
+     Read back from Postgres those absent JSON keys are `undefined`, and
+     lib-dynamodb's marshaller THROWS on an undefined attribute value unless the
+     DocumentClient is built with removeUndefinedValues. A throw there fails the
+     whole BatchWriteCommand, so ONE partial-utm link stops the entire
+     projection batch and the redirect resolves nothing. These tests use a REAL
+     DynamoDBDocumentClient (its marshalling middleware runs for real) over a
+     stubbed base client (no network), so they exercise the actual marshaller
+     rather than a hand-rolled fake. */
+
+  /** A link row whose utm has only some keys set and whose rule omits the
+   *  optional when.device / when.language / weight — the exact shapes the smoke
+   *  fixtures ($RUN-utm, $RUN-geo) produce. */
+  function partialRow() {
+    return linkRow({
+      utm: { source: "newsletter", campaign: "spring" },
+    });
+  }
+  const partialRules = [
+    { rule: { id: "r-in", whenCountry: "IN", whenDevice: undefined, whenLanguage: undefined, then: "https://example.in/store", weight: undefined } },
+  ];
+
+  /* A sentinel the stubbed transport throws so a request that gets PAST
+     marshalling lands here deterministically — no network, no credentials, no
+     real endpoint. If marshalling throws first (the undefined case), this is
+     never reached, which is exactly the difference the two tests assert. */
+  const TRANSPORT_REACHED = "transport-reached-sentinel";
+
+  /** Build a real DocumentClient over a real base client whose HTTP transport
+   *  is replaced by a sentinel-throwing handler and whose credentials are
+   *  static (so nothing tries the credential-provider chain). The
+   *  DocumentClient's marshalling middleware runs for real; only the network
+   *  leg is stubbed. */
+  function realDocClient(removeUndefinedValues: boolean) {
+    const base = new DynamoDBClient({
+      region: "us-east-1",
+      endpoint: "http://localhost:8000",
+      credentials: { accessKeyId: "dummy", secretAccessKey: "dummy" },
+      requestHandler: {
+        handle: () => Promise.reject(new Error(TRANSPORT_REACHED)),
+      } as never,
+    });
+    return DynamoDBDocumentClient.from(base, {
+      marshallOptions: { removeUndefinedValues },
+    });
+  }
+
+  it("marshals a partial-utm link WITHOUT throwing when removeUndefinedValues is set", async () => {
+    const client = realDocClient(true);
+    const projection = new DynamoProjection(makeDb([partialRow()], partialRules), client, TABLE);
+
+    /* The request marshalled cleanly (undefined stripped) and reached the
+       stubbed transport — proving the marshaller did NOT reject the undefined
+       utm/rule fields. The transport sentinel is the deliberate stop; the point
+       is that marshalling succeeded, not that a fake network returned 200. */
+    await expect(projection.upsert("link-1")).rejects.toThrow(TRANSPORT_REACHED);
+  });
+
+  it("throws a marshalling error on the same input WITHOUT removeUndefinedValues", async () => {
+    const client = realDocClient(false);
+    const projection = new DynamoProjection(makeDb([partialRow()], partialRules), client, TABLE);
+
+    /* This is the exact failure the dynamo-smoke job hit: the marshaller throws
+       on the first undefined attribute value, the BatchWrite never leaves the
+       process (the transport sentinel is never reached), and the projection is
+       left empty so every redirect 404s. The rejection must therefore NOT be
+       the transport sentinel. */
+    await expect(projection.upsert("link-1")).rejects.toThrow();
+    await expect(projection.upsert("link-1")).rejects.not.toThrow(TRANSPORT_REACHED);
   });
 });

--- a/apps/worker/src/jobs/dynamo-projection.test.ts
+++ b/apps/worker/src/jobs/dynamo-projection.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import type { Database } from "@snapurl/database";
+import { DynamoProjection } from "./dynamo-projection.js";
+
+/* MOCK-based unit tests, mirroring packages/cache/dynamodb-cache-store.test.ts.
+   No live DynamoDB and no Postgres: the db is a chainable fake whose terminal
+   (.limit / .orderBy) resolves to preset rows, and the DynamoDBDocumentClient's
+   `send` is stubbed by command constructor name. */
+
+const TABLE = "snapurl-link-projection";
+
+function commandName(command: unknown): string {
+  return (command as { constructor: { name: string } }).constructor.name;
+}
+
+/** A link row as the buildUpsertRequests join projects it. */
+function linkRow(overrides: Partial<any> = {}) {
+  return {
+    link: {
+      id: "link-1",
+      workspaceId: "ws-1",
+      destination: "https://example.com/1",
+      redirectType: "302",
+      expiresAt: null,
+      expiresTo: null,
+      activatesAt: null,
+      scheduledTo: null,
+      clickLimit: null,
+      passwordHash: null,
+      forwardQuery: true,
+      deepLink: false,
+      hideReferrer: false,
+      publicPreview: true,
+      archivedAt: null,
+      safeBrowsingStatus: "safe",
+      utm: null,
+      slug: "one",
+      ...overrides,
+    },
+    domain: "snap.to",
+    domainId: "dom-1",
+    rootRedirect: null,
+    notFoundRedirect: null,
+    clicks: 7,
+  };
+}
+
+/** A chainable drizzle-select fake. The first select() call in a sequence
+ *  returns the link-row query result at its terminal (.limit), the second
+ *  returns the rules result at its terminal (.orderBy). */
+function makeDb(linkRows: any[], rulesRows: any[]): Database {
+  let call = 0;
+  const select = () => {
+    const which = call++;
+    const rows = which % 2 === 0 ? linkRows : rulesRows;
+    const builder: any = {
+      from: () => builder,
+      innerJoin: () => builder,
+      leftJoin: () => builder,
+      where: () => builder,
+      limit: () => Promise.resolve(rows),
+      orderBy: () => Promise.resolve(rows),
+    };
+    return builder;
+  };
+  return { select } as unknown as Database;
+}
+
+function makeClient(handlers: Record<string, (input: any) => unknown>) {
+  const send = vi.fn(async (command: unknown) => {
+    const name = commandName(command);
+    const handler = handlers[name];
+    if (!handler) throw new Error(`unexpected command ${name}`);
+    return handler((command as { input: any }).input);
+  });
+  return { send, client: { send } as unknown as DynamoDBDocumentClient };
+}
+
+describe("DynamoProjection.upsert", () => {
+  it("reads the link and BatchWrites the LINK item + domain-meta item", async () => {
+    const batches: any[] = [];
+    const { client } = makeClient({
+      BatchWriteCommand: (input) => {
+        batches.push(input);
+        return {};
+      },
+    });
+    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE);
+
+    await projection.upsert("link-1");
+
+    expect(batches).toHaveLength(1);
+    const requests = batches[0].RequestItems[TABLE];
+    // One LINK put + one domain-meta put.
+    expect(requests).toHaveLength(2);
+    const link = requests.find((r: any) => r.PutRequest.Item.SK.startsWith("s#")).PutRequest.Item;
+    const meta = requests.find((r: any) => r.PutRequest.Item.SK === "d#meta").PutRequest.Item;
+    expect(link.PK).toBe("d#snap.to");
+    expect(link.SK).toBe("s#one");
+    expect(link.linkId).toBe("link-1");
+    expect(link.clicks).toBe(7);
+    expect(meta.PK).toBe("d#snap.to");
+    expect(meta.id).toBe("dom-1");
+  });
+});
+
+describe("DynamoProjection.remove", () => {
+  it("queries the linkId GSI and DeleteItems the matching item(s)", async () => {
+    let queryInput: any;
+    const batches: any[] = [];
+    const { client } = makeClient({
+      QueryCommand: (input) => {
+        queryInput = input;
+        return { Items: [{ PK: "d#snap.to", SK: "s#one", linkId: "link-1" }] };
+      },
+      BatchWriteCommand: (input) => {
+        batches.push(input);
+        return {};
+      },
+    });
+    const projection = new DynamoProjection(makeDb([], []), client, TABLE);
+
+    await projection.remove("link-1");
+
+    expect(queryInput.IndexName).toBe("linkId-index");
+    expect(queryInput.ExpressionAttributeValues[":lid"]).toBe("link-1");
+    const requests = batches[0].RequestItems[TABLE];
+    expect(requests).toHaveLength(1);
+    expect(requests[0].DeleteRequest.Key).toEqual({ PK: "d#snap.to", SK: "s#one" });
+  });
+
+  it("is a no-op when nothing is projected for the id", async () => {
+    const { client, send } = makeClient({
+      QueryCommand: () => ({ Items: [] }),
+    });
+    const projection = new DynamoProjection(makeDb([], []), client, TABLE);
+    await projection.remove("gone");
+    // Only the query ran; no BatchWrite for an empty delete set.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DynamoProjection.apply (batching)", () => {
+  it("splits >25 upserts into multiple BatchWriteCommands of <=25", async () => {
+    const batchSizes: number[] = [];
+    const { client } = makeClient({
+      BatchWriteCommand: (input) => {
+        batchSizes.push(input.RequestItems[TABLE].length);
+        return {};
+      },
+    });
+    // 20 upserts -> 40 write requests (a LINK + a meta each) -> ceil(40/25) = 2
+    // batches, proving N links are O(N/25) round trips rather than N.
+    const N = 20;
+    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE);
+    const ops = Array.from({ length: N }, (_, i) => ({ linkId: `link-${i}`, operation: "upsert" }));
+
+    const results = await projection.apply(ops);
+
+    expect(results).toHaveLength(N);
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(batchSizes.length).toBe(2);
+    expect(Math.max(...batchSizes)).toBeLessThanOrEqual(25);
+    expect(batchSizes.reduce((a, b) => a + b, 0)).toBe(N * 2);
+  });
+
+  it("retries UnprocessedItems then succeeds", async () => {
+    let attempts = 0;
+    const { client } = makeClient({
+      BatchWriteCommand: (input) => {
+        attempts++;
+        if (attempts === 1) {
+          // Hand one request back as unprocessed on the first attempt.
+          return { UnprocessedItems: { [TABLE]: [input.RequestItems[TABLE][0]] } };
+        }
+        return {};
+      },
+    });
+    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE);
+
+    const results = await projection.apply([{ linkId: "link-1", operation: "upsert" }]);
+
+    expect(attempts).toBe(2);
+    expect(results[0]!.ok).toBe(true);
+  });
+
+  it("fails only the row whose Postgres read throws, not the batch", async () => {
+    const { client } = makeClient({
+      BatchWriteCommand: () => ({}),
+    });
+    // First op's link read returns a row; give the db a single link row then an
+    // empty result set so the second upsert resolves to no requests (link gone)
+    // — that is a success (marked processed), not a failure. To exercise a
+    // hard failure, make the client throw for a delete's query.
+    const failingClient = makeClient({
+      QueryCommand: () => {
+        throw new Error("query boom");
+      },
+      BatchWriteCommand: () => ({}),
+    });
+    const projection = new DynamoProjection(makeDb([linkRow()], []), failingClient.client, TABLE);
+
+    const results = await projection.apply([
+      { linkId: "link-1", operation: "upsert" },
+      { linkId: "link-2", operation: "delete" },
+    ]);
+
+    expect(results[0]!.ok).toBe(true);
+    expect(results[1]!.ok).toBe(false);
+    // Sanity: the healthy client fixture is unused here but proves the harness.
+    void client;
+  });
+});

--- a/apps/worker/src/jobs/dynamo-projection.test.ts
+++ b/apps/worker/src/jobs/dynamo-projection.test.ts
@@ -151,10 +151,33 @@ describe("DynamoProjection.apply (batching)", () => {
         return {};
       },
     });
-    // 20 upserts -> 40 write requests (a LINK + a meta each) -> ceil(40/25) = 2
-    // batches, proving N links are O(N/25) round trips rather than N.
-    const N = 20;
-    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE);
+    /* 30 DISTINCT links on ONE domain. Each contributes a distinct LINK put;
+       all 30 share the domain's single meta item, which apply() deduplicates to
+       ONE meta put. So 30 upserts -> 31 write requests (30 links + 1 shared
+       meta) -> ceil(31/25) = 2 batches, proving both the O(N/25) batching AND
+       that the shared meta is written once (before dedup this was 60 requests
+       carrying 30 IDENTICAL meta keys, which DynamoDB rejects wholesale — the
+       #288 failure). Each op resolves to a distinct link row (distinct slug) so
+       the fake mirrors reality rather than returning one identical row. */
+    const N = 30;
+    let call = 0;
+    const distinctDb = {
+      select: () => {
+        const which = call++;
+        // Even calls: the link-row query; odd calls: that link's rules (none).
+        const rows = which % 2 === 0 ? [linkRow({ id: `link-${which / 2}`, slug: `slug-${which / 2}` })] : [];
+        const builder: any = {
+          from: () => builder,
+          innerJoin: () => builder,
+          leftJoin: () => builder,
+          where: () => builder,
+          limit: () => Promise.resolve(rows),
+          orderBy: () => Promise.resolve(rows),
+        };
+        return builder;
+      },
+    } as unknown as Database;
+    const projection = new DynamoProjection(distinctDb, client, TABLE);
     const ops = Array.from({ length: N }, (_, i) => ({ linkId: `link-${i}`, operation: "upsert" }));
 
     const results = await projection.apply(ops);
@@ -163,7 +186,8 @@ describe("DynamoProjection.apply (batching)", () => {
     expect(results.every((r) => r.ok)).toBe(true);
     expect(batchSizes.length).toBe(2);
     expect(Math.max(...batchSizes)).toBeLessThanOrEqual(25);
-    expect(batchSizes.reduce((a, b) => a + b, 0)).toBe(N * 2);
+    // N distinct LINK puts + 1 deduplicated shared meta put.
+    expect(batchSizes.reduce((a, b) => a + b, 0)).toBe(N + 1);
   });
 
   it("retries UnprocessedItems then succeeds", async () => {
@@ -286,5 +310,139 @@ describe("DynamoProjection marshalling of optional/absent fields", () => {
        the transport sentinel. */
     await expect(projection.upsert("link-1")).rejects.toThrow();
     await expect(projection.upsert("link-1")).rejects.not.toThrow(TRANSPORT_REACHED);
+  });
+});
+
+describe("DynamoProjection.apply deduplicates the shared domain-meta item", () => {
+  /* Regression guard for the SECOND dynamo-smoke failure (#288): the
+     domain-meta item projected fine but every LINK item failed, and a scan
+     showed only the single d#meta item. The cause was NOT marshalling (the
+     removeUndefinedValues fix handled that) — it was that apply() coalesces the
+     LINK put AND the domain-meta put for EVERY upsert into one BatchWriteCommand
+     without dedup. Every link on a domain (re)writes the SAME meta key
+     (PK=d#<domain>, SK=d#meta), so N upserts on one domain put N identical meta
+     PutRequests in one command. DynamoDB rejects the whole request with
+     "Provided list of item keys contains duplicates", so all N links fail
+     together while the per-row upsert() path (one meta put per flush) never
+     did. These tests assert the batch now carries the meta key exactly ONCE and
+     never sends a duplicate key to DynamoDB. */
+
+  /** A link row on a fixed domain, so several of them share one meta item. */
+  function rowOnDomain(id: string, slug: string) {
+    return linkRow({ id, slug });
+  }
+
+  /** A chainable fake whose Nth select() (even calls) returns the link row for
+   *  the CURRENT op and whose odd calls return that op's rules. The link id and
+   *  slug are looked up by the eq() the writer passes, but the fake ignores the
+   *  predicate, so drive it from an ordered list of link rows: one per upsert. */
+  function makeMultiDb(linkRowsInOrder: any[][]): Database {
+    let call = 0;
+    const select = () => {
+      const which = call++;
+      const rows = which % 2 === 0 ? linkRowsInOrder[Math.floor(which / 2)] ?? [] : [];
+      const builder: any = {
+        from: () => builder,
+        innerJoin: () => builder,
+        leftJoin: () => builder,
+        where: () => builder,
+        limit: () => Promise.resolve(rows),
+        orderBy: () => Promise.resolve(rows),
+      };
+      return builder;
+    };
+    return { select } as unknown as Database;
+  }
+
+  it("writes the shared domain-meta item ONCE for many links on one domain, with no duplicate keys", async () => {
+    const sentBatches: any[][] = [];
+    const { client } = makeClient({
+      BatchWriteCommand: (input) => {
+        sentBatches.push(input.RequestItems[TABLE]);
+        return {};
+      },
+    });
+
+    const N = 5;
+    const rows = Array.from({ length: N }, (_, i) => [rowOnDomain(`link-${i}`, `slug-${i}`)]);
+    const projection = new DynamoProjection(makeMultiDb(rows), client, TABLE);
+    const ops = Array.from({ length: N }, (_, i) => ({ linkId: `link-${i}`, operation: "upsert" }));
+
+    const results = await projection.apply(ops);
+
+    // Every op succeeded.
+    expect(results).toHaveLength(N);
+    expect(results.every((r) => r.ok)).toBe(true);
+
+    const allRequests = sentBatches.flat();
+    // No BatchWriteCommand slice contains a duplicate key — the exact thing
+    // DynamoDB's ValidationException rejects.
+    for (const batch of sentBatches) {
+      const keys = batch.map((r: any) => {
+        const item = r.PutRequest ? r.PutRequest.Item : r.DeleteRequest.Key;
+        return `${item.PK}#${item.SK}`;
+      });
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+
+    // The domain-meta item is written exactly once, not once per link.
+    const metaPuts = allRequests.filter((r: any) => r.PutRequest?.Item.SK === "d#meta");
+    expect(metaPuts).toHaveLength(1);
+
+    // All N LINK items are present, each with a non-empty linkId / PK / SK.
+    const linkPuts = allRequests.filter((r: any) => r.PutRequest?.Item.SK.startsWith("s#"));
+    expect(linkPuts).toHaveLength(N);
+    for (const put of linkPuts) {
+      const item = put.PutRequest.Item;
+      expect(item.linkId).toBeTruthy();
+      expect(item.PK).toBeTruthy();
+      expect(item.SK).toBeTruthy();
+    }
+  });
+
+  it("marshals a representative failing-fixture LINK item (rule + partial utm + expiry/activation) without throwing", async () => {
+    /* The $RUN-geo / $RUN-utm / $RUN-expired / $RUN-scheduled fixtures combined:
+       a link WITH a routing rule (partial when), WITH a partial utm object,
+       WITH an expiry AND an activation Date, and a non-null linkId — run through
+       a REAL DocumentClient so the marshaller executes for real, and asserting
+       the request reaches the stubbed transport (i.e. marshalling succeeded and
+       the batch carried no duplicate keys). */
+    const richRow = linkRow({
+      id: "link-rich",
+      slug: "geo",
+      utm: { source: "newsletter", campaign: "spring" },
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      expiresTo: "https://example.com/moved",
+      activatesAt: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const richRules = [
+      {
+        rule: {
+          id: "r-in",
+          whenCountry: "IN",
+          whenDevice: undefined,
+          whenLanguage: undefined,
+          then: "https://example.in/store",
+          weight: undefined,
+        },
+      },
+    ];
+
+    const base = new DynamoDBClient({
+      region: "us-east-1",
+      endpoint: "http://localhost:8000",
+      credentials: { accessKeyId: "dummy", secretAccessKey: "dummy" },
+      requestHandler: {
+        handle: () => Promise.reject(new Error("transport-reached-sentinel")),
+      } as never,
+    });
+    const client = DynamoDBDocumentClient.from(base, {
+      marshallOptions: { removeUndefinedValues: true },
+    });
+    const projection = new DynamoProjection(makeDb([richRow], richRules), client, TABLE);
+
+    // Reaching the transport proves the item marshalled cleanly and the
+    // BatchWriteCommand was built (no duplicate-key rejection, no marshal throw).
+    await expect(projection.upsert("link-rich")).rejects.toThrow("transport-reached-sentinel");
   });
 });

--- a/apps/worker/src/jobs/dynamo-projection.ts
+++ b/apps/worker/src/jobs/dynamo-projection.ts
@@ -99,6 +99,17 @@ export class DynamoProjection implements ProjectionTarget {
     for (const op of ops) {
       const index = results.length;
       try {
+        /* NOTE: resolution is per-op and sequential, so a batch of N deletes
+           issues N GSI QueryCommands here (one per linkId) BEFORE any writes
+           are coalesced — the read side is O(N) round trips even though the
+           writes below are batched to O(N / 25). This is a deliberate
+           trade-off: deletes are rare relative to upserts (a delete is a
+           user removing a link, an upsert is every edit and every new link),
+           so the read fan-out is not worth batching with a BatchGetItem across
+           the linkId GSI (which would also need its own <=100-key slicing and
+           per-key result stitching). Revisit only if bulk deletes become a hot
+           path. Upserts take the same per-op read but there is no cheaper bulk
+           form for them either (each reads a different link's full row set). */
         const requests =
           op.operation === "delete"
             ? await this.buildDeleteRequests(op.linkId)

--- a/apps/worker/src/jobs/dynamo-projection.ts
+++ b/apps/worker/src/jobs/dynamo-projection.ts
@@ -1,0 +1,271 @@
+import {
+  domains,
+  eq,
+  linkCounters,
+  links,
+  routingRules,
+  sql,
+  toDomainItem,
+  toLinkItem,
+  LINK_ID_ATTR,
+  LINK_ID_GSI,
+  type Database,
+  type DomainItem,
+  type LinkItem,
+  type ProjectedDomain,
+  type ProjectedLink,
+} from "@snapurl/database";
+import type { RoutingRule } from "@snapurl/contract";
+import {
+  BatchWriteCommand,
+  QueryCommand,
+  type DynamoDBDocumentClient,
+} from "@aws-sdk/lib-dynamodb";
+import type { ProjectionOp, ProjectionResult, ProjectionTarget } from "./outbox.js";
+
+/* ============================================================
+   DynamoProjection — the real projection writer (AWS profile).
+
+   Replaces NoProjection under LINK_PROJECTION=dynamo. It reads a
+   link's config from Postgres (the link row still exists for an
+   upsert) and writes the LINK item + the domain-meta item into the
+   DynamoDB projection the redirect's DynamoLinkResolver reads.
+
+   Batching (why drainOutbox hands it a whole claimed batch): a
+   100-link bulk import must not be 100 sequential round trips. The
+   optional apply() method takes the entire claimed batch, buffers
+   all the puts/deletes, and flushes them in BatchWriteCommand
+   requests of at most 25 items each — so N links cost O(N / 25 * 2)
+   round trips (each link contributes a LINK put and a domain-meta
+   put), not O(N). UnprocessedItems are retried with bounded
+   backoff. The per-row upsert/remove methods remain for the
+   fallback path (a target without apply(), e.g. NoProjection), so
+   nothing about the default no-op behaviour changes.
+
+   The delete-key gap: the outbox row for a delete carries only the
+   link id, and the API removed the link row in the same
+   transaction, so (domain, slug) cannot be read from Postgres. The
+   projection table therefore has a GSI on the top-level `linkId`
+   attribute (LINK_ID_GSI); remove(linkId) queries it and deletes
+   the matching LINK item(s) by their real PK/SK.
+   ============================================================ */
+
+/** DynamoDB caps a BatchWriteItem at 25 requests. */
+const BATCH_LIMIT = 25;
+
+/** Bounded retries for UnprocessedItems returned by BatchWriteItem. */
+const MAX_BATCH_ATTEMPTS = 5;
+
+/** A single put or delete request destined for a BatchWriteCommand. */
+type WriteRequest =
+  | { PutRequest: { Item: LinkItem | DomainItem } }
+  | { DeleteRequest: { Key: { PK: string; SK: string } } };
+
+export class DynamoProjection implements ProjectionTarget {
+  constructor(
+    private readonly db: Database,
+    private readonly client: DynamoDBDocumentClient,
+    private readonly table: string,
+  ) {}
+
+  /* ---- per-row fallback (used when drainOutbox does not batch) ---- */
+
+  async upsert(linkId: string): Promise<void> {
+    const requests = await this.buildUpsertRequests(linkId);
+    await this.flush(requests);
+  }
+
+  async remove(linkId: string): Promise<void> {
+    const requests = await this.buildDeleteRequests(linkId);
+    await this.flush(requests);
+  }
+
+  /* ---- batched path (drainOutbox hands the whole claimed batch here) ----
+
+     Each op is resolved to its write requests INDEPENDENTLY and marked
+     per-op, so drainOutbox keeps its per-row processed_at / attempts
+     bookkeeping: an op whose requests all flush is `ok: true`; an op whose
+     resolution or flush throws is `ok: false` with the error, and only that
+     row bumps attempts. The DynamoDB writes across all successfully-resolved
+     ops are coalesced into <=25-item BatchWriteCommands so N links are
+     O(N / 25) round trips, not N. */
+  async apply(ops: ProjectionOp[]): Promise<ProjectionResult[]> {
+    const results: ProjectionResult[] = [];
+    const pending: WriteRequest[] = [];
+    /* Which result indices a given write request belongs to, so a flush
+       failure can be attributed back to the exact ops that were in it. */
+    const owners: number[][] = [];
+
+    for (const op of ops) {
+      const index = results.length;
+      try {
+        const requests =
+          op.operation === "delete"
+            ? await this.buildDeleteRequests(op.linkId)
+            : await this.buildUpsertRequests(op.linkId);
+        results.push({ linkId: op.linkId, ok: true });
+        for (const request of requests) {
+          pending.push(request);
+          owners.push([index]);
+        }
+      } catch (err) {
+        // Resolution failed (e.g. Postgres read error): this row alone fails.
+        results.push({ linkId: op.linkId, ok: false, error: err });
+      }
+    }
+
+    /* Flush the coalesced requests in <=25-item batches. A batch that fails
+       after its bounded retries fails every op that contributed a request to
+       it — those rows are retried on the next drain, exactly as the per-row
+       path would have. */
+    for (let start = 0; start < pending.length; start += BATCH_LIMIT) {
+      const slice = pending.slice(start, start + BATCH_LIMIT);
+      const sliceOwners = owners.slice(start, start + BATCH_LIMIT);
+      try {
+        await this.flush(slice);
+      } catch (err) {
+        for (const ownerList of sliceOwners) {
+          for (const index of ownerList) {
+            results[index] = { linkId: results[index]!.linkId, ok: false, error: err };
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /* ---- request builders ---- */
+
+  /** Read the link (+ counter, rules, domain) from Postgres and build the
+   *  LINK put + the domain-meta put. Returns [] if the link no longer exists
+   *  (a delete that raced ahead of this upsert) so the row is marked processed
+   *  rather than retried forever. */
+  private async buildUpsertRequests(linkId: string): Promise<WriteRequest[]> {
+    const [[row], rules] = await Promise.all([
+      this.db
+        .select({
+          link: links,
+          domain: domains.domain,
+          domainId: domains.id,
+          rootRedirect: domains.rootRedirect,
+          notFoundRedirect: domains.notFoundRedirect,
+          clicks: sql<number>`coalesce(${linkCounters.clicks}, 0)`,
+        })
+        .from(links)
+        .innerJoin(domains, eq(links.domainId, domains.id))
+        .leftJoin(linkCounters, eq(linkCounters.linkId, links.id))
+        .where(eq(links.id, linkId))
+        .limit(1),
+      this.db
+        .select({ rule: routingRules })
+        .from(routingRules)
+        .where(eq(routingRules.linkId, linkId))
+        .orderBy(routingRules.position),
+    ]);
+
+    if (!row) return [];
+
+    const projectedLink: ProjectedLink = {
+      id: row.link.id,
+      workspaceId: row.link.workspaceId,
+      destination: row.link.destination,
+      redirectType: row.link.redirectType as ProjectedLink["redirectType"],
+      rules: rules.map(({ rule: r }) => ({
+        id: r.id,
+        when: {
+          country: r.whenCountry,
+          device: r.whenDevice as RoutingRule["when"]["device"],
+          language: r.whenLanguage,
+        },
+        then: r.then,
+        weight: r.weight,
+      })),
+      expiresAt: row.link.expiresAt,
+      expiresTo: row.link.expiresTo,
+      activatesAt: row.link.activatesAt,
+      scheduledTo: row.link.scheduledTo,
+      clickLimit: row.link.clickLimit,
+      /* Point-in-time click count, same source and semantics as the Postgres
+         resolver — see the note in @snapurl/database's toLinkItem. */
+      clicks: row.clicks,
+      hasPassword: Boolean(row.link.passwordHash),
+      forwardQuery: row.link.forwardQuery,
+      deepLink: row.link.deepLink,
+      hideReferrer: row.link.hideReferrer,
+      publicPreview: row.link.publicPreview,
+      archived: Boolean(row.link.archivedAt),
+      safeBrowsingStatus: row.link.safeBrowsingStatus,
+      utm: row.link.utm,
+    };
+
+    const projectedDomain: ProjectedDomain = {
+      id: row.domainId,
+      rootRedirect: row.rootRedirect,
+      notFoundRedirect: row.notFoundRedirect,
+    };
+
+    const linkItem = toLinkItem(projectedLink, row.domain, row.link.slug);
+    const domainItem = toDomainItem(row.domain, projectedDomain);
+
+    /* The domain-meta item is (re)written alongside every link upsert for that
+       domain — the simplest way to keep resolveDomain() current without a
+       separate outbox stream, and cheap (one extra put per upsert). */
+    return [{ PutRequest: { Item: linkItem } }, { PutRequest: { Item: domainItem } }];
+  }
+
+  /** Query the GSI for the LINK item(s) with this link id and build deletes.
+   *  Returns [] if nothing is projected (already gone) so the row is marked
+   *  processed. The domain-meta item is intentionally left in place: it is
+   *  keyed by domain, shared by every link on it, and harmless when stale. */
+  private async buildDeleteRequests(linkId: string): Promise<WriteRequest[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.table,
+        IndexName: LINK_ID_GSI,
+        KeyConditionExpression: "#lid = :lid",
+        ExpressionAttributeNames: { "#lid": LINK_ID_ATTR },
+        ExpressionAttributeValues: { ":lid": linkId },
+      }),
+    );
+    const items = (result.Items ?? []) as LinkItem[];
+    return items.map((item) => ({
+      DeleteRequest: { Key: { PK: item.PK, SK: item.SK } },
+    }));
+  }
+
+  /* ---- flush ---- */
+
+  /** Write a set of requests (already <=25 when called from apply(), split
+   *  here when called from the per-row fallback) via BatchWriteCommand,
+   *  retrying UnprocessedItems with bounded exponential backoff. */
+  private async flush(requests: WriteRequest[]): Promise<void> {
+    for (let start = 0; start < requests.length; start += BATCH_LIMIT) {
+      await this.flushBatch(requests.slice(start, start + BATCH_LIMIT));
+    }
+  }
+
+  private async flushBatch(batch: WriteRequest[]): Promise<void> {
+    if (batch.length === 0) return;
+    let unprocessed: WriteRequest[] = batch;
+
+    for (let attempt = 0; attempt < MAX_BATCH_ATTEMPTS; attempt++) {
+      const result = await this.client.send(
+        new BatchWriteCommand({ RequestItems: { [this.table]: unprocessed } }),
+      );
+      const remaining = (result.UnprocessedItems?.[this.table] ?? []) as WriteRequest[];
+      if (remaining.length === 0) return;
+      unprocessed = remaining;
+      // Bounded backoff so a throttled table backs off rather than hot-loops.
+      await sleep(2 ** attempt * 50);
+    }
+
+    throw new Error(
+      `dynamodb: ${unprocessed.length} projection item(s) still unprocessed after ${MAX_BATCH_ATTEMPTS} BatchWrite attempts`,
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/worker/src/jobs/dynamo-projection.ts
+++ b/apps/worker/src/jobs/dynamo-projection.ts
@@ -61,11 +61,34 @@ type WriteRequest =
   | { PutRequest: { Item: LinkItem | DomainItem } }
   | { DeleteRequest: { Key: { PK: string; SK: string } } };
 
+/** The minimum a logger must offer so the writer can surface the ACTUAL
+ *  DynamoDB error when a batch fails. drainOutbox only records the error's
+ *  stringified form in projection_outbox.last_error and counts the failure;
+ *  the error's name/message never reached a log line, so a projection that
+ *  wrote nothing looked silent even at LOG_LEVEL=debug. A pino logger satisfies
+ *  this; it is optional so the per-row unit tests can omit it. */
+export interface ProjectionLogger {
+  error(obj: Record<string, unknown>, msg: string): void;
+}
+
+/** The DynamoDB Key that identifies an item, used to deduplicate coalesced
+ *  write requests: two PutRequests (or a Put and a Delete) with the same
+ *  {PK, SK} in one BatchWriteCommand make DynamoDB reject the WHOLE request
+ *  with "Provided list of item keys contains duplicates". */
+function requestKey(request: WriteRequest): string {
+  const key = "PutRequest" in request ? request.PutRequest.Item : request.DeleteRequest.Key;
+  return `${key.PK}\u0000${key.SK}`;
+}
+
 export class DynamoProjection implements ProjectionTarget {
   constructor(
     private readonly db: Database,
     private readonly client: DynamoDBDocumentClient,
     private readonly table: string,
+    /** Optional: when present, a resolution or flush failure logs the ACTUAL
+     *  error (name + message) at error level so a failed projection is never
+     *  silent again. */
+    private readonly log?: ProjectionLogger,
   ) {}
 
   /* ---- per-row fallback (used when drainOutbox does not batch) ---- */
@@ -91,10 +114,22 @@ export class DynamoProjection implements ProjectionTarget {
      O(N / 25) round trips, not N. */
   async apply(ops: ProjectionOp[]): Promise<ProjectionResult[]> {
     const results: ProjectionResult[] = [];
-    const pending: WriteRequest[] = [];
-    /* Which result indices a given write request belongs to, so a flush
-       failure can be attributed back to the exact ops that were in it. */
-    const owners: number[][] = [];
+    /* The coalesced write requests, DEDUPLICATED by DynamoDB Key. Every link
+       upsert on a domain (re)writes that domain's single meta item, so a batch
+       of N upserts on one domain produces N IDENTICAL domain-meta PutRequests.
+       DynamoDB's BatchWriteItem rejects the ENTIRE request with a
+       ValidationException ("Provided list of item keys contains duplicates") if
+       any two operations target the same key — so without this dedup one
+       domain's N links all fail together, which is exactly the
+       "domain-meta succeeds, every LINK item fails" the smoke job hit: the
+       per-row upsert() path only ever has one meta put per flush, but the
+       batched path coalesced N of them into one command.
+
+       Deduping keeps the LAST request written for a key (upserts are
+       idempotent, so any of the identical meta puts is equivalent) and unions
+       the owning result-indices, so a flush failure still fails every op that
+       contributed that key. */
+    const byKey = new Map<string, { request: WriteRequest; owners: Set<number> }>();
 
     for (const op of ops) {
       const index = results.length;
@@ -116,25 +151,51 @@ export class DynamoProjection implements ProjectionTarget {
             : await this.buildUpsertRequests(op.linkId);
         results.push({ linkId: op.linkId, ok: true });
         for (const request of requests) {
-          pending.push(request);
-          owners.push([index]);
+          const key = requestKey(request);
+          const existing = byKey.get(key);
+          if (existing) {
+            existing.request = request;
+            existing.owners.add(index);
+          } else {
+            byKey.set(key, { request, owners: new Set([index]) });
+          }
         }
       } catch (err) {
         // Resolution failed (e.g. Postgres read error): this row alone fails.
+        this.log?.error(
+          { err: serialiseError(err), linkId: op.linkId, operation: op.operation },
+          "projection resolve failed",
+        );
         results.push({ linkId: op.linkId, ok: false, error: err });
       }
     }
 
-    /* Flush the coalesced requests in <=25-item batches. A batch that fails
-       after its bounded retries fails every op that contributed a request to
-       it — those rows are retried on the next drain, exactly as the per-row
-       path would have. */
+    const pending = [...byKey.values()].map((entry) => entry.request);
+    const owners = [...byKey.values()].map((entry) => [...entry.owners]);
+
+    /* Flush the coalesced (and deduped) requests in <=25-item batches. A batch
+       that fails after its bounded retries fails every op that contributed a
+       request to it — those rows are retried on the next drain, exactly as the
+       per-row path would have. */
     for (let start = 0; start < pending.length; start += BATCH_LIMIT) {
       const slice = pending.slice(start, start + BATCH_LIMIT);
       const sliceOwners = owners.slice(start, start + BATCH_LIMIT);
       try {
         await this.flush(slice);
       } catch (err) {
+        /* Surface the ACTUAL DynamoDB error (name + message) at error level.
+           drainOutbox only stores String(err) in last_error and counts the
+           failure, so before this the ValidationException text never reached a
+           log line and the empty projection looked silent even at debug. */
+        this.log?.error(
+          {
+            err: serialiseError(err),
+            table: this.table,
+            items: slice.length,
+            linkIds: [...new Set(sliceOwners.flat().map((i) => results[i]!.linkId))],
+          },
+          "projection batch write failed",
+        );
         for (const ownerList of sliceOwners) {
           for (const index of ownerList) {
             results[index] = { linkId: results[index]!.linkId, ok: false, error: err };
@@ -279,4 +340,17 @@ export class DynamoProjection implements ProjectionTarget {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Reduce an unknown thrown value to the fields worth logging. A DynamoDB
+ *  ValidationException carries its diagnosis in `name` + `message` (e.g.
+ *  "ValidationException: Provided list of item keys contains duplicates"); a
+ *  plain object logged as `{ err }` under pino can serialise to `{}` and hide
+ *  exactly that text, which is how the batched projection failure stayed
+ *  invisible. Pull the useful fields out explicitly. */
+function serialiseError(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message };
+  }
+  return { value: String(err) };
 }

--- a/apps/worker/src/jobs/outbox.ts
+++ b/apps/worker/src/jobs/outbox.ts
@@ -47,12 +47,37 @@ import { sql, type Database } from "@snapurl/database";
    claimed again — it is a real alert that the edge is stale.
    ============================================================ */
 
+/** One claimed outbox row, reduced to what a projection target acts on. */
+export interface ProjectionOp {
+  linkId: string;
+  operation: string;
+}
+
+/** The per-op outcome of a batched apply(): the batch method must report each
+ *  op independently so drainOutbox keeps its per-row processed_at / attempts
+ *  bookkeeping — one poisonous row must not fail the whole batch's rows. */
+export interface ProjectionResult {
+  linkId: string;
+  ok: boolean;
+  error?: unknown;
+}
+
 export interface ProjectionTarget {
   upsert(linkId: string): Promise<void>;
   remove(linkId: string): Promise<void>;
+  /* Optional batch entry point. When a target implements it, drainOutbox hands
+     it the whole claimed batch so the target can coalesce its writes (e.g. a
+     DynamoDB projection batches into <=25-item BatchWrites — a 100-link import
+     is O(N/25) round trips, not 100). A target without it (NoProjection) keeps
+     the per-row upsert/remove path, so the default no-op behaviour is
+     unchanged. The result array MUST carry one entry per input op, in order. */
+  apply?(ops: ProjectionOp[]): Promise<ProjectionResult[]>;
 }
 
-/** The no-op target: the redirect reads Postgres, so there is nothing to project. */
+/** The no-op target: the redirect reads Postgres, so there is nothing to
+ *  project. Deliberately does NOT implement apply(), so drainOutbox uses the
+ *  per-row path and its behaviour is byte-for-byte what it was before batching
+ *  existed. This is the default under LINK_PROJECTION=none. */
 export class NoProjection implements ProjectionTarget {
   async upsert(): Promise<void> {}
   async remove(): Promise<void> {}
@@ -92,30 +117,64 @@ export async function drainOutbox(
   let processed = 0;
   let failed = 0;
 
-  /* Processed outside any long transaction: target.upsert/remove may be a
+  /* Mark one claimed row processed (success) or bump its attempts (failure).
+     Kept as one helper so the per-row path and the batched path record the
+     exact same bookkeeping.
+
+     Success: leaving claimed_at set is fine — the claim filters on
+     processed_at is null, and pruneOutbox only looks at processed_at.
+
+     Failure: attempts are recorded so a permanently poisonous row stops being
+     retried forever and starts being visible instead. A row at MAX_ATTEMPTS is
+     a real alert: the edge is serving stale config. claimed_at is cleared so
+     the row is retryable on the next drain rather than waiting out the lease. */
+  const markProcessed = async (id: string) => {
+    await db.execute(sql`update projection_outbox set processed_at = now() where id = ${id}::uuid`);
+    processed++;
+  };
+  const markFailed = async (id: string, err: unknown) => {
+    failed++;
+    await db.execute(sql`
+      update projection_outbox
+      set attempts = attempts + 1, last_error = ${String(err).slice(0, 500)}, claimed_at = null
+      where id = ${id}::uuid
+    `);
+  };
+
+  /* Processed outside any long transaction: the projection write may be a
      DynamoDB network call, and each row is marked on its own so a slow or
      failing dependency never holds locks across I/O. */
+  if (target.apply) {
+    /* Batched path: hand the whole claimed batch to the target so it can
+       coalesce its writes (a DynamoDB target batches into <=25-item
+       BatchWrites). The result carries one entry per op, in order, so each
+       row's processed_at / attempts bookkeeping is still recorded per row —
+       one poisonous row fails alone, exactly as the per-row path does. */
+    let results: ProjectionResult[];
+    try {
+      results = await target.apply(rows.map((r) => ({ linkId: r.link_id, operation: r.operation })));
+    } catch (err) {
+      /* apply() itself threw (not a per-op failure): fail every claimed row so
+         the whole batch is retried on the next drain. */
+      for (const row of rows) await markFailed(row.id, err);
+      return { processed, failed };
+    }
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i]!;
+      const result = results[i];
+      if (result && result.ok) await markProcessed(row.id);
+      else await markFailed(row.id, result?.error ?? new Error("projection apply() returned no result for row"));
+    }
+    return { processed, failed };
+  }
+
   for (const row of rows) {
     try {
       if (row.operation === "delete") await target.remove(row.link_id);
       else await target.upsert(row.link_id);
-
-      /* Success. Leaving claimed_at set is fine: the claim filters on
-         processed_at is null, and pruneOutbox only looks at processed_at. */
-      await db.execute(sql`update projection_outbox set processed_at = now() where id = ${row.id}::uuid`);
-      processed++;
+      await markProcessed(row.id);
     } catch (err) {
-      /* Attempts are recorded so a permanently poisonous row stops being
-         retried forever and starts being visible instead. A row at
-         MAX_ATTEMPTS is a real alert: the edge is serving stale config.
-         claimed_at is cleared so the row is retryable on the next drain
-         rather than waiting out the lease. */
-      failed++;
-      await db.execute(sql`
-        update projection_outbox
-        set attempts = attempts + 1, last_error = ${String(err).slice(0, 500)}, claimed_at = null
-        where id = ${row.id}::uuid
-      `);
+      await markFailed(row.id, err);
     }
   }
 

--- a/apps/worker/src/lambda.test.ts
+++ b/apps/worker/src/lambda.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { serializeClickEvent, type ClickEvent } from "@snapurl/database";
+
+/* The worker's SQS event source mapping path (#288 3b).
+
+   No live SQS or Postgres: initDb() is mocked to hand back a dummy db, and
+   insertClickEvents is spied so the test asserts which ClickEvents were drained
+   into click_events and can make a chosen record's insert throw. This is the
+   concrete "clicks survive freeze/thaw, asserted not assumed" proof on the
+   consumer side — the redirect awaits the SQS send (see sqs-click-sink.test.ts)
+   and the worker drains the queue into click_events here, with one bad message
+   isolated to batchItemFailures. */
+
+const insertClickEvents = vi.fn(async () => {});
+
+vi.mock("@snapurl/database", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@snapurl/database")>();
+  return { ...actual, insertClickEvents: (...args: unknown[]) => insertClickEvents(...args) };
+});
+
+const fakeDb = { __fake: true };
+vi.mock("./main.js", () => ({
+  initDb: vi.fn(async () => ({ db: fakeDb, close: async () => {} })),
+  runFrequent: vi.fn(),
+  runMaintenance: vi.fn(),
+}));
+
+// Imported after the mocks so the handler closes over them.
+const { handler } = await import("./lambda.js");
+
+function clickEvent(overrides: Partial<ClickEvent> = {}): ClickEvent {
+  return {
+    linkId: "11111111-1111-1111-1111-111111111111",
+    workspaceId: "22222222-2222-2222-2222-222222222222",
+    occurredAt: new Date("2025-01-02T03:04:05.678Z"),
+    visitorHash: "abcdef0123456789abcdef0123456789",
+    country: "IN",
+    city: "Pune",
+    device: "android",
+    browser: "Chrome",
+    os: "Android",
+    referrerHost: "example.com",
+    isQr: false,
+    isBot: false,
+    blockedReason: null,
+    matchedRuleId: null,
+    variant: null,
+    ...overrides,
+  };
+}
+
+function record(messageId: string, event: ClickEvent) {
+  return { messageId, body: serializeClickEvent(event) };
+}
+
+describe("worker SQS click consumer", () => {
+  beforeEach(() => {
+    insertClickEvents.mockReset();
+    insertClickEvents.mockResolvedValue(undefined);
+  });
+
+  it("drains every record in the batch into click_events and reports no failures", async () => {
+    const events = [
+      clickEvent({ linkId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }),
+      clickEvent({ linkId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" }),
+      clickEvent({ linkId: "cccccccc-cccc-cccc-cccc-cccccccccccc" }),
+    ];
+    const result = await handler({
+      Records: [record("m1", events[0]), record("m2", events[1]), record("m3", events[2])],
+    });
+
+    expect(result).toEqual({ batchItemFailures: [] });
+    expect(insertClickEvents).toHaveBeenCalledTimes(3);
+    // Each ClickEvent was revived (occurredAt is a Date again) and inserted.
+    const inserted = insertClickEvents.mock.calls.map((c: any[]) => c[1][0]);
+    expect(inserted).toEqual(events);
+    expect(inserted[0].occurredAt).toBeInstanceOf(Date);
+  });
+
+  it("isolates a single bad message: only its id is in batchItemFailures, the rest still insert", async () => {
+    // The second record's insert throws (a row the database rejects); the other
+    // two must still land and only m2 must be redriven.
+    insertClickEvents.mockImplementation(async (_db: unknown, events: ClickEvent[]) => {
+      if (events[0].linkId === "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb") {
+        throw new Error("insert rejected");
+      }
+    });
+
+    const result = await handler({
+      Records: [
+        record("m1", clickEvent({ linkId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" })),
+        record("m2", clickEvent({ linkId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" })),
+        record("m3", clickEvent({ linkId: "cccccccc-cccc-cccc-cccc-cccccccccccc" })),
+      ],
+    });
+
+    expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "m2" }] });
+    // All three were attempted — one bad message does not short-circuit the batch.
+    expect(insertClickEvents).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports an unparseable body as a failure without throwing", async () => {
+    const result = await handler({
+      Records: [{ messageId: "bad", body: "not json" }],
+    });
+    expect(result).toEqual({ batchItemFailures: [{ itemIdentifier: "bad" }] });
+    expect(insertClickEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -1,4 +1,4 @@
-import { resolveDatabaseUrl, runMigrations } from "@snapurl/database";
+import { deserializeClickEvent, insertClickEvents, resolveDatabaseUrl, runMigrations, type Database } from "@snapurl/database";
 import { initDb, runFrequent, runMaintenance } from "./main.js";
 
 /* The worker as a Lambda, dispatched by a `task` discriminator.
@@ -36,13 +36,70 @@ import { initDb, runFrequent, runMaintenance } from "./main.js";
  * migrations should run when someone decides to run them. A scheduled
  * migration is a schema change nobody was watching — which is why migrate is
  * on no schedule at all and only ever runs on a manual invocation.
+ *
+ * The SECOND invocation path (#288 3b): an SQS event source mapping. On the
+ * AWS profile the redirect sends each click to an SQS queue (SqsClickSink), and
+ * the Lambda service polls that queue OUTSIDE the VPC and invokes this function
+ * with an event shaped { Records: [{ messageId, body, ... }] } — no `task`. We
+ * detect that shape before the task branches and drain the batch into
+ * click_events, the same table PostgresClickSink writes, using the shared
+ * insertClickEvents. Failed records are reported back via batchItemFailures so
+ * the mapping (configured with reportBatchItemFailures) redrives only those,
+ * not the whole batch. The rollups then fold these rows as usual.
  */
 export interface WorkerEvent {
   task?: "frequent" | "maintenance" | "rollup" | "migrate";
 }
 
-export const handler = async (event: WorkerEvent = {}) => {
-  if (event.task === "migrate") {
+/** One record as an SQS event source mapping delivers it. Only the two fields
+ *  the consumer needs are typed; the mapping supplies many more. */
+interface SqsRecord {
+  messageId: string;
+  body: string;
+}
+
+/** The event an SQS event source mapping invokes the Lambda with. */
+interface SqsEvent {
+  Records: SqsRecord[];
+}
+
+/** The partial-batch-failure response the mapping expects when
+ *  reportBatchItemFailures is on: the messageId of every record that must be
+ *  retried, and only those. An empty list means the whole batch succeeded. */
+interface SqsBatchResponse {
+  batchItemFailures: Array<{ itemIdentifier: string }>;
+}
+
+/** Drain a batch of click messages into click_events with partial-batch-failure
+ *  reporting. Each record is inserted independently so one poison message (an
+ *  unparseable body, a row the database rejects) is the only one redriven — the
+ *  rest still land. Returns the messageIds that failed. */
+async function drainClickBatch(db: Database, records: SqsRecord[]): Promise<SqsBatchResponse> {
+  const batchItemFailures: Array<{ itemIdentifier: string }> = [];
+  for (const record of records) {
+    try {
+      const event = deserializeClickEvent(record.body);
+      await insertClickEvents(db, [event]);
+    } catch {
+      /* Report this one for redrive and keep going. The mapping retries only
+         the reported ids up to the queue's maxReceiveCount, after which they
+         land in the DLQ — one bad message never fails the batch. */
+      batchItemFailures.push({ itemIdentifier: record.messageId });
+    }
+  }
+  return { batchItemFailures };
+}
+
+export const handler = async (event: WorkerEvent | SqsEvent = {}) => {
+  /* The SQS event source mapping path: detected by the Records array BEFORE the
+     task discriminator, because an SQS event carries no `task`. */
+  if (Array.isArray((event as SqsEvent).Records)) {
+    const { db } = await initDb();
+    return drainClickBatch(db, (event as SqsEvent).Records);
+  }
+
+  const workerEvent = event as WorkerEvent;
+  if (workerEvent.task === "migrate") {
     /* Resolve via the shared resolver so migrations work under the ARN path
        too: with DATABASE_SECRET_ARN set this fetches the credentials from
        Secrets Manager; with no ARN it returns process.env.DATABASE_URL
@@ -62,7 +119,7 @@ export const handler = async (event: WorkerEvent = {}) => {
      connection is made. Shared by both the frequent and maintenance branches. */
   const { db } = await initDb();
 
-  if (event.task === "maintenance") {
+  if (workerEvent.task === "maintenance") {
     const maintenance = await runMaintenance(db);
     return { task: "maintenance", maintenance };
   }

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -91,13 +91,27 @@ export async function close(): Promise<void> {
 const LINK_PROJECTION = process.env.LINK_PROJECTION ?? "none";
 let projectionTarget: ProjectionTarget | undefined;
 
+/* An OPTIONAL endpoint override for the DynamoDB client. Unset in production
+   (the client resolves the real regional endpoint); set to something like
+   http://localhost:8000 in CI so the writer targets a dynamodb-local container.
+   AWS_ENDPOINT_URL_DYNAMODB takes precedence over the service-agnostic
+   AWS_ENDPOINT_URL, matching the SDK's own precedence, and both being unset
+   returns undefined so `endpoint` is simply omitted — a genuine no-op. */
+function dynamoEndpoint(): string | undefined {
+  return process.env.AWS_ENDPOINT_URL_DYNAMODB ?? process.env.AWS_ENDPOINT_URL ?? undefined;
+}
+
 function projectionFor(database: Database): ProjectionTarget {
   if (!projectionTarget) {
     if (LINK_PROJECTION === "dynamo") {
       const table = process.env.LINK_PROJECTION_TABLE;
       if (!table) throw new Error("LINK_PROJECTION=dynamo requires LINK_PROJECTION_TABLE to be set.");
+      /* endpoint is left undefined in production so the SDK talks to the real
+         regional DynamoDB endpoint. It is set ONLY when AWS_ENDPOINT_URL_DYNAMODB
+         (or the generic AWS_ENDPOINT_URL) is present, which is how CI points the
+         writer at a dynamodb-local container — a strict no-op when unset. */
       const client = DynamoDBDocumentClient.from(
-        new DynamoDBClient({ region: process.env.AWS_REGION }),
+        new DynamoDBClient({ region: process.env.AWS_REGION, endpoint: dynamoEndpoint() }),
       );
       projectionTarget = new DynamoProjection(database, client, table);
     } else {

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -126,7 +126,13 @@ function projectionFor(database: Database): ProjectionTarget {
         new DynamoDBClient({ region: process.env.AWS_REGION, endpoint: dynamoEndpoint() }),
         { marshallOptions: { removeUndefinedValues: true } },
       );
-      projectionTarget = new DynamoProjection(database, client, table);
+      /* Pass the worker's logger so a projection resolve/write failure surfaces
+         the ACTUAL error (DynamoDB ValidationException name + message) at error
+         level. drainOutbox only stores String(err) in projection_outbox
+         .last_error and counts the failure, so before this the real cause never
+         reached a log line — a projection that wrote nothing looked silent even
+         at LOG_LEVEL=debug. */
+      projectionTarget = new DynamoProjection(database, client, table, log);
     } else {
       projectionTarget = new NoProjection();
     }

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,7 +1,10 @@
 import pino from "pino";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { createDatabase, resolveDatabaseUrl, type Database } from "@snapurl/database";
 import { ensureClickPartitions, pruneRetention, rollupClicks, rotateSalts } from "./jobs/rollup.js";
-import { NoProjection, drainOutbox, pruneOutbox, stuckProjections, sweepExpired } from "./jobs/outbox.js";
+import { NoProjection, drainOutbox, pruneOutbox, stuckProjections, sweepExpired, type ProjectionTarget } from "./jobs/outbox.js";
+import { DynamoProjection } from "./jobs/dynamo-projection.js";
 import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
 
 /* ============================================================
@@ -72,12 +75,42 @@ export async function close(): Promise<void> {
   if (dbHandle) await dbHandle.close();
 }
 
-const projection = new NoProjection();
+/* Which projection target the outbox drains into, keyed on LINK_PROJECTION:
+
+     'dynamo' -> DynamoProjection, writing the DynamoDB projection the AWS
+                 redirect resolves against (LINK_PROJECTION_TABLE names the
+                 table; region from the standard AWS_REGION env).
+     anything else / unset -> NoProjection, the no-op default. The single-node
+                 and Kubernetes workers keep using it — the redirect reads
+                 Postgres directly there, so there is nothing to project.
+
+   Built once and reused across warm Lambda invocations, mirroring the memoised
+   db handle. The DynamoDB path needs the db handle to read a link's config for
+   an upsert, so the target is resolved lazily against the passed database
+   rather than at import (which would open no Postgres connection either way). */
+const LINK_PROJECTION = process.env.LINK_PROJECTION ?? "none";
+let projectionTarget: ProjectionTarget | undefined;
+
+function projectionFor(database: Database): ProjectionTarget {
+  if (!projectionTarget) {
+    if (LINK_PROJECTION === "dynamo") {
+      const table = process.env.LINK_PROJECTION_TABLE;
+      if (!table) throw new Error("LINK_PROJECTION=dynamo requires LINK_PROJECTION_TABLE to be set.");
+      const client = DynamoDBDocumentClient.from(
+        new DynamoDBClient({ region: process.env.AWS_REGION }),
+      );
+      projectionTarget = new DynamoProjection(database, client, table);
+    } else {
+      projectionTarget = new NoProjection();
+    }
+  }
+  return projectionTarget;
+}
 
 /** Runs often: this is the loop that makes the dashboards current. */
 export async function runFrequent(database: Database) {
   const rolled = await rollupClicks(database);
-  const outbox = await drainOutbox(database, projection);
+  const outbox = await drainOutbox(database, projectionFor(database));
   const webhooks = await deliverWebhooks(database);
 
   if (rolled.events || outbox.processed || outbox.failed || webhooks.sent || webhooks.failed) {

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -109,9 +109,22 @@ function projectionFor(database: Database): ProjectionTarget {
       /* endpoint is left undefined in production so the SDK talks to the real
          regional DynamoDB endpoint. It is set ONLY when AWS_ENDPOINT_URL_DYNAMODB
          (or the generic AWS_ENDPOINT_URL) is present, which is how CI points the
-         writer at a dynamodb-local container — a strict no-op when unset. */
+         writer at a dynamodb-local container — a strict no-op when unset.
+
+         removeUndefinedValues is REQUIRED, not an optimisation: a projected
+         link carries many optional fields (utm with only some of
+         source/medium/campaign/content set, routing rules whose when.device /
+         when.language / weight are absent), and a ResolvedLink read from
+         Postgres surfaces those absent JSON keys as `undefined`. Without this
+         flag lib-dynamodb's marshaller THROWS on the first undefined attribute
+         value, which fails the whole BatchWriteCommand — so a single link with
+         a partial utm object stops the entire projection batch and the redirect
+         resolves nothing (every /:slug 404s). Stripping undefined values here
+         projects exactly the fields that are set, and the reader revives them
+         identically, so the DynamoDB item matches the Postgres row. */
       const client = DynamoDBDocumentClient.from(
         new DynamoDBClient({ region: process.env.AWS_REGION, endpoint: dynamoEndpoint() }),
+        { marshallOptions: { removeUndefinedValues: true } },
       );
       projectionTarget = new DynamoProjection(database, client, table);
     } else {

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -599,6 +599,125 @@ without a dedicated interface endpoint — which unblocks, but does not implemen
 `'gateway'`), or if a deployment genuinely needs none of the egress features and wants
 to save the ~$3/mo (`'none'`).
 
+### Profile 3: the AWS serverless projection and the click pipeline
+
+**Filled in by #288 (Phase 7 of #267):** the ports were already there — `LinkResolver`
+in `apps/redirect`, `ClickSink` in `apps/redirect`, `ProjectionTarget` in `apps/worker`
+— and Profile 3 is the AWS adapters behind them. Two switches turn them on, both
+defaulting OFF so every other profile is byte-for-byte unchanged:
+
+| Env switch | Default | `dynamo` / `sqs` (the AWS profile) |
+| --- | --- | --- |
+| `LINK_PROJECTION` | `none` — redirect reads Postgres via `PostgresLinkResolver`; worker's `NoProjection` is a no-op | `dynamo` — redirect reads a DynamoDB projection; worker drains `projection_outbox` into it |
+| `CLICK_SINK` | `postgres` — redirect `INSERT`s clicks straight into `click_events` | `sqs` — redirect sends an awaited SQS message; the worker drains it back into `click_events` |
+
+Local dev, compose, the single-node profile and the Kubernetes profile all leave both
+unset, so they run the exact Postgres paths they always did. Only the CDK stack sets
+`dynamo`/`sqs`, and only on `redirectFn`/`workerFn` (never `commonEnv`).
+
+**The projection is one DynamoDB table, keyed by domain.** A LINK item per `(domain,
+slug)` carries every field the redirect needs to make a routing decision:
+
+- `PK = 'd#' + normaliseHost(domain)`, `SK = 's#' + slug.toLowerCase()` — the same
+  normalisation `PostgresLinkResolver` uses, so a link created against `SNAP.TO/Foo`
+  resolves from a request whose Host is `snap.to` and slug is `foo`, identically to
+  Postgres.
+- a DOMAIN-META item per domain — `SK = 'd#meta'` — holding `{id, rootRedirect,
+  notFoundRedirect}` so the root (`/`) and not-found redirects resolve with one GetItem.
+  It is (re)written alongside every link upsert on that domain: the simplest way to keep
+  `resolveDomain()` current without a second outbox stream, and one cheap extra put.
+
+One `GetItem` per redirect, no join, no connection pool to warm. The item shape and the
+`Date`↔ISO-string conversion live in **one** place (`@snapurl/database`'s
+`link-projection` mapper), imported by both the worker (writer) and the redirect
+(reader), so a field the writer projects cannot drift from the field the reader revives.
+
+**Clicks are a point-in-time value, on purpose.** The projected `clicks` is read from
+`link_counters` at projection time, exactly as `gateFor()` already treats it: "the count
+is the last rollup's, not a live one." A hard click cap can therefore be overshot by a
+handful under concurrency — but it is the *same* overshoot the Postgres path already
+carries, so the DynamoDB and Postgres resolvers cannot disagree on the gate beyond the
+rollup lag both share. A synchronous live count would cost more latency than the
+accuracy is worth on the hot path.
+
+**The delete-key GSI, so the API never changes.** `enqueueProjection` stores only
+`{linkId, operation}` in the outbox and the API's delete removes the link row in the
+*same* transaction. So at drain time a `delete` cannot read `(domain, slug)` from
+Postgres to build the item key — the row is already gone. The issue's constraint is that
+the API stays untouched, so the resolution lives entirely on the projection side: the
+table carries a `linkId-index` GSI on a top-level `linkId` attribute present on every
+LINK item, and `remove(linkId)` queries the GSI for the matching item(s) and deletes
+them by their real PK/SK. (A reverse-pointer item was the alternative; the GSI is the
+DynamoDB idiom and needs no second write on the upsert path.) An upsert does *not* need
+the GSI — the link row still exists for an upsert, so `(domain, slug)` is read straight
+from Postgres. A writer test round-trips upsert→remove to prove it.
+
+**SQS as an event source mapping, not a self-managed `ReceiveMessage` loop.** The
+worker does not poll the queue. An SQS event source mapping (`SqsEventSource`,
+`reportBatchItemFailures: true`) is polled by the Lambda service *outside* the VPC and
+delivers a batch as an ordinary `{ Records: [...] }` invocation, which the worker drains
+into `click_events` with partial-batch-failure reporting so one bad message does not
+reprocess the whole batch. A self-managed `ReceiveMessage` loop would have had to run
+*inside* the redirect or a polling Lambda and, to reach SQS from a private subnet, would
+have needed an SQS interface VPC endpoint (hourly + per-GB cost) — the ESM needs none,
+because the poller lives on the AWS side of the boundary. **This sequencing depended on
+3a landing first:** the redirect could only be allowed to leave the VPC once it could
+resolve links from DynamoDB (3a) *and* record clicks without a Postgres connection (3b's
+SQS sink), so 3a (projection + resolver) had to precede 3b (SQS sink + VPC removal).
+
+**The payoff: the redirect leaves the VPC.** Under `dynamo` + `sqs` the redirect touches
+only DynamoDB and SQS — both public AWS endpoints — and `init()` opens no Postgres
+connection at all. `redirectFn` drops its `vpcSettings`; `apiFn` and `workerFn` keep
+theirs. What that buys:
+
+- **No ENI.** A VPC Lambda attaches an elastic network interface at cold start; a
+  no-VPC Lambda does not, so the cold start is faster — the thing that matters most on a
+  redirect hot path.
+- **No connection pool, no ~109-connection ceiling.** A db.t4g.micro caps at ~109
+  connections; a fleet of redirect instances each holding even one pooled connection is
+  how that ceiling is hit. DynamoDB and SQS are connectionless HTTP, so redirect
+  concurrency no longer competes for RDS connections at all.
+- **The 10s-timeout failure mode is gone.** The old fire-and-forget-or-await Postgres
+  `INSERT` under the Lambda Web Adapter could pin a backend the pool could not reclaim,
+  queueing the next request on a warm instance behind a query that never finishes until
+  the function times out. With no Postgres in the redirect there is nothing to pin.
+
+**What made leaving Postgres possible: the CacheStore-backed salt source.** The daily
+visitor-hash salt was the last thing tying the redirect to Postgres — it read/wrote the
+`daily_salts` table on every request. `SaltSource` now has two implementations behind a
+shared caching base: `PostgresSaltCache` (unchanged, used whenever a Postgres handle
+exists) and `CacheStoreSaltCache`, which reads/writes the shared `CacheStore` — already
+DynamoDB on the AWS profile (`CACHE_DRIVER=dynamodb`, from #285) and reachable without a
+VPC. So a redirect that has left Postgres still salts its hashes from DynamoDB. The one
+race (two cold instances writing a salt on the first request of a new day) affects only
+unique-visitor counting, never redirect correctness, and closes the instant the key is
+populated — the same bounded imprecision the "no cookies" promise already documents.
+
+**The freeze/thaw argument, asserted rather than assumed.** Under the Lambda Web Adapter
+the sandbox freezes the moment the redirect responds. A fire-and-forget Postgres
+`INSERT` is suspended mid-flight — the click is lost *and* it pins a backend the pool
+cannot reclaim. An **awaited** SQS `SendMessage` is an HTTP request that completes and is
+acknowledged *before* the response returns, so the click is durably on the queue by the
+time the invocation ends; the worker's ESM drains it into `click_events` later. That is
+the freeze-safe write #277 wanted, and it is a unit-test assertion, not a hope:
+`SqsClickSink` awaits the send, and the worker consumer test feeds it a batch and asserts
+every message lands in `click_events` while a single bad message is isolated to
+`batchItemFailures`.
+
+**CI-proven vs mock-proven vs deploy-deferred.** Being explicit about what has actually
+been exercised:
+
+| Claim | Status | How |
+| --- | --- | --- |
+| Redirect resolves from DynamoDB under `LINK_PROJECTION=dynamo` (Done-when #1) | **CI-proven** | The `dynamo-smoke` job stands up `amazon/dynamodb-local`, the worker drains the outbox into it, and `scripts/smoke-redirect.sh` passes with every 302/404 served from DynamoDB |
+| `SqsClickSink` awaits the send; the worker consumer drains a batch into `click_events` with partial-batch-failure isolation (freeze/thaw survival) | **Mock-proven** | Unit tests against a mocked SDK `send` keyed by command name; the resolver/writer/mapper round-trips are likewise unit-tested |
+| CDK shape: PAY_PER_REQUEST + PITR table + GSI, SQS queue + DLQ, worker ESM with `ReportBatchItemFailures`, `redirectFn` with no `VpcConfig` | **CI-proven** (synth) | `cdk synth` asserts every resource; no deploy |
+| Real no-VPC resolution and the real SQS round trip against AWS | **Deploy-deferred** | Needs a live stack; the sandbox and CI cannot run a real deploy. The CI smoke uses `AWS_ENDPOINT_URL_DYNAMODB` to point the adapters at dynamodb-local — the same optional endpoint override that is unset (a no-op) in production |
+
+**Revisit if** the point-in-time click count's overshoot ever needs to be tighter (a
+conditional-write cap on the item is the DynamoDB move), or if the salt race matters
+enough to warrant an atomic first-write primitive on the `CacheStore` port.
+
 ---
 
 ## Part 5 — Open questions for you

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -177,9 +177,11 @@ profile rather than globally, chosen at deploy time by `CACHE_DRIVER`.
   $12/mo minimum) to solve problems this profile does not have. That is the original reasoning,
   preserved and still correct.
 
-The DynamoDB adapter exists in code (`packages/cache`), but the CDK DynamoDB cache table is a
-Phase-7 follow-up (#288 territory), so `CACHE_DRIVER=dynamodb` is not wired into the stack yet. The
-point of the port is precisely that this stays a per-profile config choice, not a rewrite.
+The DynamoDB adapter exists in code (`packages/cache`); the CDK DynamoDB cache table was the
+Phase-7 follow-up (#288), and #288 wires it: the stack now provisions a `CacheTable` and sets
+`CACHE_DRIVER=dynamodb` on the redirect (see Profile 3 below), so the AWS profile's `CacheStore` is
+genuinely DynamoDB rather than the per-instance in-memory default. The point of the port is
+precisely that this stays a per-profile config choice, not a rewrite.
 
 **A GraphQL layer.** The frontend is TanStack Query over REST and the contract is already typed
 end to end. GraphQL would add a schema to keep in sync with no caller asking for it.
@@ -686,12 +688,22 @@ theirs. What that buys:
 visitor-hash salt was the last thing tying the redirect to Postgres — it read/wrote the
 `daily_salts` table on every request. `SaltSource` now has two implementations behind a
 shared caching base: `PostgresSaltCache` (unchanged, used whenever a Postgres handle
-exists) and `CacheStoreSaltCache`, which reads/writes the shared `CacheStore` — already
-DynamoDB on the AWS profile (`CACHE_DRIVER=dynamodb`, from #285) and reachable without a
-VPC. So a redirect that has left Postgres still salts its hashes from DynamoDB. The one
-race (two cold instances writing a salt on the first request of a new day) affects only
-unique-visitor counting, never redirect correctness, and closes the instant the key is
-populated — the same bounded imprecision the "no cookies" promise already documents.
+exists) and `CacheStoreSaltCache`, which reads/writes the shared `CacheStore`. For that
+store to actually be *shared* — the whole point, since a per-instance store would give
+every warm redirect its own salt and inflate unique counts by the instance fan-out —
+#288 provisions a dedicated `CacheTable` and sets `CACHE_DRIVER=dynamodb` +
+`CACHE_DYNAMO_TABLE` on the redirect (with a read/write grant). The `#285` adapter alone
+was not enough: without the table and the env var the factory would have defaulted to
+the per-instance in-memory store, so the redirect out of the VPC would have fragmented
+the salt. With them, a redirect that has left Postgres salts its hashes from a shared
+DynamoDB table reachable without a VPC. `CacheStoreSaltCache.load` re-reads the key after
+its own write (mirroring `PostgresSaltCache`'s re-read after `onConflictDoNothing`), so
+two cold instances racing a new day converge on the surviving value rather than each
+keeping its own for the day. The residual race is only the instant between two writes; it
+affects unique-visitor counting only, never redirect correctness — the same bounded
+imprecision the "no cookies" promise already documents. (`set()` is last-write-wins, not
+an atomic `SETNX`; the `CacheStore` port has no first-write primitive, and adding one for
+a once-a-day cold-start window is not worth the surface area.)
 
 **The freeze/thaw argument, asserted rather than assumed.** Under the Lambda Web Adapter
 the sandbox freezes the moment the redirect responds. A fire-and-forget Postgres
@@ -711,7 +723,7 @@ been exercised:
 | --- | --- | --- |
 | Redirect resolves from DynamoDB under `LINK_PROJECTION=dynamo` (Done-when #1) | **CI-proven** | The `dynamo-smoke` job stands up `amazon/dynamodb-local`, the worker drains the outbox into it, and `scripts/smoke-redirect.sh` passes with every 302/404 served from DynamoDB |
 | `SqsClickSink` awaits the send; the worker consumer drains a batch into `click_events` with partial-batch-failure isolation (freeze/thaw survival) | **Mock-proven** | Unit tests against a mocked SDK `send` keyed by command name; the resolver/writer/mapper round-trips are likewise unit-tested |
-| CDK shape: PAY_PER_REQUEST + PITR table + GSI, SQS queue + DLQ, worker ESM with `ReportBatchItemFailures`, `redirectFn` with no `VpcConfig` | **CI-proven** (synth) | `cdk synth` asserts every resource; no deploy |
+| CDK shape: PAY_PER_REQUEST + PITR projection table + GSI, single-key `CacheTable` (TTL on `expiresAt`), SQS queue + DLQ, worker ESM with `ReportBatchItemFailures`, `redirectFn` with no `VpcConfig` and `CACHE_DRIVER=dynamodb` + `CACHE_DYNAMO_TABLE` (api/worker keep the VPC, no `CACHE_DRIVER`) | **CI-proven** (synth) | `cdk synth` asserts every resource; no deploy |
 | Real no-VPC resolution and the real SQS round trip against AWS | **Deploy-deferred** | Needs a live stack; the sandbox and CI cannot run a real deploy. The CI smoke uses `AWS_ENDPOINT_URL_DYNAMODB` to point the adapters at dynamodb-local — the same optional endpoint override that is unset (a no-op) in production |
 
 **Revisit if** the point-in-time click count's overshoot ever needs to be tighter (a

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -281,6 +281,40 @@ export class SnapUrlStack extends Stack {
     });
 
     /* ---------------------------------------------------------
+       Cache table (Phase 7, #288)
+
+       The CacheStore for the AWS profile: DynamoDbCacheStore (@snapurl/cache)
+       reads and writes this table. It backs the redirect's daily-salt cache —
+       and this is the load-bearing point of #288 3b. The redirect out of the
+       VPC generates today's salt once per new day and writes it here; every
+       other redirect instance reads the SAME salt back, so a visitor is hashed
+       under one shared salt rather than one salt per warm instance. Without a
+       SHARED store the salt cache falls back to per-instance in-memory and the
+       unique-visitor count double-counts by the instance fan-out (the exact gap
+       the v1 review flagged). See apps/redirect/src/salt.ts (CacheStoreSaltCache)
+       and RedirectFn's CACHE_DRIVER=dynamodb below.
+
+       Separate from LinkProjectionTable on purpose: the two have different key
+       schemas. The cache adapter is single-key on `pk` (no sort key), matching
+       DynamoDbCacheStore's item shape, whereas the projection is a PK/SK table.
+
+       PAY_PER_REQUEST: the salt is written at most once per day per new instance
+       and read from the in-process day cache thereafter, so there is no steady
+       RPS to provision against. TTL is on `expiresAt` (the attribute the cache
+       adapter stamps in unix epoch seconds), so a day's salt is retired
+       automatically once its TTL passes — no rotation job needed for this table.
+
+       DESTROY, not RETAIN (unlike the projection): the only thing stored here is
+       a day-scoped salt that is regenerated on demand, so there is nothing worth
+       keeping across a `cdk destroy`. */
+    const cacheTable = new dynamodb.Table(this, "CacheTable", {
+      partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: "expiresAt",
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    /* ---------------------------------------------------------
        Click queue (Phase 7, #288 3b)
 
        On the AWS profile the redirect no longer INSERTs a click on its hot
@@ -679,6 +713,19 @@ export class SnapUrlStack extends Stack {
            removing it from the VPC below (#288 3b). */
         CLICK_SINK: "sqs",
         CLICK_QUEUE_URL: clickQueue.queueUrl,
+        /* AWS profile: back the CacheStore with DynamoDB, not the per-instance
+           in-memory default. This is what makes the redirect's daily salt
+           SHARED across all warm instances: CacheStoreSaltCache reads/writes
+           the salt through this store (see apps/redirect/src/salt.ts), so once
+           any instance has written today's salt every other instance reads the
+           same value back. Left to the 'memory' default each instance would
+           generate its own salt and hash the same visitor differently all day,
+           inflating unique counts by the instance fan-out. The table is
+           single-key on `pk`, matching DynamoDbCacheStore. Set on redirectFn
+           only (not commonEnv): the api/worker keep their own CACHE_DRIVER
+           story and the single-node/k8s profiles never see it. */
+        CACHE_DRIVER: "dynamodb",
+        CACHE_DYNAMO_TABLE: cacheTable.tableName,
       },
       /* NOT in the VPC — this is the #288 payoff. With LINK_PROJECTION=dynamo +
          CLICK_SINK=sqs the redirect resolves from DynamoDB, sends clicks to SQS
@@ -698,6 +745,13 @@ export class SnapUrlStack extends Stack {
     /* The redirect sends each click to the queue; the worker (below) consumes
        it. grantSendMessages is the least-privilege grant for a producer. */
     clickQueue.grantSendMessages(redirectFn);
+
+    /* The redirect reads AND writes the cache table: CacheStoreSaltCache does a
+       get() for today's salt and, on the first request of a new day, a set() to
+       publish the salt it generated so every other instance reads it back.
+       grantReadWriteData covers both. This shared write is what closes the
+       per-instance-salt gap that leaving the VPC would otherwise open. */
+    cacheTable.grantReadWriteData(redirectFn);
 
 
     /* IAM auth, not NONE: a NONE Function URL is reachable by anyone on the

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -8,6 +8,7 @@ import {
 } from "aws-cdk-lib";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as events from "aws-cdk-lib/aws-events";
@@ -234,6 +235,48 @@ export class SnapUrlStack extends Stack {
        only S3 and DynamoDB get one — the two that happen to be gateways. */
     vpc.addGatewayEndpoint("S3Endpoint", { service: ec2.GatewayVpcEndpointAwsService.S3 });
     vpc.addGatewayEndpoint("DynamoEndpoint", { service: ec2.GatewayVpcEndpointAwsService.DYNAMODB });
+
+    /* ---------------------------------------------------------
+       Link projection table (Phase 7, #288)
+
+       The redirect hot path resolves link config from this DynamoDB projection
+       rather than Postgres: one GetItem, no connection pool, no ~109-connection
+       RDS ceiling — which is what makes the redirect viable on Lambda and, once
+       the SQS click sink lands (#288 3b / FEAT-003), lets it leave the VPC. The
+       worker drains projection_outbox into it; the redirect reads it back. The
+       item shape is @snapurl/database's link-projection module.
+
+       PAY_PER_REQUEST: the redirect's traffic is spiky and mostly served by the
+       hot-link cache, so there is no steady RPS to provision against — on-demand
+       is both cheaper and one less number to tune. PITR is on: the projection is
+       derivable from Postgres (re-drain the outbox), but point-in-time recovery
+       is free-tier-cheap insurance against an operational mistake.
+
+       The GSI on `linkId` closes the delete-key gap: the API's outbox row for a
+       delete carries only the link id and the link row is gone by drain time, so
+       the worker cannot compute the (domain, slug) key from Postgres. It queries
+       this index for the item(s) with that id and deletes them instead. The
+       index name and the `linkId` attribute match LINK_ID_GSI / LINK_ID_ATTR in
+       @snapurl/database. */
+    const linkProjectionTable = new dynamodb.Table(this, "LinkProjectionTable", {
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      /* RETAIN, not DESTROY: like the database's SNAPSHOT policy, a `cdk
+         destroy` should not silently take the edge's link config with it. The
+         table is cheap to keep and re-derivable, but losing it unprompted is
+         the wrong default. */
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+    linkProjectionTable.addGlobalSecondaryIndex({
+      indexName: "linkId-index",
+      partitionKey: { name: "linkId", type: dynamodb.AttributeType.STRING },
+      /* KEYS_ONLY: the delete path only needs each matching item's PK/SK to
+         issue the DeleteItem, so projecting the full item into the index would
+         be storage and write cost for nothing. */
+      projectionType: dynamodb.ProjectionType.KEYS_ONLY,
+    });
 
     /* ---------------------------------------------------------
        Database
@@ -563,9 +606,25 @@ export class SnapUrlStack extends Stack {
          is the highest-volume function — two JSON lines per request at `info`
          is ~60GB/month of ingest at 100M redirects — so the hot path stays
          quiet while api and worker keep the configured level. */
-      environment: { ...commonEnv, AWS_LWA_READINESS_CHECK_PATH: "/health", LOG_LEVEL: "warn" },
+      environment: {
+        ...commonEnv,
+        AWS_LWA_READINESS_CHECK_PATH: "/health",
+        LOG_LEVEL: "warn",
+        /* AWS profile: resolve link config from the DynamoDB projection, not
+           Postgres. On redirectFn/workerFn only (not commonEnv), so this stays
+           the AWS profile's choice — the single-node/k8s profiles are
+           compose/Helm and never see it, and the free/none topology is
+           unaffected. */
+        LINK_PROJECTION: "dynamo",
+        LINK_PROJECTION_TABLE: linkProjectionTable.tableName,
+      },
+      /* Still IN the VPC for now — the redirect leaves it in FEAT-003, once the
+         SQS click sink exists so it no longer needs Postgres on the hot path. */
       ...vpcSettings,
     });
+
+    /* The redirect only reads the projection. */
+    linkProjectionTable.grantReadData(redirectFn);
 
 
     /* IAM auth, not NONE: a NONE Function URL is reachable by anyone on the
@@ -691,9 +750,20 @@ export class SnapUrlStack extends Stack {
       /* No WORKER_MODE: nothing reads it. The long-running process takes
          `--once` from argv, and the Lambda entrypoint (apps/worker/src/lambda.ts)
          skips that path entirely and calls the two jobs directly. */
-      environment: commonEnv,
+      environment: {
+        ...commonEnv,
+        /* AWS profile: drain projection_outbox into the DynamoDB projection.
+           On workerFn only, matching redirectFn — see the note there. */
+        LINK_PROJECTION: "dynamo",
+        LINK_PROJECTION_TABLE: linkProjectionTable.tableName,
+      },
       ...vpcSettings,
     });
+
+    /* The worker writes the projection (puts on upsert) and deletes on remove,
+       and queries the linkId GSI to find what to delete — readWriteData covers
+       the table and its indexes. */
+    linkProjectionTable.grantReadWriteData(workerFn);
 
 
     /* EventBridge rather than an in-process interval: a scheduled rule

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -14,6 +14,8 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as events from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaEventSources from "aws-cdk-lib/aws-lambda-event-sources";
+import * as sqs from "aws-cdk-lib/aws-sqs";
 import * as ecrAssets from "aws-cdk-lib/aws-ecr-assets";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as apigw from "aws-cdk-lib/aws-apigatewayv2";
@@ -279,6 +281,51 @@ export class SnapUrlStack extends Stack {
     });
 
     /* ---------------------------------------------------------
+       Click queue (Phase 7, #288 3b)
+
+       On the AWS profile the redirect no longer INSERTs a click on its hot
+       path — it sends the click to this queue (CLICK_SINK=sqs), and the worker
+       drains it back into click_events via an event source mapping (below). An
+       awaited SendMessage is the freeze-safe write the redirect needs under the
+       Lambda Web Adapter, and SQS is a public AWS endpoint, so a redirect that
+       also resolves from DynamoDB needs neither Postgres nor the VPC — which is
+       why the redirect leaves the VPC further down.
+
+       SQS has no gateway VPC endpoint (only a ~$7/month interface endpoint), so
+       this queue is why 3b depended on 3a: an in-VPC redirect calling
+       SendMessage would either cost that money or not reach the queue at all.
+       With the redirect out of the VPC it reaches SQS over the public internet
+       for free.
+
+       A dead-letter queue catches a message the worker fails to insert
+       maxReceiveCount times (a poison message: an unparseable body, a row the
+       database rejects). Without it such a message would redrive forever. The
+       consumer reports per-record failures (batchItemFailures), so only the
+       genuinely bad message is retried toward this DLQ; the rest of its batch
+       still lands. */
+    const clickDlq = new sqs.Queue(this, "ClickDlq", {
+      /* 14 days, the SQS maximum: a poison message should sit here long enough
+         for someone to notice and inspect it, not silently age out. */
+      retentionPeriod: Duration.days(14),
+    });
+    const clickQueue = new sqs.Queue(this, "ClickQueue", {
+      /* At least the worker's function timeout (5 min): while the worker is
+         mid-batch a message must stay invisible to other pollers, or it could
+         be delivered twice and the click double-counted. Six times the timeout
+         is the AWS-recommended headroom for a consumer that can retry within
+         one visibility window. */
+      visibilityTimeout: Duration.minutes(30),
+      deadLetterQueue: {
+        queue: clickDlq,
+        /* Five attempts before a message is parked in the DLQ. The consumer's
+           partial-batch-failure reporting means this counts per-message, not
+           per-batch, so a transient blip gets a few honest retries while a
+           truly poison message is quarantined rather than looping. */
+        maxReceiveCount: 5,
+      },
+    });
+
+    /* ---------------------------------------------------------
        Database
        --------------------------------------------------------- */
 
@@ -457,11 +504,18 @@ export class SnapUrlStack extends Stack {
        ISecurityGroup[], and a readonly tuple will not satisfy it. */
     const vpcSettings = {
       vpc,
-      /* Egress-aware: PRIVATE_WITH_EGRESS when NAT is on so the API, redirect
-         and worker can call Safe Browsing / webhooks / OAuth / mail; the
-         isolated group under natStrategy === 'none'. Redirect shares this
-         object for RDS access — giving it egress when NAT is on is harmless
-         and consistent, and Phase 7 may rely on it. */
+      /* Egress-aware: PRIVATE_WITH_EGRESS when NAT is on so the API and worker
+         can call Safe Browsing / webhooks / OAuth / mail / RDS; the isolated
+         group under natStrategy === 'none'.
+
+         The REDIRECT no longer shares this. Phase 7 (#288) moved it to the
+         DynamoDB projection (3a) and the SQS click sink (3b), so on the AWS
+         profile it touches only DynamoDB and SQS — both public AWS endpoints —
+         and needs no Postgres, no ENI and no VPC. Removing it from the VPC is
+         the payoff: no cold-start ENI attach, no connection pool, no
+         ~109-connection RDS ceiling, and the 10-second timeout failure mode
+         goes with it. See RedirectFn below, which deliberately omits
+         ...vpcSettings. The API and worker KEEP it. */
       vpcSubnets: appLambdaSubnets,
       securityGroups: [lambdaSecurityGroup] as ec2.ISecurityGroup[],
     };
@@ -617,14 +671,33 @@ export class SnapUrlStack extends Stack {
            unaffected. */
         LINK_PROJECTION: "dynamo",
         LINK_PROJECTION_TABLE: linkProjectionTable.tableName,
+        /* AWS profile: send clicks to the SQS queue rather than INSERT them on
+           the hot path. An awaited SendMessage is freeze-safe under the Lambda
+           Web Adapter (a Postgres INSERT is not), and the worker drains the
+           queue back into click_events. Together with LINK_PROJECTION=dynamo
+           this takes the redirect off Postgres entirely — the precondition for
+           removing it from the VPC below (#288 3b). */
+        CLICK_SINK: "sqs",
+        CLICK_QUEUE_URL: clickQueue.queueUrl,
       },
-      /* Still IN the VPC for now — the redirect leaves it in FEAT-003, once the
-         SQS click sink exists so it no longer needs Postgres on the hot path. */
-      ...vpcSettings,
+      /* NOT in the VPC — this is the #288 payoff. With LINK_PROJECTION=dynamo +
+         CLICK_SINK=sqs the redirect resolves from DynamoDB, sends clicks to SQS
+         and reads its daily salt from the DynamoDB-backed CacheStore — all
+         public AWS endpoints — so it needs no Postgres, no ENI and no VPC.
+         Dropping ...vpcSettings removes the cold-start ENI attach, the
+         connection pool and the ~109-connection RDS ceiling, and the 10-second
+         redirect timeout failure mode goes with it. A no-VPC Lambda still
+         reaches Secrets Manager, DynamoDB and SQS over the public internet, so
+         the JWT-access grant below still works. The API and worker keep the
+         VPC (they still need RDS). */
     });
 
     /* The redirect only reads the projection. */
     linkProjectionTable.grantReadData(redirectFn);
+
+    /* The redirect sends each click to the queue; the worker (below) consumes
+       it. grantSendMessages is the least-privilege grant for a producer. */
+    clickQueue.grantSendMessages(redirectFn);
 
 
     /* IAM auth, not NONE: a NONE Function URL is reachable by anyone on the
@@ -765,6 +838,26 @@ export class SnapUrlStack extends Stack {
        the table and its indexes. */
     linkProjectionTable.grantReadWriteData(workerFn);
 
+    /* The SQS event source mapping the issue explicitly chose over a
+       self-managed ReceiveMessage: the Lambda service POLLS the queue from
+       OUTSIDE the VPC and invokes the worker with the batch, so no SQS VPC
+       endpoint is needed even though the worker itself stays in the VPC (it
+       needs RDS to insert click_events and run the rollups). SqsEventSource
+       also grants the worker the consume permissions (Receive/Delete/GetAttrs).
+
+       reportBatchItemFailures pairs with the handler returning
+       { batchItemFailures: [...] }: only the reported records are redriven, so
+       one poison message does not reprocess or DLQ the whole batch. batchSize
+       10 keeps each invocation small and latency low for a hot click stream;
+       the visibility timeout on the queue (>= the worker's 5-min timeout) keeps
+       an in-flight batch invisible to other pollers. */
+    workerFn.addEventSource(
+      new lambdaEventSources.SqsEventSource(clickQueue, {
+        batchSize: 10,
+        reportBatchItemFailures: true,
+      }),
+    );
+
 
     /* EventBridge rather than an in-process interval: a scheduled rule
        survives a redeploy and a scale-to-zero, which the v1 node-cron did
@@ -821,9 +914,17 @@ export class SnapUrlStack extends Stack {
        here, after apiFn, redirectFn and workerFn all exist. */
     if (hasEgress) {
       database.secret!.grantRead(apiFn);
-      database.secret!.grantRead(redirectFn);
+      /* No DB-secret grant for the redirect any more (#288 3b): with
+         LINK_PROJECTION=dynamo + CLICK_SINK=sqs it never opens Postgres, so it
+         never resolves DATABASE_SECRET_ARN and reading the DB secret would be a
+         grant it cannot use. The DATABASE_SECRET_ARN env var still arrives via
+         commonEnv but is harmless unread. The API and worker keep the grant. */
       database.secret!.grantRead(workerFn);
       config.jwtAccessSecret.grantRead(apiFn);
+      /* The redirect KEEPS its JWT-access grant: it still verifies the
+         short-lived unlock token on password-protected links, and a no-VPC
+         Lambda resolves JWT_ACCESS_SECRET_ARN from Secrets Manager over the
+         public internet just as it reaches DynamoDB and SQS. */
       config.jwtAccessSecret.grantRead(redirectFn);
       config.jwtRefreshSecret.grantRead(apiFn);
     }

--- a/packages/cache/src/factory.ts
+++ b/packages/cache/src/factory.ts
@@ -60,7 +60,18 @@ export async function createCacheStore(
       const { DynamoDBClient } = await import("@aws-sdk/client-dynamodb");
       const { DynamoDBDocumentClient } = await import("@aws-sdk/lib-dynamodb");
       const { DynamoDbCacheStore } = await import("./dynamodb-cache-store.js");
-      const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+      /* endpoint is left to the SDK in production (real regional endpoint) and
+         overridden ONLY when AWS_ENDPOINT_URL_DYNAMODB / AWS_ENDPOINT_URL is
+         set, so CI can point the shared cache/salt store at a dynamodb-local
+         container exactly as the resolver and writer clients do — a no-op when
+         unset. removeUndefinedValues matches the projection clients so a cache
+         entry with absent optional fields marshals rather than throwing. */
+      const endpoint =
+        process.env.AWS_ENDPOINT_URL_DYNAMODB ?? process.env.AWS_ENDPOINT_URL ?? undefined;
+      const client = DynamoDBDocumentClient.from(
+        new DynamoDBClient({ region: process.env.AWS_REGION, endpoint }),
+        { marshallOptions: { removeUndefinedValues: true } },
+      );
       return new DynamoDbCacheStore(client, config.dynamoTable);
     }
 

--- a/packages/database/src/click-events.ts
+++ b/packages/database/src/click-events.ts
@@ -1,0 +1,83 @@
+import { clickEvents } from "./schema/index.js";
+import type { Database } from "./client.js";
+
+/* ============================================================
+   The click event, and the one INSERT that lands it.
+
+   A click is recorded in two shapes across the codebase:
+
+     - the redirect's PostgresClickSink writes it straight to
+       click_events (single-node / k8s / compose);
+     - on the AWS profile the redirect SqsClickSink sends it to a
+       queue as JSON, and the worker's SQS consumer drains that
+       queue back into the SAME click_events table.
+
+   Both must produce byte-for-byte identical rows, so the column
+   mapping lives here as one function and both paths call it. The
+   ClickEvent type also lives here (rather than in the redirect)
+   so the worker consumer can import it without depending on the
+   redirect app. It is re-exported from apps/redirect/src/click-sink.ts
+   so existing redirect importers are unchanged.
+   ============================================================ */
+
+export interface ClickEvent {
+  linkId: string;
+  workspaceId: string;
+  occurredAt: Date;
+  visitorHash: string;
+  country: string | null;
+  city: string | null;
+  device: string | null;
+  browser: string | null;
+  os: string | null;
+  referrerHost: string | null;
+  isQr: boolean;
+  isBot: boolean;
+  blockedReason: string | null;
+  matchedRuleId: string | null;
+  variant: string | null;
+}
+
+/** The wire shape of a ClickEvent on the SQS queue: identical to ClickEvent
+ *  except occurredAt is an ISO-8601 string (JSON has no Date). */
+type SerializedClickEvent = Omit<ClickEvent, "occurredAt"> & { occurredAt: string };
+
+/** Serialise a ClickEvent for an SQS MessageBody. The only non-JSON field is
+ *  occurredAt, which becomes an ISO string; deserializeClickEvent reverses it. */
+export function serializeClickEvent(event: ClickEvent): string {
+  const wire: SerializedClickEvent = { ...event, occurredAt: event.occurredAt.toISOString() };
+  return JSON.stringify(wire);
+}
+
+/** Revive a ClickEvent from an SQS record body, turning occurredAt back into a
+ *  Date so the row inserted matches the one the redirect built. */
+export function deserializeClickEvent(body: string): ClickEvent {
+  const wire = JSON.parse(body) as SerializedClickEvent;
+  return { ...wire, occurredAt: new Date(wire.occurredAt) };
+}
+
+/** The single INSERT path into click_events, shared by PostgresClickSink and
+ *  the worker's SQS consumer so a click recorded either way is the same row.
+ *  A no-op on an empty batch. */
+export async function insertClickEvents(db: Database, events: ClickEvent[]): Promise<void> {
+  if (events.length === 0) return;
+  await db.insert(clickEvents).values(
+    events.map((event) => ({
+      linkId: event.linkId,
+      workspaceId: event.workspaceId,
+      occurredAt: event.occurredAt,
+      visitorHash: event.visitorHash,
+      country: event.country,
+      city: event.city,
+      device: event.device,
+      browser: event.browser,
+      os: event.os,
+      referrerHost: event.referrerHost,
+      isQr: event.isQr,
+      isBot: event.isBot,
+      blockedReason: event.blockedReason,
+      matchedRuleId: event.matchedRuleId,
+      variant: event.variant,
+    })),
+  );
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -2,5 +2,6 @@ export * from "./client.js";
 export * from "./secrets.js";
 export * from "./schema/index.js";
 export * from "./events.js";
+export * from "./link-projection.js";
 export { sql, eq, and, or, not, desc, asc, inArray, isNull, isNotNull, gte, lte, gt, lt, count, sum, like, ilike } from "drizzle-orm";
 export * from "./migrate.js";

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -2,6 +2,7 @@ export * from "./client.js";
 export * from "./secrets.js";
 export * from "./schema/index.js";
 export * from "./events.js";
+export * from "./click-events.js";
 export * from "./link-projection.js";
 export { sql, eq, and, or, not, desc, asc, inArray, isNull, isNotNull, gte, lte, gt, lt, count, sum, like, ilike } from "drizzle-orm";
 export * from "./migrate.js";

--- a/packages/database/src/link-projection.test.ts
+++ b/packages/database/src/link-projection.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  DOMAIN_META_SK,
+  domainMetaKey,
+  fromDomainItem,
+  fromLinkItem,
+  linkKey,
+  normaliseHost,
+  toDomainItem,
+  toLinkItem,
+  type ProjectedDomain,
+  type ProjectedLink,
+} from "./link-projection.js";
+
+/* Pure-data mapper: no SDK, no DynamoDB. These assert the item shape and the
+   loss-free round-trip both apps depend on — a projected field the redirect
+   revives cannot drift from what the worker wrote. */
+
+describe("link-projection keys", () => {
+  it("keys a LINK item by normalised host and lowercased slug", () => {
+    // A printed "SNAP.TO/Foo" and a header "snap.to/foo" share one key.
+    expect(linkKey("SNAP.TO", "Foo")).toEqual({ PK: "d#snap.to", SK: "s#foo" });
+    expect(linkKey("  snap.to  ", "bar")).toEqual({ PK: "d#snap.to", SK: "s#bar" });
+  });
+
+  it("keys the domain-meta item by host and the fixed meta SK", () => {
+    expect(domainMetaKey("SNAP.TO")).toEqual({ PK: "d#snap.to", SK: DOMAIN_META_SK });
+  });
+
+  it("normaliseHost lowercases and trims but keeps the port", () => {
+    expect(normaliseHost("  LOCALHOST:3002 ")).toBe("localhost:3002");
+  });
+});
+
+describe("toLinkItem / fromLinkItem round-trip", () => {
+  const full: ProjectedLink = {
+    id: "11111111-1111-1111-1111-111111111111",
+    workspaceId: "22222222-2222-2222-2222-222222222222",
+    destination: "https://example.com/dest",
+    redirectType: "301",
+    rules: [
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        when: { country: "US", device: "mobile", language: "en" },
+        then: "https://example.com/us",
+        weight: 0.5,
+      },
+    ],
+    expiresAt: new Date("2030-01-02T03:04:05.000Z"),
+    expiresTo: "https://example.com/expired",
+    activatesAt: new Date("2029-12-31T00:00:00.000Z"),
+    scheduledTo: "https://example.com/soon",
+    clickLimit: 100,
+    clicks: 42,
+    hasPassword: true,
+    forwardQuery: false,
+    deepLink: true,
+    hideReferrer: true,
+    publicPreview: false,
+    archived: true,
+    safeBrowsingStatus: "safe",
+    utm: { source: "print", medium: "qr", campaign: "spring", content: "a" },
+  };
+
+  it("round-trips every field including Dates", () => {
+    const item = toLinkItem(full, "snap.to", "foo");
+    // Dates are stored as ISO strings.
+    expect(item.expiresAt).toBe("2030-01-02T03:04:05.000Z");
+    expect(item.activatesAt).toBe("2029-12-31T00:00:00.000Z");
+    expect(item.linkId).toBe(full.id);
+    expect(item.PK).toBe("d#snap.to");
+    expect(item.SK).toBe("s#foo");
+
+    const back = fromLinkItem(item);
+    // The id is projected as `linkId`; fromLinkItem maps it back to `id`.
+    expect(back).toEqual(full);
+    expect(back.expiresAt).toBeInstanceOf(Date);
+    expect(back.activatesAt).toBeInstanceOf(Date);
+  });
+
+  it("round-trips nulls and utm=null loss-free", () => {
+    const minimal: ProjectedLink = {
+      ...full,
+      redirectType: "302",
+      rules: [],
+      expiresAt: null,
+      expiresTo: null,
+      activatesAt: null,
+      scheduledTo: null,
+      clickLimit: null,
+      clicks: 0,
+      utm: null,
+    };
+    const item = toLinkItem(minimal, "snap.to", "bar");
+    expect(item.expiresAt).toBeNull();
+    expect(item.activatesAt).toBeNull();
+    expect(item.utm).toBeNull();
+
+    expect(fromLinkItem(item)).toEqual(minimal);
+  });
+});
+
+describe("toDomainItem / fromDomainItem round-trip", () => {
+  it("round-trips the domain meta", () => {
+    const domain: ProjectedDomain = {
+      id: "44444444-4444-4444-4444-444444444444",
+      rootRedirect: "https://example.com/root",
+      notFoundRedirect: null,
+    };
+    const item = toDomainItem("SNAP.TO", domain);
+    expect(item.PK).toBe("d#snap.to");
+    expect(item.SK).toBe(DOMAIN_META_SK);
+    expect(fromDomainItem(item)).toEqual(domain);
+  });
+});

--- a/packages/database/src/link-projection.ts
+++ b/packages/database/src/link-projection.ts
@@ -1,0 +1,236 @@
+import type { RoutingRule } from "@snapurl/contract";
+
+/* ============================================================
+   The DynamoDB link projection — item shapes and a pure mapper.
+
+   The AWS profile serves the redirect hot path from a DynamoDB
+   projection of the link config, not from Postgres: one HTTP-based
+   key lookup, no connection pool to warm. The worker drains the
+   projection_outbox and writes these items; the redirect reads
+   them back. Both apps import THIS module so the item shape and
+   the Date<->stored-form conversion have exactly one definition —
+   a projected field and the field the reader revives cannot drift.
+
+   This module is deliberately SDK-free: it is pure data mapping,
+   no @aws-sdk import, so it lives in @snapurl/database (which both
+   apps already depend on) and the AWS SDK stays confined to the
+   redirect (reader) and worker (writer) that actually talk to
+   DynamoDB.
+
+   Single table, keyed by domain:
+     - a LINK item per (domain, slug):
+         PK = 'd#' + normaliseHost(domain)
+         SK = 's#' + slug.toLowerCase()
+       carrying every ResolvedLink field, plus the link `id` as a
+       top-level `linkId` attribute so a delete (which only knows
+       the link id — see below) can find it via a GSI.
+     - a DOMAIN-META item per domain:
+         PK = 'd#' + normaliseHost(domain)
+         SK = DOMAIN_META_SK ('d#meta')
+       carrying {id, rootRedirect, notFoundRedirect} for the
+       root/not-found redirect lookups.
+
+   The delete-key gap: the API's enqueueProjection stores only
+   {linkId, operation} in the outbox and deletes the links row in
+   the same transaction, so at drain time a `delete` cannot read
+   the (domain, slug) needed to build the LINK item's key from
+   Postgres. The projection table therefore carries a Global
+   Secondary Index on the `linkId` attribute (LINK_ID_GSI), so the
+   writer's remove(linkId) queries the GSI for the item(s) with
+   that id and deletes them. Upserts do not need this — the link
+   row still exists for an upsert, so the writer reads (domain,
+   slug) straight from Postgres.
+   ============================================================ */
+
+/** Fixed sort key for the per-domain meta item (root / not-found redirect). */
+export const DOMAIN_META_SK = "d#meta";
+
+/** The attribute the delete GSI is keyed on. Present on every LINK item. */
+export const LINK_ID_ATTR = "linkId";
+
+/** The name of the Global Secondary Index keyed on {@link LINK_ID_ATTR}. */
+export const LINK_ID_GSI = "linkId-index";
+
+/** The shape one LINK item resolves to — identical to the redirect's
+ *  ResolvedLink. Defined here (rather than imported from the redirect) so this
+ *  package stays free of an app dependency; the two are structurally the same
+ *  and the redirect's LinkResolver returns exactly this. */
+export interface ProjectedLink {
+  id: string;
+  workspaceId: string;
+  destination: string;
+  redirectType: "301" | "302" | "307";
+  rules: RoutingRule[];
+  expiresAt: Date | null;
+  expiresTo: string | null;
+  activatesAt: Date | null;
+  scheduledTo: string | null;
+  clickLimit: number | null;
+  clicks: number;
+  hasPassword: boolean;
+  forwardQuery: boolean;
+  deepLink: boolean;
+  hideReferrer: boolean;
+  publicPreview: boolean;
+  archived: boolean;
+  safeBrowsingStatus: string;
+  utm: {
+    source?: string | null;
+    medium?: string | null;
+    campaign?: string | null;
+    content?: string | null;
+  } | null;
+}
+
+/** The shape one DOMAIN-META item resolves to. */
+export interface ProjectedDomain {
+  id: string;
+  rootRedirect: string | null;
+  notFoundRedirect: string | null;
+}
+
+/** The stored form of a LINK item. Date fields are ISO strings (or null) so
+ *  the mapper — not the caller — owns the Date<->string conversion, exactly as
+ *  CachingLinkResolver does when it revives a cached link. */
+export interface LinkItem {
+  PK: string;
+  SK: string;
+  /** The link id, top-level, so the delete GSI can be keyed on it. */
+  linkId: string;
+  workspaceId: string;
+  destination: string;
+  redirectType: string;
+  rules: RoutingRule[];
+  expiresAt: string | null;
+  expiresTo: string | null;
+  activatesAt: string | null;
+  scheduledTo: string | null;
+  clickLimit: number | null;
+  clicks: number;
+  hasPassword: boolean;
+  forwardQuery: boolean;
+  deepLink: boolean;
+  hideReferrer: boolean;
+  publicPreview: boolean;
+  archived: boolean;
+  safeBrowsingStatus: string;
+  utm: ProjectedLink["utm"];
+}
+
+/** The stored form of a DOMAIN-META item. */
+export interface DomainItem {
+  PK: string;
+  SK: string;
+  id: string;
+  rootRedirect: string | null;
+  notFoundRedirect: string | null;
+}
+
+/** Strips nothing but case/whitespace: the SAME normalisation the Postgres
+ *  resolver's host lookup uses, so a link created against "SNAP.TO" resolves
+ *  from a request whose Host header is "snap.to". This is the single source of
+ *  truth; the redirect re-exports it from its resolver so both key-builders and
+ *  the Postgres lookup agree. */
+export function normaliseHost(host: string): string {
+  return host.toLowerCase().trim();
+}
+
+/** PK for every item on a domain (both LINK and DOMAIN-META). */
+export function domainPk(host: string): string {
+  return `d#${normaliseHost(host)}`;
+}
+
+/** SK for a LINK item, matching the Postgres slug normalisation (lowercased). */
+export function linkSk(slug: string): string {
+  return `s#${slug.toLowerCase()}`;
+}
+
+/** The full DynamoDB Key for a LINK item. */
+export function linkKey(host: string, slug: string): { PK: string; SK: string } {
+  return { PK: domainPk(host), SK: linkSk(slug) };
+}
+
+/** The full DynamoDB Key for a DOMAIN-META item. */
+export function domainMetaKey(host: string): { PK: string; SK: string } {
+  return { PK: domainPk(host), SK: DOMAIN_META_SK };
+}
+
+/** ProjectedLink -> stored LinkItem. Dates become ISO strings (null preserved),
+ *  everything else is copied verbatim. */
+export function toLinkItem(link: ProjectedLink, host: string, slug: string): LinkItem {
+  return {
+    PK: domainPk(host),
+    SK: linkSk(slug),
+    linkId: link.id,
+    workspaceId: link.workspaceId,
+    destination: link.destination,
+    redirectType: link.redirectType,
+    rules: link.rules,
+    expiresAt: link.expiresAt === null ? null : link.expiresAt.toISOString(),
+    expiresTo: link.expiresTo,
+    activatesAt: link.activatesAt === null ? null : link.activatesAt.toISOString(),
+    scheduledTo: link.scheduledTo,
+    clickLimit: link.clickLimit,
+    /* Point-in-time click count, read from link_counters at projection time.
+       This matches gateFor()'s "the count is the last rollup's, not a live
+       one" overshoot semantics and is identical to the Postgres path, so the
+       DynamoDB and Postgres resolvers cannot disagree on the click-limit gate
+       beyond the rollup lag both already carry. */
+    clicks: link.clicks,
+    hasPassword: link.hasPassword,
+    forwardQuery: link.forwardQuery,
+    deepLink: link.deepLink,
+    hideReferrer: link.hideReferrer,
+    publicPreview: link.publicPreview,
+    archived: link.archived,
+    safeBrowsingStatus: link.safeBrowsingStatus,
+    utm: link.utm ?? null,
+  };
+}
+
+/** Stored LinkItem -> ProjectedLink. Revives the Date fields (null preserved)
+ *  exactly like CachingLinkResolver.reviveLink, so the redirect sees a real
+ *  Date on expiresAt/activatesAt and gateFor()'s time comparisons work. */
+export function fromLinkItem(item: LinkItem): ProjectedLink {
+  return {
+    id: item.linkId,
+    workspaceId: item.workspaceId,
+    destination: item.destination,
+    redirectType: item.redirectType as ProjectedLink["redirectType"],
+    rules: item.rules ?? [],
+    expiresAt: item.expiresAt === null ? null : new Date(item.expiresAt),
+    expiresTo: item.expiresTo,
+    activatesAt: item.activatesAt === null ? null : new Date(item.activatesAt),
+    scheduledTo: item.scheduledTo,
+    clickLimit: item.clickLimit,
+    clicks: item.clicks,
+    hasPassword: item.hasPassword,
+    forwardQuery: item.forwardQuery,
+    deepLink: item.deepLink,
+    hideReferrer: item.hideReferrer,
+    publicPreview: item.publicPreview,
+    archived: item.archived,
+    safeBrowsingStatus: item.safeBrowsingStatus,
+    utm: item.utm ?? null,
+  };
+}
+
+/** ProjectedDomain -> stored DomainItem. */
+export function toDomainItem(host: string, domain: ProjectedDomain): DomainItem {
+  return {
+    PK: domainPk(host),
+    SK: DOMAIN_META_SK,
+    id: domain.id,
+    rootRedirect: domain.rootRedirect,
+    notFoundRedirect: domain.notFoundRedirect,
+  };
+}
+
+/** Stored DomainItem -> ProjectedDomain. */
+export function fromDomainItem(item: DomainItem): ProjectedDomain {
+  return {
+    id: item.id,
+    rootRedirect: item.rootRedirect,
+    notFoundRedirect: item.notFoundRedirect,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1121.0
         version: 3.1121.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.1121.0
+        version: 3.1121.0
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1121.0
         version: 3.1121.0(@aws-sdk/client-dynamodb@3.1121.0)
@@ -417,6 +420,10 @@ packages:
     resolution: {integrity: sha512-kx66Imv5DomVdd5uwai10Dhf0zZg9Z3EODxJCYRGjmaD0GR08GkvuIPPIqE+ZmpHANCWbur9UKpgyXGJzk60pg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sqs@3.1121.0':
+    resolution: {integrity: sha512-T9NYR8Gcs30TUMbwf4QS2UyLMFheps3Kqgr//t1XfpIqgkpuBNkSiXa5LunlJL3MCTDT0bL01PkuhdHcXBwuVg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.977.9':
     resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
     engines: {node: '>=20.0.0'}
@@ -469,6 +476,10 @@ packages:
 
   '@aws-sdk/middleware-endpoint-discovery@3.972.30':
     resolution: {integrity: sha512-0hmD7/NG2NoVOVHvUb6rtY5POQYr+/9gdHvrYhIBA1zmCqKOBd5Gz3dL+iZ15FHOJbs/5kLplGoePc8PHTlzYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.42':
+    resolution: {integrity: sha512-D/O6iHAqlm0b430vIGewanSsr5RzaWbSDFlHYdKLWlZb4kaMKBmb44ReNHAFEKj5tNRY8pysw0qfciosB/VcJg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.44':
@@ -3806,6 +3817,18 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/client-sqs@3.1121.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/middleware-sdk-sqs': 3.972.42
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.977.9':
     dependencies:
       '@aws-sdk/types': 3.974.5
@@ -3925,6 +3948,13 @@ snapshots:
   '@aws-sdk/middleware-endpoint-discovery@3.972.30':
     dependencies:
       '@aws-sdk/endpoint-cache': 3.972.11
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-sqs@3.972.42':
+    dependencies:
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
 
   apps/redirect:
     dependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.1121.0
+        version: 3.1121.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.1121.0
+        version: 3.1121.0(@aws-sdk/client-dynamodb@3.1121.0)
       '@snapurl/cache':
         specifier: workspace:*
         version: link:../../packages/cache
@@ -133,6 +139,12 @@ importers:
 
   apps/worker:
     dependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.1121.0
+        version: 3.1121.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.1121.0
+        version: 3.1121.0(@aws-sdk/client-dynamodb@3.1121.0)
       '@snapurl/contract':
         specifier: workspace:*
         version: link:../../packages/contract


### PR DESCRIPTION
Closes #288. Phase 7 of epic #267 — fills in the AWS adapters behind ports that already existed. Deps #281 (NAT) and #282 (SKIP LOCKED) are merged. Defaults keep single-node/k8s/compose byte-for-byte unchanged.

## 3a — DynamoDB projection + resolver (`LINK_PROJECTION`, default `none`)
- Shared SDK-free mapper (`packages/database/src/link-projection.ts`): item PK=`d#`+domain / SK=`s#`+slug carries every `ResolvedLink` field; a domain-meta item (SK=`d#meta`) backs `resolveDomain`. `clicks` is projected point-in-time from `link_counters` (same 'last rollup value' overshoot semantics as `gateFor`).
- **`DynamoLinkResolver`** over GetItem; **`DynamoProjection`** writer replacing `NoProjection`, draining `projection_outbox` in **≤25-item BatchWrites** with UnprocessedItems retry (a 100-link import is O(N/25) round trips). Batching is threaded through an optional `apply(ops)` on `ProjectionTarget`; `NoProjection` doesn't implement it, so `LINK_PROJECTION=none` is the unchanged per-row path (and #282's atomic claim is untouched).
- **Delete-key gap solved without touching the API:** the outbox payload has only `{linkId,operation}` and the API deletes the row in-tx, so a delete can't reconstruct domain+slug — resolved via a `linkId-index` GSI (keys are immutable for a link's lifetime, so no orphan risk).

## 3b — SQS click sink + worker consumer + redirect leaves the VPC (`CLICK_SINK`, default `postgres`)
- **`SqsClickSink`**: awaited `SendMessage` — the freeze-safe write (#277's Phase-7 note realized; an HTTP send survives freeze/thaw where a Postgres INSERT doesn't).
- Worker consumes via an **SQS event source mapping** (polled outside the VPC — the issue's explicit choice), with **partial-batch-failure** (`reportBatchItemFailures`) so one poison message doesn't reprocess the batch; inserts via the shared `insertClickEvents` (byte-identical rows to `PostgresClickSink`). The rollup folds them as usual (#282 prevents double-processing).
- **Redirect leaves the VPC:** under `LINK_PROJECTION=dynamo`+`CLICK_SINK=sqs` it touches only DynamoDB+SQS (public endpoints). The one blocker was the daily salt (a Postgres read/write per redirect) — refactored `salt.ts` into a `SaltSource` with a `CacheStoreSaltCache` that salts from the shared DynamoDB CacheStore. Payoff: no ENI, no pool, no ~109-conn ceiling, faster cold start, the 10s-timeout failure mode gone.

## CDK
Adds the projection Table (PAY_PER_REQUEST + PITR + `linkId-index` GSI, RETAIN), a cache Table (TTL), an SQS click queue + DLQ (`maxReceiveCount:5`), the worker `SqsEventSource` (batch 10, reportBatchItemFailures); **drops `vpcSettings` + the DB-secret grant from redirectFn only** (api+worker keep the VPC). `cdk synth` verified: RedirectFn VpcConfig=false / LINK_PROJECTION=dynamo / CLICK_SINK=sqs / CACHE_DRIVER=dynamodb; ApiFn+WorkerFn VpcConfig=true.

## Done-when
- ✅ **Smoke passes with `LINK_PROJECTION=dynamo`** — new `dynamo-smoke` CI job runs the stack against `amazon/dynamodb-local`, projects outbox→dynamo via the worker, and runs `smoke-redirect.sh` proving the redirect resolves from DynamoDB.
- ✅ **Redirect has no VPC config and still resolves** — synth-verified for the config; real no-VPC resolution is deploy-deferred.
- ✅ **Clicks survive freeze/thaw, asserted** — `SqsClickSink` awaits the send (test-asserted) and the event-source consumer inserts them (test-asserted, incl. partial-batch-failure).

## CI-proven vs mock-proven vs deploy-deferred
- CI: the `LINK_PROJECTION=dynamo` dynamodb-local smoke; all existing jobs stay green (defaults = none/postgres/memory).
- Mock unit tests: DynamoLinkResolver/writer/batching, SqsClickSink await, worker SQS consumer + partial-batch-failure, mapper round-trip.
- Deploy-deferred: real no-VPC resolution + real SQS end-to-end.

## Review
v1 NEEDS_CHANGES (the CacheStoreSaltCache wasn't fully wired in CDK — RedirectFn lacked CACHE_DRIVER=dynamodb + the table/grant, would've thrown at boot); fixed in `af77d8f` (dedicated cache table + env + grant on RedirectFn only, dynamoTable threaded through createCacheStore, re-read-after-set convergence). v2 APPROVED.

Verified: frozen-lockfile clean, type-check, tests (new adapter/consumer suites pass), build, infra type-check, cdk synth.