### PR TITLE
Profile 3: CloudFront Function + KeyValueStore edge fast path (#289)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1121.0",
     "@aws-sdk/client-dynamodb": "^3.1121.0",
     "@aws-sdk/lib-dynamodb": "^3.1121.0",
     "@snapurl/contract": "workspace:*",

--- a/apps/worker/src/jobs/dynamo-projection.test.ts
+++ b/apps/worker/src/jobs/dynamo-projection.test.ts
@@ -3,6 +3,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import type { Database } from "@snapurl/database";
 import { DynamoProjection } from "./dynamo-projection.js";
+import type { KvsWriter } from "./kvs-projection.js";
 
 /* MOCK-based unit tests, mirroring packages/cache/dynamodb-cache-store.test.ts.
    No live DynamoDB and no Postgres: the db is a chainable fake whose terminal
@@ -444,5 +445,152 @@ describe("DynamoProjection.apply deduplicates the shared domain-meta item", () =
     // Reaching the transport proves the item marshalled cleanly and the
     // BatchWriteCommand was built (no duplicate-key rejection, no marshal throw).
     await expect(projection.upsert("link-rich")).rejects.toThrow("transport-reached-sentinel");
+  });
+});
+
+describe("DynamoProjection edge fast path (#289) — optional KvsWriter", () => {
+  /* When a KvsWriter is injected, DynamoProjection must ALSO drive the edge
+     fast path: an upsert calls putIfEligible(link, host, slug) and a delete
+     calls deleteKey(host, slug) — after the DynamoDB write. When NO writer is
+     injected it must make ZERO KVS calls, so NoProjection and the non-KVS AWS
+     path stay byte-for-byte unchanged. A spy stands in for the real writer. */
+
+  /** A spy KvsWriter recording every call, structurally a KvsWriter. */
+  function spyWriter() {
+    const putIfEligible = vi.fn(async () => {});
+    const deleteKey = vi.fn(async () => {});
+    return {
+      putIfEligible,
+      deleteKey,
+      writer: { putIfEligible, deleteKey } as unknown as KvsWriter,
+    };
+  }
+
+  it("upsert writes DynamoDB AND drives putIfEligible with the link + host + slug", async () => {
+    const batches: any[] = [];
+    const { client } = makeClient({
+      BatchWriteCommand: (input) => {
+        batches.push(input);
+        return {};
+      },
+    });
+    const kvs = spyWriter();
+    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE, undefined, kvs.writer);
+
+    await projection.upsert("link-1");
+
+    // DynamoDB still written.
+    expect(batches).toHaveLength(1);
+    expect(batches[0].RequestItems[TABLE]).toHaveLength(2);
+    // KVS driven with the projected link and the row's (domain, slug).
+    expect(kvs.putIfEligible).toHaveBeenCalledTimes(1);
+    const [link, host, slug] = kvs.putIfEligible.mock.calls[0] as any[];
+    expect(link.destination).toBe("https://example.com/1");
+    expect(link.redirectType).toBe("302");
+    expect(host).toBe("snap.to");
+    expect(slug).toBe("one");
+    expect(kvs.deleteKey).not.toHaveBeenCalled();
+  });
+
+  it("remove queries the GSI, DeleteItems in DynamoDB AND drives deleteKey with host + slug", async () => {
+    const batches: any[] = [];
+    const { client } = makeClient({
+      QueryCommand: () => ({ Items: [{ PK: "d#snap.to", SK: "s#one", linkId: "link-1" }] }),
+      BatchWriteCommand: (input) => {
+        batches.push(input);
+        return {};
+      },
+    });
+    const kvs = spyWriter();
+    const projection = new DynamoProjection(makeDb([], []), client, TABLE, undefined, kvs.writer);
+
+    await projection.remove("link-1");
+
+    // DynamoDB delete still issued.
+    expect(batches[0].RequestItems[TABLE][0].DeleteRequest.Key).toEqual({
+      PK: "d#snap.to",
+      SK: "s#one",
+    });
+    // KVS deleteKey driven with the host + slug recovered from the item key.
+    expect(kvs.deleteKey).toHaveBeenCalledTimes(1);
+    expect(kvs.deleteKey).toHaveBeenCalledWith("snap.to", "one");
+    expect(kvs.putIfEligible).not.toHaveBeenCalled();
+  });
+
+  it("apply() drives the writer per-op (upsert -> putIfEligible, delete -> deleteKey)", async () => {
+    let call = 0;
+    const upsertRows = [linkRow({ id: "link-up", slug: "up" })];
+    const db = {
+      select: () => {
+        // Even calls: link row for the upsert op; odd: its (empty) rules.
+        const which = call++;
+        const rows = which === 0 ? upsertRows : [];
+        const builder: any = {
+          from: () => builder,
+          innerJoin: () => builder,
+          leftJoin: () => builder,
+          where: () => builder,
+          limit: () => Promise.resolve(rows),
+          orderBy: () => Promise.resolve(rows),
+        };
+        return builder;
+      },
+    } as unknown as Database;
+    const { client } = makeClient({
+      QueryCommand: () => ({ Items: [{ PK: "d#snap.to", SK: "s#del", linkId: "link-del" }] }),
+      BatchWriteCommand: () => ({}),
+    });
+    const kvs = spyWriter();
+    const projection = new DynamoProjection(db, client, TABLE, undefined, kvs.writer);
+
+    const results = await projection.apply([
+      { linkId: "link-up", operation: "upsert" },
+      { linkId: "link-del", operation: "delete" },
+    ]);
+
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(kvs.putIfEligible).toHaveBeenCalledTimes(1);
+    expect(kvs.putIfEligible.mock.calls[0]![1]).toBe("snap.to");
+    expect(kvs.putIfEligible.mock.calls[0]![2]).toBe("up");
+    expect(kvs.deleteKey).toHaveBeenCalledTimes(1);
+    expect(kvs.deleteKey).toHaveBeenCalledWith("snap.to", "del");
+  });
+
+  it("a KVS write failure fails only that op (DynamoDB already written), not the batch", async () => {
+    const { client } = makeClient({
+      BatchWriteCommand: () => ({}),
+    });
+    const kvs = spyWriter();
+    kvs.putIfEligible.mockRejectedValueOnce(new Error("kvs boom"));
+    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE, undefined, kvs.writer);
+
+    const results = await projection.apply([{ linkId: "link-1", operation: "upsert" }]);
+
+    // The op is marked failed so the outbox retries it, even though the
+    // DynamoDB item was written first (durability preserved).
+    expect(results[0]!.ok).toBe(false);
+    expect(String((results[0] as any).error)).toContain("kvs boom");
+  });
+
+  it("makes ZERO KVS calls when no KvsWriter is injected (byte-for-byte unchanged)", async () => {
+    const batches: any[] = [];
+    const { client } = makeClient({
+      QueryCommand: () => ({ Items: [{ PK: "d#snap.to", SK: "s#one", linkId: "link-1" }] }),
+      BatchWriteCommand: (input) => {
+        batches.push(input);
+        return {};
+      },
+    });
+    // No fifth constructor arg — writer is undefined.
+    const projection = new DynamoProjection(makeDb([linkRow()], []), client, TABLE);
+
+    await projection.upsert("link-1");
+    await projection.remove("link-1");
+    await projection.apply([{ linkId: "link-1", operation: "upsert" }]);
+
+    // Only DynamoDB was touched; nothing could have called a non-existent
+    // writer. The assertion here is that the calls above all succeed without a
+    // KvsWriter present (a KVS call would have thrown on undefined).
+    expect(batches.length).toBeGreaterThan(0);
   });
 });

--- a/apps/worker/src/jobs/dynamo-projection.ts
+++ b/apps/worker/src/jobs/dynamo-projection.ts
@@ -22,6 +22,7 @@ import {
   type DynamoDBDocumentClient,
 } from "@aws-sdk/lib-dynamodb";
 import type { ProjectionOp, ProjectionResult, ProjectionTarget } from "./outbox.js";
+import type { KvsWriter } from "./kvs-projection.js";
 
 /* ============================================================
    DynamoProjection — the real projection writer (AWS profile).
@@ -61,6 +62,31 @@ type WriteRequest =
   | { PutRequest: { Item: LinkItem | DomainItem } }
   | { DeleteRequest: { Key: { PK: string; SK: string } } };
 
+/** What an upsert resolves to: the DynamoDB write requests plus, for the #289
+ *  edge fast path, the ProjectedLink and its (host, slug) so the KVS writer can
+ *  PutKey/DeleteKey it. `edge` is undefined when the link no longer exists (the
+ *  requests are then empty too). */
+interface UpsertResolution {
+  requests: WriteRequest[];
+  edge?: { link: ProjectedLink; host: string; slug: string };
+}
+
+/** Recover (host, slug) from a LINK item's DynamoDB key. The projection stores
+ *  PK = 'd#' + normalised host and SK = 's#' + lowercased slug, so stripping
+ *  those prefixes yields exactly the values kvsKey() re-normalises — the KVS
+ *  key derived here matches the one the writer used on the corresponding
+ *  upsert. Domain-meta keys (SK 'd#meta') are not link keys and are skipped. */
+function edgeTargetsOf(requests: WriteRequest[]): Array<{ host: string; slug: string }> {
+  const targets: Array<{ host: string; slug: string }> = [];
+  for (const request of requests) {
+    if (!("DeleteRequest" in request)) continue;
+    const { PK, SK } = request.DeleteRequest.Key;
+    if (!PK.startsWith("d#") || !SK.startsWith("s#")) continue;
+    targets.push({ host: PK.slice(2), slug: SK.slice(2) });
+  }
+  return targets;
+}
+
 /** The minimum a logger must offer so the writer can surface the ACTUAL
  *  DynamoDB error when a batch fails. drainOutbox only records the error's
  *  stringified form in projection_outbox.last_error and counts the failure;
@@ -89,18 +115,37 @@ export class DynamoProjection implements ProjectionTarget {
      *  error (name + message) at error level so a failed projection is never
      *  silent again. */
     private readonly log?: ProjectionLogger,
+    /** Optional CloudFront KeyValueStore writer (#289). Present ONLY on the AWS
+     *  profile when LINK_PROJECTION_KVS_ARN is set; undefined everywhere else,
+     *  so NoProjection and the non-KVS AWS path make ZERO KVS calls and behave
+     *  byte-for-byte as before. When present, each upsert also projects the
+     *  link to the edge fast path (PutKey if edge-eligible, DeleteKey if not)
+     *  and each remove DeleteKeys it. The DynamoDB item is ALWAYS written first
+     *  so a KVS-only failure never loses the authoritative DynamoDB projection;
+     *  a KVS failure then fails the outbox row so the next drain retries it. */
+    private readonly kvs?: KvsWriter,
   ) {}
 
   /* ---- per-row fallback (used when drainOutbox does not batch) ---- */
 
   async upsert(linkId: string): Promise<void> {
-    const requests = await this.buildUpsertRequests(linkId);
-    await this.flush(requests);
+    const resolved = await this.buildUpsertRequests(linkId);
+    // DynamoDB first: the authoritative projection must never be lost to a
+    // KVS-only failure.
+    await this.flush(resolved.requests);
+    if (this.kvs && resolved.edge) {
+      await this.kvs.putIfEligible(resolved.edge.link, resolved.edge.host, resolved.edge.slug);
+    }
   }
 
   async remove(linkId: string): Promise<void> {
     const requests = await this.buildDeleteRequests(linkId);
     await this.flush(requests);
+    if (this.kvs) {
+      for (const { host, slug } of edgeTargetsOf(requests)) {
+        await this.kvs.deleteKey(host, slug);
+      }
+    }
   }
 
   /* ---- batched path (drainOutbox hands the whole claimed batch here) ----
@@ -131,6 +176,12 @@ export class DynamoProjection implements ProjectionTarget {
        contributed that key. */
     const byKey = new Map<string, { request: WriteRequest; owners: Set<number> }>();
 
+    /* Per-op KVS work, keyed by result index, applied ONLY after the op's
+       DynamoDB requests have flushed successfully (DynamoDB first: a KVS-only
+       failure must never lose the authoritative projection). undefined for any
+       op when no KvsWriter is configured, so the non-KVS path is unchanged. */
+    const edgeByIndex = new Map<number, () => Promise<void>>();
+
     for (const op of ops) {
       const index = results.length;
       try {
@@ -145,10 +196,25 @@ export class DynamoProjection implements ProjectionTarget {
            per-key result stitching). Revisit only if bulk deletes become a hot
            path. Upserts take the same per-op read but there is no cheaper bulk
            form for them either (each reads a different link's full row set). */
-        const requests =
-          op.operation === "delete"
-            ? await this.buildDeleteRequests(op.linkId)
-            : await this.buildUpsertRequests(op.linkId);
+        let requests: WriteRequest[];
+        if (op.operation === "delete") {
+          requests = await this.buildDeleteRequests(op.linkId);
+          if (this.kvs) {
+            const targets = edgeTargetsOf(requests);
+            const kvs = this.kvs;
+            edgeByIndex.set(index, async () => {
+              for (const { host, slug } of targets) await kvs.deleteKey(host, slug);
+            });
+          }
+        } else {
+          const resolved = await this.buildUpsertRequests(op.linkId);
+          requests = resolved.requests;
+          if (this.kvs && resolved.edge) {
+            const kvs = this.kvs;
+            const { link, host, slug } = resolved.edge;
+            edgeByIndex.set(index, () => kvs.putIfEligible(link, host, slug));
+          }
+        }
         results.push({ linkId: op.linkId, ok: true });
         for (const request of requests) {
           const key = requestKey(request);
@@ -204,6 +270,27 @@ export class DynamoProjection implements ProjectionTarget {
       }
     }
 
+    /* #289 edge fast path: drive the KVS writer per-op, but ONLY for ops whose
+       DynamoDB write has already succeeded (DynamoDB first — a KVS-only failure
+       must never lose the authoritative projection). A KVS write failure marks
+       that row failed so the outbox retries it on the next drain, exactly as a
+       DynamoDB failure would; it does not touch any other row. No-op when no
+       KvsWriter is configured (edgeByIndex is empty), so the non-KVS path is
+       byte-for-byte unchanged. */
+    for (const [index, run] of edgeByIndex) {
+      const result = results[index]!;
+      if (!result.ok) continue; // DynamoDB write for this op failed; skip KVS.
+      try {
+        await run();
+      } catch (err) {
+        this.log?.error(
+          { err: serialiseError(err), linkId: result.linkId },
+          "projection KVS write failed",
+        );
+        results[index] = { linkId: result.linkId, ok: false, error: err };
+      }
+    }
+
     return results;
   }
 
@@ -213,7 +300,7 @@ export class DynamoProjection implements ProjectionTarget {
    *  LINK put + the domain-meta put. Returns [] if the link no longer exists
    *  (a delete that raced ahead of this upsert) so the row is marked processed
    *  rather than retried forever. */
-  private async buildUpsertRequests(linkId: string): Promise<WriteRequest[]> {
+  private async buildUpsertRequests(linkId: string): Promise<UpsertResolution> {
     const [[row], rules] = await Promise.all([
       this.db
         .select({
@@ -236,7 +323,7 @@ export class DynamoProjection implements ProjectionTarget {
         .orderBy(routingRules.position),
     ]);
 
-    if (!row) return [];
+    if (!row) return { requests: [] };
 
     const projectedLink: ProjectedLink = {
       id: row.link.id,
@@ -283,7 +370,10 @@ export class DynamoProjection implements ProjectionTarget {
     /* The domain-meta item is (re)written alongside every link upsert for that
        domain — the simplest way to keep resolveDomain() current without a
        separate outbox stream, and cheap (one extra put per upsert). */
-    return [{ PutRequest: { Item: linkItem } }, { PutRequest: { Item: domainItem } }];
+    return {
+      requests: [{ PutRequest: { Item: linkItem } }, { PutRequest: { Item: domainItem } }],
+      edge: { link: projectedLink, host: row.domain, slug: row.link.slug },
+    };
   }
 
   /** Query the GSI for the LINK item(s) with this link id and build deletes.

--- a/apps/worker/src/jobs/kvs-projection.test.ts
+++ b/apps/worker/src/jobs/kvs-projection.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CloudFrontKeyValueStoreClient } from "@aws-sdk/client-cloudfront-keyvaluestore";
+import { kvsKey, type ProjectedLink } from "@snapurl/database";
+import { KvsWriter } from "./kvs-projection.js";
+
+/* MOCK-based unit tests, mirroring dynamo-projection.test.ts: the SDK client's
+   send() is stubbed and routed by command constructor name. No live CloudFront
+   KeyValueStore, no network. */
+
+const KVS_ARN = "arn:aws:cloudfront::123456789012:key-value-store/test-store";
+const HOST = "snap.to";
+const SLUG = "foo";
+const ETAG = "ETagVersion1";
+
+function commandName(command: unknown): string {
+  return (command as { constructor: { name: string } }).constructor.name;
+}
+
+/** A plain, edge-eligible link: no password, no rules, no click limit, no time
+ *  gate, not archived, safe-browsing clean. */
+function eligibleLink(overrides: Partial<ProjectedLink> = {}): ProjectedLink {
+  return {
+    id: "link-1",
+    workspaceId: "ws-1",
+    destination: "https://example.com/dest",
+    redirectType: "302",
+    rules: [],
+    expiresAt: null,
+    expiresTo: null,
+    activatesAt: null,
+    scheduledTo: null,
+    clickLimit: null,
+    clicks: 0,
+    hasPassword: false,
+    forwardQuery: true,
+    deepLink: false,
+    hideReferrer: false,
+    publicPreview: true,
+    archived: false,
+    safeBrowsingStatus: "clean",
+    utm: null,
+    ...overrides,
+  };
+}
+
+/** A ConflictException-shaped error (optimistic-concurrency conflict). */
+function conflictError(): Error {
+  const err = new Error("ETag mismatch");
+  err.name = "ConflictException";
+  return err;
+}
+
+function makeClient(handlers: Record<string, (input: any) => unknown>) {
+  const send = vi.fn(async (command: unknown) => {
+    const name = commandName(command);
+    const handler = handlers[name];
+    if (!handler) throw new Error(`unexpected command ${name}`);
+    return handler((command as { input: any }).input);
+  });
+  return { send, client: { send } as unknown as CloudFrontKeyValueStoreClient };
+}
+
+describe("KvsWriter.putIfEligible", () => {
+  it("Describes for the ETag then PutKeys an eligible link with the right Key/Value/IfMatch", async () => {
+    const puts: any[] = [];
+    const { client, send } = makeClient({
+      DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+      PutKeyCommand: (input) => {
+        puts.push(input);
+        return {};
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    await writer.putIfEligible(eligibleLink(), HOST, SLUG);
+
+    // Describe (read ETag) then Put, in that order.
+    expect(send.mock.calls.map((c) => commandName(c[0]))).toEqual([
+      "DescribeKeyValueStoreCommand",
+      "PutKeyCommand",
+    ]);
+    expect(puts).toHaveLength(1);
+    expect(puts[0].KvsARN).toBe(KVS_ARN);
+    expect(puts[0].Key).toBe(kvsKey(HOST, SLUG));
+    expect(puts[0].IfMatch).toBe(ETAG);
+    expect(JSON.parse(puts[0].Value)).toEqual({
+      destination: "https://example.com/dest",
+      redirectType: "302",
+    });
+  });
+
+  /* Every ineligibility axis: an ineligible link must DeleteKey (drop it from
+     the edge), never PutKey — so a link that gains a gate stops being edge
+     served and falls through to the authoritative Lambda. */
+  const ineligible: Array<[string, Partial<ProjectedLink>]> = [
+    ["password", { hasPassword: true }],
+    ["routing rule", { rules: [{ id: "r", when: {}, then: "https://x", weight: 1 } as any] }],
+    ["click limit", { clickLimit: 100 }],
+    ["expiresAt", { expiresAt: new Date("2099-01-01T00:00:00.000Z") }],
+    ["activatesAt", { activatesAt: new Date("2099-01-01T00:00:00.000Z") }],
+    ["archived", { archived: true }],
+    ["unsafe", { safeBrowsingStatus: "malware" }],
+  ];
+
+  for (const [label, overrides] of ineligible) {
+    it(`DeleteKeys (not PutKey) an ineligible link: ${label}`, async () => {
+      const deletes: any[] = [];
+      const { client, send } = makeClient({
+        DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+        DeleteKeyCommand: (input) => {
+          deletes.push(input);
+          return {};
+        },
+      });
+      const writer = new KvsWriter(client, KVS_ARN);
+
+      await writer.putIfEligible(eligibleLink(overrides), HOST, SLUG);
+
+      // No PutKeyCommand was ever issued.
+      expect(send.mock.calls.map((c) => commandName(c[0]))).not.toContain("PutKeyCommand");
+      expect(deletes).toHaveLength(1);
+      expect(deletes[0].KvsARN).toBe(KVS_ARN);
+      expect(deletes[0].Key).toBe(kvsKey(HOST, SLUG));
+      expect(deletes[0].IfMatch).toBe(ETAG);
+    });
+  }
+});
+
+describe("KvsWriter.deleteKey", () => {
+  it("Describes for the ETag then DeleteKeys the derived key", async () => {
+    const deletes: any[] = [];
+    const { client, send } = makeClient({
+      DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+      DeleteKeyCommand: (input) => {
+        deletes.push(input);
+        return {};
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    await writer.deleteKey(HOST, SLUG);
+
+    expect(send.mock.calls.map((c) => commandName(c[0]))).toEqual([
+      "DescribeKeyValueStoreCommand",
+      "DeleteKeyCommand",
+    ]);
+    expect(deletes[0].Key).toBe(kvsKey(HOST, SLUG));
+    expect(deletes[0].IfMatch).toBe(ETAG);
+  });
+});
+
+describe("KvsWriter ETag optimistic-concurrency conflict", () => {
+  it("re-reads the ETag and retries on a ConflictException, then succeeds", async () => {
+    let describeCalls = 0;
+    let putAttempts = 0;
+    const { client, send } = makeClient({
+      DescribeKeyValueStoreCommand: () => {
+        describeCalls++;
+        // A fresh ETag on the second read, proving it re-read.
+        return { ETag: describeCalls === 1 ? "stale" : "fresh" };
+      },
+      PutKeyCommand: (input) => {
+        putAttempts++;
+        if (putAttempts === 1) throw conflictError();
+        return { _ifMatch: input.IfMatch };
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    await writer.putIfEligible(eligibleLink(), HOST, SLUG);
+
+    // Two Describes (initial + re-read) and two Put attempts.
+    expect(describeCalls).toBe(2);
+    expect(putAttempts).toBe(2);
+    // The second Put used the freshly re-read ETag.
+    const lastPut = send.mock.calls
+      .filter((c) => commandName(c[0]) === "PutKeyCommand")
+      .map((c) => (c[0] as any).input)
+      .at(-1);
+    expect(lastPut.IfMatch).toBe("fresh");
+  });
+
+  it("gives up after the bounded attempts and rethrows the conflict", async () => {
+    let putAttempts = 0;
+    const { client } = makeClient({
+      DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+      PutKeyCommand: () => {
+        putAttempts++;
+        throw conflictError();
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    await expect(writer.putIfEligible(eligibleLink(), HOST, SLUG)).rejects.toThrow("ETag mismatch");
+    // Bounded: exactly MAX_ATTEMPTS (3) tries, not an infinite loop.
+    expect(putAttempts).toBe(3);
+  });
+
+  it("does NOT retry a non-conflict error (rethrows immediately)", async () => {
+    let putAttempts = 0;
+    const { client } = makeClient({
+      DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+      PutKeyCommand: () => {
+        putAttempts++;
+        throw new Error("AccessDeniedException");
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    await expect(writer.putIfEligible(eligibleLink(), HOST, SLUG)).rejects.toThrow(
+      "AccessDeniedException",
+    );
+    expect(putAttempts).toBe(1);
+  });
+});

--- a/apps/worker/src/jobs/kvs-projection.test.ts
+++ b/apps/worker/src/jobs/kvs-projection.test.ts
@@ -17,7 +17,9 @@ function commandName(command: unknown): string {
 }
 
 /** A plain, edge-eligible link: no password, no rules, no click limit, no time
- *  gate, not archived, safe-browsing clean. */
+ *  gate, not archived, safe-browsing clean, AND no transform the edge cannot
+ *  reproduce (no forwardQuery, no utm, no deepLink, no hideReferrer) and not a
+ *  301 (whose permanence the edge would not honour). */
 function eligibleLink(overrides: Partial<ProjectedLink> = {}): ProjectedLink {
   return {
     id: "link-1",
@@ -32,7 +34,7 @@ function eligibleLink(overrides: Partial<ProjectedLink> = {}): ProjectedLink {
     clickLimit: null,
     clicks: 0,
     hasPassword: false,
-    forwardQuery: true,
+    forwardQuery: false,
     deepLink: false,
     hideReferrer: false,
     publicPreview: true,
@@ -100,6 +102,14 @@ describe("KvsWriter.putIfEligible", () => {
     ["activatesAt", { activatesAt: new Date("2099-01-01T00:00:00.000Z") }],
     ["archived", { archived: true }],
     ["unsafe", { safeBrowsingStatus: "malware" }],
+    /* Transform behaviours the edge cannot reproduce (each independently makes a
+       link ineligible so it stays on the authoritative Lambda). */
+    ["forwardQuery", { forwardQuery: true }],
+    ["utm", { utm: { source: "print", medium: "qr", campaign: null, content: null } }],
+    ["deepLink", { deepLink: true }],
+    ["hideReferrer", { hideReferrer: true }],
+    /* A 301's permanence would not be honoured at the edge. */
+    ["301", { redirectType: "301" }],
   ];
 
   for (const [label, overrides] of ineligible) {

--- a/apps/worker/src/jobs/kvs-projection.test.ts
+++ b/apps/worker/src/jobs/kvs-projection.test.ts
@@ -18,8 +18,8 @@ function commandName(command: unknown): string {
 
 /** A plain, edge-eligible link: no password, no rules, no click limit, no time
  *  gate, not archived, safe-browsing clean, AND no transform the edge cannot
- *  reproduce (no forwardQuery, no utm, no deepLink, no hideReferrer) and not a
- *  301 (whose permanence the edge would not honour). */
+ *  reproduce (no forwardQuery, no utm, no deepLink, no hideReferrer) and a plain
+ *  302 (301's permanence and 307's exact status the edge would not honour). */
 function eligibleLink(overrides: Partial<ProjectedLink> = {}): ProjectedLink {
   return {
     id: "link-1",
@@ -108,8 +108,11 @@ describe("KvsWriter.putIfEligible", () => {
     ["utm", { utm: { source: "print", medium: "qr", campaign: null, content: null } }],
     ["deepLink", { deepLink: true }],
     ["hideReferrer", { hideReferrer: true }],
-    /* A 301's permanence would not be honoured at the edge. */
+    /* Only a plain 302 is edge-served: a 301's permanence would not be honoured
+       at the edge, and the edge Function cannot emit a 307 exactly (it collapses
+       every non-301 hit to 302), so both fall through to the Lambda. */
     ["301", { redirectType: "301" }],
+    ["307", { redirectType: "307" }],
   ];
 
   for (const [label, overrides] of ineligible) {

--- a/apps/worker/src/jobs/kvs-projection.ts
+++ b/apps/worker/src/jobs/kvs-projection.ts
@@ -1,0 +1,114 @@
+import {
+  DeleteKeyCommand,
+  DescribeKeyValueStoreCommand,
+  PutKeyCommand,
+  type CloudFrontKeyValueStoreClient,
+} from "@aws-sdk/client-cloudfront-keyvaluestore";
+import { isEdgeEligible, kvsKey, kvsValue, type ProjectedLink } from "@snapurl/database";
+
+/* ============================================================
+   KvsWriter — the CloudFront KeyValueStore edge fast path (#289).
+
+   For a plain, unconditional link (no password, no rules, no
+   click limit, no time gate, not archived, safe-browsing clean —
+   see isEdgeEligible in @snapurl/database) the redirect can be
+   answered AT THE EDGE by a CloudFront Function reading a
+   KeyValueStore entry: no Lambda invocation, no DynamoDB read, no
+   VPC round trip. This writer is driven by the SAME outbox drain
+   that writes the DynamoDB projection, so the two stores stay in
+   step: every edge-eligible upsert PutKeys {destination,
+   redirectType}; every ineligible-or-removed link DeleteKeys, so
+   a link that gains a password/rule/limit stops being edge-served
+   and falls back to the authoritative Lambda.
+
+   The key format, eligibility rule and stored value all come from
+   @snapurl/database (kvsKey / isEdgeEligible / kvsValue), the same
+   definitions the CloudFront Function reads against, so the write
+   here and the read there cannot drift.
+
+   Store limits (AWS): 5 MB per store, 1 KB per value. A value is
+   JSON `{destination, redirectType}` — a URL plus a 3-char code,
+   comfortably under 1 KB, so no truncation guard is needed. The
+   store-wide 5 MB cap is a capacity concern, not a per-write one.
+
+   Optimistic concurrency: every KVS write is conditional on the
+   store's current ETag. We DescribeKeyValueStore to read the ETag,
+   pass it as IfMatch, and on a ConflictException (another writer
+   moved the ETag between our read and our write) re-read the ETag
+   and retry, bounded to MAX_ATTEMPTS so a hot store cannot loop
+   forever — the outbox row then fails and is retried on the next
+   drain.
+   ============================================================ */
+
+/** Bounded retries for the ETag optimistic-concurrency conflict. A conflict
+ *  means another writer advanced the store's ETag between our Describe and our
+ *  Put/Delete; we re-read and retry. If we still lose after this many attempts
+ *  we give up and let the outbox row fail so the next drain retries it. */
+const MAX_ATTEMPTS = 3;
+
+/** The SDK error name raised when IfMatch does not match the store's current
+ *  ETag (optimistic-concurrency conflict). */
+const CONFLICT_ERROR = "ConflictException";
+
+function isConflict(err: unknown): boolean {
+  return err instanceof Error && err.name === CONFLICT_ERROR;
+}
+
+export class KvsWriter {
+  constructor(
+    private readonly client: CloudFrontKeyValueStoreClient,
+    private readonly kvsArn: string,
+  ) {}
+
+  /** Project a link to the edge: PutKey when it is edge-eligible, DeleteKey
+   *  otherwise. Called on every upsert, so a link that JUST became ineligible
+   *  (gained a password, a rule, a click limit, an expiry…) is removed from the
+   *  fast path in the same drain that projected the DynamoDB change — the edge
+   *  stops serving it and traffic falls through to the Lambda. */
+  async putIfEligible(link: ProjectedLink, host: string, slug: string): Promise<void> {
+    const key = kvsKey(host, slug);
+    if (isEdgeEligible(link)) {
+      const value = kvsValue(link);
+      await this.withEtag((etag) =>
+        this.client.send(
+          new PutKeyCommand({ KvsARN: this.kvsArn, Key: key, Value: value, IfMatch: etag }),
+        ),
+      );
+    } else {
+      await this.deleteByKey(key);
+    }
+  }
+
+  /** Remove a link from the edge fast path (a delete op). */
+  async deleteKey(host: string, slug: string): Promise<void> {
+    await this.deleteByKey(kvsKey(host, slug));
+  }
+
+  private async deleteByKey(key: string): Promise<void> {
+    await this.withEtag((etag) =>
+      this.client.send(new DeleteKeyCommand({ KvsARN: this.kvsArn, Key: key, IfMatch: etag })),
+    );
+  }
+
+  /** Read the store's current ETag, run the conditional write with it as
+   *  IfMatch, and on an optimistic-concurrency conflict re-read the ETag and
+   *  retry — bounded to MAX_ATTEMPTS. Any non-conflict error (or the final
+   *  conflict) propagates so the outbox marks the row failed and retries it. */
+  private async withEtag(write: (etag: string) => Promise<unknown>): Promise<void> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      const { ETag } = await this.client.send(
+        new DescribeKeyValueStoreCommand({ KvsARN: this.kvsArn }),
+      );
+      try {
+        await write(ETag ?? "");
+        return;
+      } catch (err) {
+        if (!isConflict(err)) throw err;
+        // Stale ETag: another writer moved it. Re-read and retry.
+        lastErr = err;
+      }
+    }
+    throw lastErr;
+  }
+}

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,10 +1,12 @@
 import pino from "pino";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { CloudFrontKeyValueStoreClient } from "@aws-sdk/client-cloudfront-keyvaluestore";
 import { createDatabase, resolveDatabaseUrl, type Database } from "@snapurl/database";
 import { ensureClickPartitions, pruneRetention, rollupClicks, rotateSalts } from "./jobs/rollup.js";
 import { NoProjection, drainOutbox, pruneOutbox, stuckProjections, sweepExpired, type ProjectionTarget } from "./jobs/outbox.js";
 import { DynamoProjection } from "./jobs/dynamo-projection.js";
+import { KvsWriter } from "./jobs/kvs-projection.js";
 import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
 
 /* ============================================================
@@ -101,6 +103,19 @@ function dynamoEndpoint(): string | undefined {
   return process.env.AWS_ENDPOINT_URL_DYNAMODB ?? process.env.AWS_ENDPOINT_URL ?? undefined;
 }
 
+/* The same endpoint-override pattern as dynamoEndpoint(), for the CloudFront
+   KeyValueStore client (#289 edge fast path). Unset in production so the SDK
+   resolves the real (global) cloudfront-keyvaluestore endpoint;
+   AWS_ENDPOINT_URL_CLOUDFRONT_KEYVALUESTORE (or the generic AWS_ENDPOINT_URL)
+   points it at a stub in CI. Both unset returns undefined, a genuine no-op. */
+function kvsEndpoint(): string | undefined {
+  return (
+    process.env.AWS_ENDPOINT_URL_CLOUDFRONT_KEYVALUESTORE ??
+    process.env.AWS_ENDPOINT_URL ??
+    undefined
+  );
+}
+
 function projectionFor(database: Database): ProjectionTarget {
   if (!projectionTarget) {
     if (LINK_PROJECTION === "dynamo") {
@@ -126,13 +141,32 @@ function projectionFor(database: Database): ProjectionTarget {
         new DynamoDBClient({ region: process.env.AWS_REGION, endpoint: dynamoEndpoint() }),
         { marshallOptions: { removeUndefinedValues: true } },
       );
+      /* #289 edge fast path: OPT-IN. Only when LINK_PROJECTION_KVS_ARN is set do
+         we construct a CloudFront KeyValueStore client and a KvsWriter and hand
+         it to the DynamoProjection, so each edge-eligible upsert ALSO PutKeys
+         {destination, redirectType} into the store the CloudFront Function
+         reads, and each ineligible-or-removed link DeleteKeys it. When the env
+         is UNSET the writer is undefined and behaviour is exactly as today: the
+         DynamoDB projection still writes; nothing touches KVS. The client uses
+         the standard AWS_REGION and the same optional endpoint-override pattern
+         as the DynamoDB client (for CI/local). */
+      const kvsArn = process.env.LINK_PROJECTION_KVS_ARN;
+      const kvsWriter = kvsArn
+        ? new KvsWriter(
+            new CloudFrontKeyValueStoreClient({
+              region: process.env.AWS_REGION,
+              endpoint: kvsEndpoint(),
+            }),
+            kvsArn,
+          )
+        : undefined;
       /* Pass the worker's logger so a projection resolve/write failure surfaces
          the ACTUAL error (DynamoDB ValidationException name + message) at error
          level. drainOutbox only stores String(err) in projection_outbox
          .last_error and counts the failure, so before this the real cause never
          reached a log line — a projection that wrote nothing looked silent even
          at LOG_LEVEL=debug. */
-      projectionTarget = new DynamoProjection(database, client, table, log);
+      projectionTarget = new DynamoProjection(database, client, table, log, kvsWriter);
     } else {
       projectionTarget = new NoProjection();
     }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -730,6 +730,88 @@ been exercised:
 conditional-write cap on the item is the DynamoDB move), or if the salt race matters
 enough to warrant an atomic first-write primitive on the `CacheStore` port.
 
+### Profile 3: the CloudFront Function + KeyValueStore edge fast path
+
+**Built by #289 (Phase 7 of #267, the last thing in the epic):** for the majority of
+links that are simple — no password, no routing rules, no click limit, not expired, not
+scheduled — the redirect is now answered **at the edge with no origin fetch at all**: no
+Lambda invocation, no DynamoDB, no VPC. Expected p50 in India ~10-20 ms against ~245 ms
+today. The viewer-request CloudFront Function (JS_2_0), which already copied Host into
+`x-forwarded-host` for #274, now also reads a per-link CloudFront KeyValueStore entry and
+returns the 302/301 itself. It falls through to the Lambda origin unchanged for anything
+it cannot answer, so correctness never depends on the fast path being complete.
+
+**The design.** A KVS entry `{ destination, redirectType }` per edge-eligible link, keyed
+`<host>/<slug>` (both lowercased — the `edgeKey`/`kvsKey` invariant shared with
+`@snapurl/database`), written by the **same outbox drain** that writes the DynamoDB
+projection (which is why 3a had to come first): each edge-eligible upsert also `PutKey`s
+the entry, each ineligible-or-removed link `DeleteKey`s it. The store limits — 5 MB per
+store, 1 KB per value — fit a `{destination, redirectType}` JSON comfortably. The Function
+guards conservatively before it looks anything up: only a bare `GET` of a single
+non-empty path segment, no `?k=` unlock token, no trailing `+` trust-preview convention;
+anything else, plus any KVS miss or error, returns the request unchanged so CloudFront
+forwards it to the authoritative Lambda origin. A link is **edge-eligible** only when it
+is a plain unconditional redirect (no password, no rules, no click limit, no expiry, no
+activation, not archived, Safe-Browsing clean) — the edge cannot reliably evaluate time
+or conditions, so the safest rule is to keep everything else on the Lambda.
+
+**The blocking decision — click accounting for edge-served redirects. Chose (c).** A
+redirect served at the edge never reaches the click pipeline, and the three ways to
+recover the click were:
+
+| Option | What it is | Why not |
+| --- | --- | --- |
+| (a) CloudFront real-time logs to Kinesis | Full parity with the existing click pipeline | Kinesis is ~$11/month for a single shard — most of the remaining budget on a $100-credit stack |
+| (b) Standard access logs to S3, batch-ingested by the worker | Nearly free (the S3 gateway endpoint already exists) | Delayed by minutes, and it forces parsing IPs out of log lines — which **throws away the salted-hash design** that makes the cookieless privacy promise real |
+| **(c) Only edge-serve links where per-click accuracy does not matter** (chosen) | Keep the Lambda authoritative for anything with a click limit or an analytics commitment; edge-serve the rest | Smaller latency win, but it is the only option that neither blows the budget nor undoes the privacy design, and the win still applies to the majority of links |
+
+(c) is why the edge-eligibility rule excludes click-limited links: a click limit needs the
+authoritative per-click count the Lambda path maintains, and analytics-critical links keep
+their salted-hash accounting on the Lambda. The Lambda stays authoritative for the rest;
+the edge is a pure latency optimisation over the simple-link majority.
+
+**`CACHING_DISABLED` → a 1-5s edge TTL.** The reasoning behind disabling the cache was
+right — a cached 302 makes a destination edit invisible — but the setting was over-broad.
+The layer that actually protects "print it once, change where it points forever" is
+`cacheHeadersFor()` in `packages/domain/src/destination.ts`, which already sends
+`no-store` to the **browser**, so no visitor ever caches a stale redirect regardless of
+the edge. A `defaultTtl` of 1s (min 0s, max 5s) on the RedirectCdn default behavior keeps
+edits effectively instant — well under a printed QR's reaction time — while absorbing
+QR-scan and burst storms that would otherwise each hit the fall-through Lambda origin. The
+TTL only helps the **fall-through** path: the viewer-request Function answers simple links
+from KVS *before* the cache is consulted, so the fast path is separate. The cache key
+includes the query string (`CacheQueryStringBehavior.all()`) so the `?k=` unlock token and
+the UTM / forwardQuery overrides key distinct entries — dropping it would let one visitor's
+unlock/UTM response be served to the next.
+
+**Reachability — verified before building, not during.** `cloudfront-keyvaluestore` is a
+**global public API** with no PrivateLink / interface VPC endpoint (only the free S3 and
+DynamoDB gateway endpoints exist in this VPC). The worker writes the store, and under the
+default `natStrategy = 'instance'` (and `'gateway'`) the worker Lambda sits in
+`PRIVATE_WITH_EGRESS` subnets whose default route is the NAT, so it reaches the public KVS
+endpoint over the internet — the same egress path Safe Browsing, webhooks and mail already
+use. Under `natStrategy = 'none'` the worker is isolated with no egress, so the KVS writer
+cannot reach the API — but that is the *same* limitation those other egress-dependent
+features already carry, and the writer is **opt-in**: it is constructed only when
+`LINK_PROJECTION_KVS_ARN` is set (which the stack sets on `workerFn` only, granting the
+three `cloudfront-keyvaluestore` data-plane actions scoped to the store's ARN). The
+Function *reads* the store at the edge via its CloudFront association, which is never in a
+VPC, so the read path is unaffected by `natStrategy`.
+
+**CI-proven vs deploy-deferred.** The decision logic (`decide`/`edgeKey`) is unit-tested
+against an injectable `kvsGet` — hit, miss, error, and every guard — and a drift-guard
+test asserts the deployed `.js` and the tested `.logic.mjs` twin are byte-for-byte
+identical in the guarded region, so the tested logic is provably the deployed logic. The
+CDK shape (the `AWS::CloudFront::KeyValueStore`, the Function↔KVS association, the worker
+IAM grant, `LINK_PROJECTION_KVS_ARN` on the worker, the short-TTL cache policy) is
+synth-proven. A real edge invocation and a real KVS round trip are **deploy-deferred** —
+CloudFront Functions and KeyValueStores cannot run in CI or the sandbox.
+
+**Revisit if** per-click accuracy on edge-served links ever becomes worth paying for
+(option (a) or (b), with the privacy cost of (b) understood), or if the eligibility rule
+proves too conservative and a time-bounded link could be safely edge-served with a
+carefully evaluated TTL.
+
 ---
 
 ## Part 5 — Open questions for you

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -738,7 +738,7 @@ scheduled — the redirect is now answered **at the edge with no origin fetch at
 Lambda invocation, no DynamoDB, no VPC. Expected p50 in India ~10-20 ms against ~245 ms
 today. The viewer-request CloudFront Function (JS_2_0), which already copied Host into
 `x-forwarded-host` for #274, now also reads a per-link CloudFront KeyValueStore entry and
-returns the 302/301 itself. It falls through to the Lambda origin unchanged for anything
+returns the 302 itself. It falls through to the Lambda origin unchanged for anything
 it cannot answer, so correctness never depends on the fast path being complete.
 
 **The design.** A KVS entry `{ destination, redirectType }` per edge-eligible link, keyed
@@ -765,14 +765,18 @@ hold:
   Lambda sets `Referrer-Policy: no-referrer`). The edge returns only the raw stored
   destination, so serving any of these at the edge would drop query forwarding, campaign
   params, Android deep-linking, or the no-referrer header the author asked for;
-- a **301**: `cacheHeadersFor("301")` honours the author's chosen permanence with
-  `public, max-age=300`, whereas the edge answers every hit with `no-store`. Rather than
-  special-case the Function, only 302/307 are edge-served and a 301 stays on the Lambda so
-  its permanence is honoured.
+- a **non-302 redirect type**: only plain **302** links are edge-served; **301** and
+  **307** stay on the authoritative Lambda. A 301's permanence is honoured on the Lambda
+  with `public, max-age=300` (`cacheHeadersFor("301")`), whereas the edge answers every
+  hit with `no-store`. A 307's *exact* status the edge Function cannot emit — its status
+  mapping collapses every non-301 hit to 302 (`parsed.redirectType === "301" ? 301 :
+  302`), so an edge-served 307 would answer HTTP 302 where the Lambda answers HTTP 307 (via
+  `REDIRECT_STATUS`). Rather than special-case the Function, both 301 and 307 fall through
+  to the authoritative Lambda.
 
 Because the edge cannot reproduce the Lambda's query-forwarding, UTM injection,
-deep-linking, referrer suppression, or 301 permanence, those links stay authoritative on
-the Lambda; keeping everything else there too is the safest rule.
+deep-linking, referrer suppression, 301 permanence, or a 307's exact status, those links
+stay authoritative on the Lambda; keeping everything else there too is the safest rule.
 
 **The blocking decision — click accounting for edge-served redirects. Chose (c).** A
 redirect served at the edge never reaches the click pipeline, and the three ways to

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -751,9 +751,28 @@ guards conservatively before it looks anything up: only a bare `GET` of a single
 non-empty path segment, no `?k=` unlock token, no trailing `+` trust-preview convention;
 anything else, plus any KVS miss or error, returns the request unchanged so CloudFront
 forwards it to the authoritative Lambda origin. A link is **edge-eligible** only when it
-is a plain unconditional redirect (no password, no rules, no click limit, no expiry, no
-activation, not archived, Safe-Browsing clean) — the edge cannot reliably evaluate time
-or conditions, so the safest rule is to keep everything else on the Lambda.
+is a plain unconditional redirect that the edge can answer exactly the way the Lambda
+would. It is **edge-INELIGIBLE** (kept on the authoritative Lambda) when *any* of these
+hold:
+
+- a **blocking gate** the edge cannot evaluate: a password, routing rules, a click limit,
+  an expiry, an activation time, archived, or a non-`clean` Safe-Browsing status — the
+  edge cannot reliably evaluate time or conditions;
+- a **transform** the Lambda applies on the happy path and the edge cannot reproduce:
+  `forwardQuery` (the Lambda merges the incoming query via `buildDestination`), a non-null
+  `utm` (the Lambda injects the stored campaign params), `deepLink` (the Lambda rewrites
+  Android destinations into `intent://…` via `buildDeepLink`), or `hideReferrer` (the
+  Lambda sets `Referrer-Policy: no-referrer`). The edge returns only the raw stored
+  destination, so serving any of these at the edge would drop query forwarding, campaign
+  params, Android deep-linking, or the no-referrer header the author asked for;
+- a **301**: `cacheHeadersFor("301")` honours the author's chosen permanence with
+  `public, max-age=300`, whereas the edge answers every hit with `no-store`. Rather than
+  special-case the Function, only 302/307 are edge-served and a 301 stays on the Lambda so
+  its permanence is honoured.
+
+Because the edge cannot reproduce the Lambda's query-forwarding, UTM injection,
+deep-linking, referrer suppression, or 301 permanence, those links stay authoritative on
+the Lambda; keeping everything else there too is the safest rule.
 
 **The blocking decision — click accounting for edge-served redirects. Chose (c).** A
 redirect served at the edge never reaches the click pipeline, and the three ways to

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -2,3 +2,8 @@ cdk.out/
 *.js
 !bin/*.ts
 !lib/*.ts
+# The CloudFront Function source (#289) is hand-written JS the CDK inlines,
+# not compiled output — keep it tracked. Its testable twin (.mjs) is not
+# matched by *.js, but list it here alongside for clarity.
+!functions/*.js
+!functions/*.mjs

--- a/infra/functions/redirect-viewer-request.js
+++ b/infra/functions/redirect-viewer-request.js
@@ -119,4 +119,12 @@ async function handler(event) {
   });
 }
 
-export { handler, decide, edgeKey };
+/*
+ * CloudFront Functions (JS_2_0) expect the module to export exactly the entry
+ * point `handler`. `decide` and `edgeKey` are deliberately NOT exported here —
+ * they are exercised through the byte-for-byte twin in
+ * redirect-viewer-request.logic.mjs (the DRIFT-GUARDED REGION above is what the
+ * test asserts is identical), so the deployed file stays a minimal, valid
+ * CloudFront Function while the logic remains fully unit-tested.
+ */
+export { handler };

--- a/infra/functions/redirect-viewer-request.js
+++ b/infra/functions/redirect-viewer-request.js
@@ -1,0 +1,122 @@
+/* eslint-disable */
+/*
+ * RedirectViewerRequest — CloudFront viewer-request function (runtime JS_2_0).
+ *
+ * Two jobs, in order:
+ *
+ *   1. x-forwarded-host (#274). The origin is a Lambda Function URL, which
+ *      rejects any request whose Host is not its own, so CloudFront pins Host
+ *      to the origin and this function copies the viewer's Host into
+ *      x-forwarded-host for the redirect app to read. This MUST happen on every
+ *      path, including the fall-through, or the Lambda cannot resolve the
+ *      viewer's domain.
+ *
+ *   2. The KeyValueStore edge fast path (#289). For a plain, unconditional
+ *      link, the worker writes a KVS entry `{ destination, redirectType }` keyed
+ *      by `<host>/<slug>` (see kvsKey in @snapurl/database/link-projection). If
+ *      this is a bare GET of a single slug and the KVS has a matching entry, the
+ *      function returns the redirect itself — no Lambda invocation, no DynamoDB,
+ *      no VPC. Anything it cannot answer (any failed guard, a KVS miss, or any
+ *      error) returns the request unchanged so CloudFront forwards it to the
+ *      Lambda origin, which stays authoritative.
+ *
+ * Testability: CloudFront's global `cloudfront` module is runtime-only and
+ * cannot be imported by vitest. The decision logic therefore lives in a pure
+ * `decide(event, kvsGet)` that takes an injectable KVS getter; `handler`
+ * supplies the real `cf.kvs().get`. Because the `import cf from "cloudfront"`
+ * above cannot be resolved by vitest, the test imports an identical twin of
+ * `decide`/`edgeKey` from redirect-viewer-request.logic.mjs and asserts the two
+ * are byte-for-byte identical (the DRIFT-GUARDED REGION below), so the tested
+ * logic is provably the deployed logic.
+ *
+ * NOTE: keep this file small and dependency-free — CloudFront Functions have
+ * tight CPU and size limits, and only a subset of JS is available.
+ */
+
+import cf from "cloudfront";
+
+/*
+ * The KVS key for a viewer host + slug MUST match kvsKey() in
+ * @snapurl/database/src/link-projection.ts byte-for-byte: `<host>/<slug>`, host
+ * lowercased (normaliseHost also trims, but a Host header carries no
+ * surrounding whitespace), slug lowercased.
+ *
+ * `decide` is the pure decision logic: returns either a redirect response
+ * object (KVS hit) or the (mutated: x-forwarded-host set) request to forward to
+ * the origin. `kvsGet` is async (key) => string, throwing on miss or error.
+ */
+// --- DRIFT-GUARDED REGION START (must match redirect-viewer-request.logic.mjs) ---
+function edgeKey(host, slug) {
+  return host.toLowerCase() + "/" + slug.toLowerCase();
+}
+
+async function decide(event, kvsGet) {
+  var request = event.request;
+
+  /* (1) x-forwarded-host on EVERY path, before any short-circuit. */
+  if (request.headers.host && request.headers.host.value) {
+    request.headers["x-forwarded-host"] = { value: request.headers.host.value };
+  }
+
+  /* (2) Guards — mirror apps/redirect/src/main.ts conservatively. Only a bare
+     GET of a single slug is eligible; anything else falls through. */
+
+  // Method: GET only (OPTIONS/HEAD/POST fall through).
+  if (request.method !== "GET") return request;
+
+  // The unlock token rides ?k=. Its presence means a password flow — fall
+  // through so the Lambda can validate it.
+  if (request.querystring && Object.prototype.hasOwnProperty.call(request.querystring, "k")) {
+    return request;
+  }
+
+  // Path must be exactly one non-empty segment: "/slug". Reject the root "/",
+  // and reject multi-segment paths ("/a/b").
+  var uri = request.uri || "";
+  if (uri.charAt(0) !== "/") return request;
+  var rest = uri.slice(1);
+  if (rest.length === 0) return request; // root
+  if (rest.indexOf("/") !== -1) return request; // multi-segment
+
+  var slug = rest;
+
+  // The "+" trust-preview convention (WEB_ORIGIN/p/...) is a Lambda concern.
+  if (slug.charAt(slug.length - 1) === "+") return request;
+
+  // Host is required to build the key.
+  if (!request.headers.host || !request.headers.host.value) return request;
+  var host = request.headers.host.value;
+
+  var key = edgeKey(host, slug);
+
+  /* (3) KVS lookup. Any miss or error falls through to the origin. */
+  try {
+    var raw = await kvsGet(key);
+    if (!raw) return request;
+    var parsed = JSON.parse(raw);
+    if (!parsed || !parsed.destination) return request;
+
+    var statusCode = parsed.redirectType === "301" ? 301 : 302;
+    return {
+      statusCode: statusCode,
+      statusDescription: statusCode === 301 ? "Moved Permanently" : "Found",
+      headers: {
+        location: { value: parsed.destination },
+        // Match the app's cacheHeadersFor(): never let a browser cache a
+        // redirect, so "change where it points forever" holds.
+        "cache-control": { value: "no-store, no-cache, must-revalidate" },
+      },
+    };
+  } catch (e) {
+    return request;
+  }
+}
+// --- DRIFT-GUARDED REGION END ---
+
+async function handler(event) {
+  return decide(event, function (key) {
+    return cf.kvs().get(key);
+  });
+}
+
+export { handler, decide, edgeKey };

--- a/infra/functions/redirect-viewer-request.logic.mjs
+++ b/infra/functions/redirect-viewer-request.logic.mjs
@@ -1,0 +1,86 @@
+/*
+ * Testable twin of the RedirectViewerRequest CloudFront Function's decision
+ * logic (#289). See redirect-viewer-request.js for the full contract.
+ *
+ * WHY A SEPARATE FILE: the runtime function does `import cf from "cloudfront"`,
+ * a module that only exists inside the CloudFront Functions runtime and cannot
+ * be resolved by vitest. This file carries the SAME `edgeKey` and `decide`
+ * (byte-for-byte, minus the `cf.kvs()` wiring which lives only in the runtime
+ * `handler`) so the pure decision logic is unit-testable with an injectable
+ * `kvsGet`. redirect-viewer-request.test.ts imports `decide`/`edgeKey` from
+ * here AND asserts these two functions are identical to the ones in the runtime
+ * file — that test is the guard against the twins drifting apart.
+ *
+ * The `edgeKey` format MUST match kvsKey() in
+ * @snapurl/database/src/link-projection.ts: `<host>/<slug>`, both lowercased.
+ */
+
+// --- DRIFT-GUARDED REGION START (must match redirect-viewer-request.js) ---
+function edgeKey(host, slug) {
+  return host.toLowerCase() + "/" + slug.toLowerCase();
+}
+
+async function decide(event, kvsGet) {
+  var request = event.request;
+
+  /* (1) x-forwarded-host on EVERY path, before any short-circuit. */
+  if (request.headers.host && request.headers.host.value) {
+    request.headers["x-forwarded-host"] = { value: request.headers.host.value };
+  }
+
+  /* (2) Guards — mirror apps/redirect/src/main.ts conservatively. Only a bare
+     GET of a single slug is eligible; anything else falls through. */
+
+  // Method: GET only (OPTIONS/HEAD/POST fall through).
+  if (request.method !== "GET") return request;
+
+  // The unlock token rides ?k=. Its presence means a password flow — fall
+  // through so the Lambda can validate it.
+  if (request.querystring && Object.prototype.hasOwnProperty.call(request.querystring, "k")) {
+    return request;
+  }
+
+  // Path must be exactly one non-empty segment: "/slug". Reject the root "/",
+  // and reject multi-segment paths ("/a/b").
+  var uri = request.uri || "";
+  if (uri.charAt(0) !== "/") return request;
+  var rest = uri.slice(1);
+  if (rest.length === 0) return request; // root
+  if (rest.indexOf("/") !== -1) return request; // multi-segment
+
+  var slug = rest;
+
+  // The "+" trust-preview convention (WEB_ORIGIN/p/...) is a Lambda concern.
+  if (slug.charAt(slug.length - 1) === "+") return request;
+
+  // Host is required to build the key.
+  if (!request.headers.host || !request.headers.host.value) return request;
+  var host = request.headers.host.value;
+
+  var key = edgeKey(host, slug);
+
+  /* (3) KVS lookup. Any miss or error falls through to the origin. */
+  try {
+    var raw = await kvsGet(key);
+    if (!raw) return request;
+    var parsed = JSON.parse(raw);
+    if (!parsed || !parsed.destination) return request;
+
+    var statusCode = parsed.redirectType === "301" ? 301 : 302;
+    return {
+      statusCode: statusCode,
+      statusDescription: statusCode === 301 ? "Moved Permanently" : "Found",
+      headers: {
+        location: { value: parsed.destination },
+        // Match the app's cacheHeadersFor(): never let a browser cache a
+        // redirect, so "change where it points forever" holds.
+        "cache-control": { value: "no-store, no-cache, must-revalidate" },
+      },
+    };
+  } catch (e) {
+    return request;
+  }
+}
+// --- DRIFT-GUARDED REGION END ---
+
+export { decide, edgeKey };

--- a/infra/functions/redirect-viewer-request.test.ts
+++ b/infra/functions/redirect-viewer-request.test.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { kvsKey } from "@snapurl/database";
+import { decide, edgeKey } from "./redirect-viewer-request.logic.mjs";
+
+/*
+ * Unit tests for the RedirectViewerRequest CloudFront Function decision logic
+ * (#289). The runtime function imports the global `cloudfront` module, which
+ * vitest cannot resolve, so these exercise the identical twin in
+ * redirect-viewer-request.logic.mjs and separately assert the twin has not
+ * drifted from the deployed .js.
+ */
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+
+/** Build a minimal CloudFront viewer-request event. */
+function eventFor(
+  opts: {
+    method?: string;
+    uri?: string;
+    host?: string | null;
+    querystring?: Record<string, unknown>;
+  } = {},
+) {
+  const headers: Record<string, { value: string }> = {};
+  if (opts.host !== null) headers.host = { value: opts.host ?? "snap.to" };
+  return {
+    request: {
+      method: opts.method ?? "GET",
+      uri: opts.uri ?? "/foo",
+      querystring: opts.querystring ?? {},
+      headers,
+    },
+  };
+}
+
+function isRedirect(result: unknown): result is { statusCode: number; headers: Record<string, { value: string }> } {
+  return typeof result === "object" && result !== null && "statusCode" in result;
+}
+
+describe("edgeKey matches @snapurl/database kvsKey", () => {
+  it("produces the identical key format the writer uses", () => {
+    // The Function has to rebuild the writer's key from the viewer host + path
+    // with no shared code, so this is the single most important invariant.
+    expect(edgeKey("SNAP.TO", "Foo")).toBe(kvsKey("SNAP.TO", "Foo"));
+    expect(edgeKey("snap.to", "bar")).toBe(kvsKey("snap.to", "bar"));
+    expect(edgeKey("Example.COM", "MixedCase")).toBe(kvsKey("Example.COM", "MixedCase"));
+  });
+});
+
+describe("decide — KVS hit", () => {
+  it("returns a 302 redirect to the stored destination on a bare GET slug", async () => {
+    const kvsGet = vi.fn().mockResolvedValue(JSON.stringify({ destination: "https://dest.example/x", redirectType: "302" }));
+    const event = eventFor({ uri: "/foo", host: "snap.to" });
+
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).toHaveBeenCalledOnce();
+    expect(kvsGet).toHaveBeenCalledWith("snap.to/foo");
+    expect(isRedirect(result)).toBe(true);
+    if (!isRedirect(result)) throw new Error("expected redirect");
+    expect(result.statusCode).toBe(302);
+    expect(result.headers.location.value).toBe("https://dest.example/x");
+    expect(result.headers["cache-control"].value).toContain("no-store");
+    // x-forwarded-host is still set on the (unused) request too — the header
+    // mutation happens before the short-circuit.
+    expect(event.request.headers["x-forwarded-host"].value).toBe("snap.to");
+  });
+
+  it("yields statusCode 301 when redirectType is '301'", async () => {
+    const kvsGet = vi.fn().mockResolvedValue(JSON.stringify({ destination: "https://dest.example/perm", redirectType: "301" }));
+    const result = await decide(eventFor(), kvsGet);
+
+    expect(isRedirect(result)).toBe(true);
+    if (!isRedirect(result)) throw new Error("expected redirect");
+    expect(result.statusCode).toBe(301);
+    expect(result.statusDescription).toBe("Moved Permanently");
+  });
+
+  it("lowercases host and slug into the key", async () => {
+    const kvsGet = vi.fn().mockResolvedValue(JSON.stringify({ destination: "https://d/x", redirectType: "302" }));
+    await decide(eventFor({ uri: "/Foo", host: "SNAP.TO" }), kvsGet);
+    expect(kvsGet).toHaveBeenCalledWith("snap.to/foo");
+  });
+});
+
+describe("decide — miss / error fall-through (request returned unchanged, x-forwarded-host set)", () => {
+  it("returns the request unchanged on a KVS miss (getter resolves empty)", async () => {
+    const kvsGet = vi.fn().mockResolvedValue(undefined);
+    const event = eventFor();
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).toHaveBeenCalledOnce();
+    expect(result).toBe(event.request);
+    expect(event.request.headers["x-forwarded-host"].value).toBe("snap.to");
+  });
+
+  it("returns the request unchanged when the getter throws (KVS error)", async () => {
+    const kvsGet = vi.fn().mockRejectedValue(new Error("KeyNotFound"));
+    const event = eventFor();
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).toHaveBeenCalledOnce();
+    expect(result).toBe(event.request);
+    expect(event.request.headers["x-forwarded-host"].value).toBe("snap.to");
+  });
+
+  it("returns the request unchanged when the stored value is not valid JSON", async () => {
+    const kvsGet = vi.fn().mockResolvedValue("not-json");
+    const event = eventFor();
+    const result = await decide(event, kvsGet);
+    expect(result).toBe(event.request);
+  });
+});
+
+describe("decide — guarded paths fall through WITHOUT calling kvs.get", () => {
+  it("a slug ending in '+' (trust preview) falls through", async () => {
+    const kvsGet = vi.fn();
+    const event = eventFor({ uri: "/foo+" });
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).not.toHaveBeenCalled();
+    expect(result).toBe(event.request);
+    expect(event.request.headers["x-forwarded-host"].value).toBe("snap.to");
+  });
+
+  it("a '?k=' unlock token falls through", async () => {
+    const kvsGet = vi.fn();
+    const event = eventFor({ querystring: { k: { value: "token" } } });
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).not.toHaveBeenCalled();
+    expect(result).toBe(event.request);
+  });
+
+  it("the root path '/' falls through", async () => {
+    const kvsGet = vi.fn();
+    const event = eventFor({ uri: "/" });
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).not.toHaveBeenCalled();
+    expect(result).toBe(event.request);
+  });
+
+  it("a multi-segment path falls through", async () => {
+    const kvsGet = vi.fn();
+    const event = eventFor({ uri: "/a/b" });
+    const result = await decide(event, kvsGet);
+
+    expect(kvsGet).not.toHaveBeenCalled();
+    expect(result).toBe(event.request);
+  });
+
+  it("a non-GET method falls through", async () => {
+    const kvsGet = vi.fn();
+    for (const method of ["OPTIONS", "HEAD", "POST"]) {
+      const event = eventFor({ method });
+      const result = await decide(event, kvsGet);
+      expect(result).toBe(event.request);
+    }
+    expect(kvsGet).not.toHaveBeenCalled();
+  });
+
+  it("still sets x-forwarded-host on a guarded fall-through", async () => {
+    const kvsGet = vi.fn();
+    const event = eventFor({ uri: "/", host: "vanity.example" });
+    await decide(event, kvsGet);
+    expect(event.request.headers["x-forwarded-host"].value).toBe("vanity.example");
+  });
+});
+
+describe("drift guard: the tested twin equals the deployed function", () => {
+  it("the DRIFT-GUARDED REGION is byte-for-byte identical in both files", () => {
+    const runtime = readFileSync(new URL("redirect-viewer-request.js", `file://${here}`), "utf8");
+    const twin = readFileSync(new URL("redirect-viewer-request.logic.mjs", `file://${here}`), "utf8");
+
+    const region = (src: string) => {
+      const start = src.indexOf("--- DRIFT-GUARDED REGION START");
+      const end = src.indexOf("--- DRIFT-GUARDED REGION END");
+      expect(start).toBeGreaterThan(-1);
+      expect(end).toBeGreaterThan(start);
+      // Drop the marker line itself (its trailing comment differs by filename),
+      // keep only the function bodies between the two markers.
+      const body = src.slice(src.indexOf("\n", start) + 1, end);
+      return body.trim();
+    };
+
+    expect(region(twin)).toBe(region(runtime));
+  });
+});

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -773,20 +773,25 @@ export class SnapUrlStack extends Stack {
        x-forwarded-host, which the origin request policy below forwards while
        leaving Host alone. apps/redirect/src/main.ts reads exactly that header.
 
-       It is a named, standalone function on purpose: Phase 7 (#289) extends
-       this same function with the KeyValueStore edge fast path. */
+       It is a named, standalone function on purpose: Phase 7 (#289) now extends
+       this same function with the KeyValueStore edge fast path — for a bare GET
+       of a simple link the function answers the 302 itself from a KVS entry the
+       worker writes, with no Lambda invocation, no DynamoDB and no VPC; anything
+       it cannot answer falls through to the origin unchanged. The source is the
+       tested/extended file in infra/functions (fromFile, so the deployed source
+       is the unit-tested source, not a divergent inline copy), and it reads the
+       RedirectLinkKvs store associated below. */
+    const linkKvs = new cloudfront.KeyValueStore(this, "RedirectLinkKvs", {
+      comment: "Edge fast-path redirects for simple links (#289): { destination, redirectType } per edge-eligible link.",
+    });
+
     const redirectViewerRequest = new cloudfront.Function(this, "RedirectViewerRequest", {
       runtime: cloudfront.FunctionRuntime.JS_2_0,
-      comment: "Copies the viewer Host into x-forwarded-host for the redirect origin.",
-      code: cloudfront.FunctionCode.fromInline(
-        [
-          "function handler(event) {",
-          "  var request = event.request;",
-          "  request.headers['x-forwarded-host'] = { value: request.headers.host.value };",
-          "  return request;",
-          "}",
-        ].join("\n"),
-      ),
+      comment: "x-forwarded-host + KVS edge fast path for simple redirects (#274/#289).",
+      keyValueStore: linkKvs,
+      code: cloudfront.FunctionCode.fromFile({
+        filePath: path.join(__dirname, "..", "functions", "redirect-viewer-request.js"),
+      }),
     });
 
     /* Host is deliberately NOT in this allow-list: CloudFront always sends the
@@ -828,10 +833,33 @@ export class SnapUrlStack extends Stack {
            not a nicety — without it the app could not resolve the viewer's
            domain once Host is pinned to the origin. */
         origin: origins.FunctionUrlOrigin.withOriginAccessControl(redirectUrl),
-        // Redirects must never be cached at the edge. The product promise is
-        // "print it once, change where it points forever" — a cached 302 makes
-        // a destination edit invisible to anyone who already clicked.
-        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        // A 1-5s edge TTL, NOT CACHING_DISABLED (#289). The product promise is
+        // "print it once, change where it points forever", and the layer that
+        // actually protects it is cacheHeadersFor() in
+        // packages/domain/src/destination.ts, which already sends `no-store` to
+        // the BROWSER — so no visitor ever caches a stale 302 regardless of the
+        // edge. CACHING_DISABLED was over-broad: a few seconds of edge TTL keeps
+        // a destination edit effectively instant (well under a printed-QR's
+        // reaction time) while absorbing QR-scan / burst storms that would
+        // otherwise each hit the fall-through Lambda origin. This TTL only helps
+        // the FALL-THROUGH path: the viewer-request Function answers simple
+        // links from KVS *before* the cache is consulted, so the fast path is
+        // separate. queryString is included in the cache key so the `?k=` unlock
+        // token and the UTM / forwardQuery overrides key distinct cache entries
+        // (they are already forwarded to the origin by RedirectOrigReqPolicy) —
+        // dropping the query string would let one visitor's unlock/UTM response
+        // be served to the next; headers/cookies stay out of the key.
+        cachePolicy: new cloudfront.CachePolicy(this, "RedirectShortTtl", {
+          comment: "Short 1-5s edge TTL for redirects (#289): absorbs burst on the fall-through Lambda; browser no-store keeps edits instant.",
+          defaultTtl: Duration.seconds(1),
+          minTtl: Duration.seconds(0),
+          maxTtl: Duration.seconds(5),
+          queryStringBehavior: cloudfront.CacheQueryStringBehavior.all(),
+          headerBehavior: cloudfront.CacheHeaderBehavior.none(),
+          cookieBehavior: cloudfront.CacheCookieBehavior.none(),
+          enableAcceptEncodingGzip: true,
+          enableAcceptEncodingBrotli: true,
+        }),
         originRequestPolicy: redirectOriginRequestPolicy,
         functionAssociations: [
           { function: redirectViewerRequest, eventType: cloudfront.FunctionEventType.VIEWER_REQUEST },
@@ -848,8 +876,8 @@ export class SnapUrlStack extends Stack {
       // PriceClass 200, not 100: India is in Price Class 200, and 100 (US /
       // Canada / Mexico / Europe / Israel) excludes it. Under 100 an Indian
       // visitor — the primary audience — routes to a European edge and back to
-      // ap-south-1 for every request, and since the behaviour is
-      // CACHING_DISABLED nothing is absorbed at the edge, so every request pays
+      // ap-south-1 for every request, and with only the short 1-5s fall-through
+      // TTL little is absorbed at the edge for a cold slug, so most requests pay
       // both legs (~150-210 ms of p50). 200 adds the Indian (and wider APAC/
       // South-American) edges; the marginally higher per-GB egress there is
       // immaterial at the payload size of a 302. (300 — the whole world,
@@ -883,6 +911,11 @@ export class SnapUrlStack extends Stack {
            On workerFn only, matching redirectFn — see the note there. */
         LINK_PROJECTION: "dynamo",
         LINK_PROJECTION_TABLE: linkProjectionTable.tableName,
+        /* #289 edge fast path: the presence of this ARN is what switches the
+           worker's KvsWriter on (see apps/worker/src/main.ts projectionFor).
+           On workerFn ONLY — the redirect never writes the KVS; the CloudFront
+           Function reads it via its association above. */
+        LINK_PROJECTION_KVS_ARN: linkKvs.keyValueStoreArn,
       },
       ...vpcSettings,
     });
@@ -891,6 +924,25 @@ export class SnapUrlStack extends Stack {
        and queries the linkId GSI to find what to delete — readWriteData covers
        the table and its indexes. */
     linkProjectionTable.grantReadWriteData(workerFn);
+
+    /* #289 edge fast path: the worker's KvsWriter maintains the RedirectLinkKvs
+       store on the same outbox drain that writes the DynamoDB projection —
+       PutKey on an edge-eligible upsert, DeleteKey when a link becomes
+       ineligible or is removed, and DescribeKeyValueStore to read the ETag each
+       conditional write needs. These are cloudfront-keyvaluestore DATA-plane
+       actions (distinct from the cloudfront:* control plane) and are scoped to
+       exactly this store's ARN. There is no CDK grant helper for the KVS data
+       plane, so the least-privilege statement is written by hand. */
+    workerFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "cloudfront-keyvaluestore:PutKey",
+          "cloudfront-keyvaluestore:DeleteKey",
+          "cloudfront-keyvaluestore:DescribeKeyValueStore",
+        ],
+        resources: [linkKvs.keyValueStoreArn],
+      }),
+    );
 
     /* The SQS event source mapping the issue explicitly chose over a
        self-managed ReceiveMessage: the Lambda service POLLS the queue from

--- a/infra/package.json
+++ b/infra/package.json
@@ -9,14 +9,17 @@
     "synth": "cdk synth",
     "diff": "cdk diff",
     "deploy": "cdk deploy",
-    "destroy": "cdk destroy"
+    "destroy": "cdk destroy",
+    "test": "vitest run"
   },
   "devDependencies": {
+    "@snapurl/database": "workspace:*",
     "@types/node": "^22",
     "aws-cdk": "^2.1029.4",
     "aws-cdk-lib": "^2.221.0",
     "constructs": "^10.4.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/infra/vitest.config.ts
+++ b/infra/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    // Only the standalone CloudFront Function logic is unit-testable here (the
+    // CDK stack itself is validated by `cdk synth`, not vitest). Keep the glob
+    // scoped to functions/ so it never tries to import a construct file.
+    include: ["functions/**/*.test.ts"],
+  },
+});

--- a/packages/database/src/link-projection.test.ts
+++ b/packages/database/src/link-projection.test.ts
@@ -4,6 +4,9 @@ import {
   domainMetaKey,
   fromDomainItem,
   fromLinkItem,
+  isEdgeEligible,
+  kvsKey,
+  kvsValue,
   linkKey,
   normaliseHost,
   toDomainItem,
@@ -97,6 +100,96 @@ describe("toLinkItem / fromLinkItem round-trip", () => {
     expect(item.utm).toBeNull();
 
     expect(fromLinkItem(item)).toEqual(minimal);
+  });
+});
+
+/* The edge fast path (#289): the eligibility rule, the KVS key format and the
+   stored value are the contract the worker's writer and the CloudFront Function
+   share. These lock the exact format the Function re-implements inline. */
+
+/** A plain, unconditional, edge-eligible link. Each eligibility case below
+    starts from this and flips exactly one field. */
+const plain: ProjectedLink = {
+  id: "11111111-1111-1111-1111-111111111111",
+  workspaceId: "22222222-2222-2222-2222-222222222222",
+  destination: "https://example.com/dest",
+  redirectType: "302",
+  rules: [],
+  expiresAt: null,
+  expiresTo: null,
+  activatesAt: null,
+  scheduledTo: null,
+  clickLimit: null,
+  clicks: 0,
+  hasPassword: false,
+  forwardQuery: false,
+  deepLink: false,
+  hideReferrer: false,
+  publicPreview: false,
+  archived: false,
+  safeBrowsingStatus: "clean",
+  utm: null,
+};
+
+describe("isEdgeEligible", () => {
+  it("is true for a plain unconditional clean link", () => {
+    expect(isEdgeEligible(plain)).toBe(true);
+  });
+
+  it("is false when the link has a password", () => {
+    expect(isEdgeEligible({ ...plain, hasPassword: true })).toBe(false);
+  });
+
+  it("is false when the link has routing rules", () => {
+    expect(
+      isEdgeEligible({
+        ...plain,
+        rules: [
+          {
+            id: "33333333-3333-3333-3333-333333333333",
+            when: { country: "US" },
+            then: "https://example.com/us",
+            weight: 1,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when the link has a click limit", () => {
+    expect(isEdgeEligible({ ...plain, clickLimit: 100 })).toBe(false);
+  });
+
+  it("is false when the link has an expiry", () => {
+    expect(isEdgeEligible({ ...plain, expiresAt: new Date("2030-01-01T00:00:00.000Z") })).toBe(false);
+  });
+
+  it("is false when the link has an activation time", () => {
+    expect(isEdgeEligible({ ...plain, activatesAt: new Date("2030-01-01T00:00:00.000Z") })).toBe(false);
+  });
+
+  it("is false when the link is archived", () => {
+    expect(isEdgeEligible({ ...plain, archived: true })).toBe(false);
+  });
+
+  it("is false when safe-browsing is not clean", () => {
+    expect(isEdgeEligible({ ...plain, safeBrowsingStatus: "flagged" })).toBe(false);
+  });
+});
+
+describe("kvsKey / kvsValue", () => {
+  it("builds a lowercased host/slug key a CloudFront Function can reproduce", () => {
+    expect(kvsKey("SNAP.TO", "Foo")).toBe("snap.to/foo");
+    expect(kvsKey("  snap.to  ", "bar")).toBe("snap.to/bar");
+    // The port is kept (normaliseHost only lowercases + trims).
+    expect(kvsKey("LOCALHOST:3002", "X")).toBe("localhost:3002/x");
+  });
+
+  it("serialises exactly {destination, redirectType} and round-trips", () => {
+    const value = kvsValue(plain);
+    expect(JSON.parse(value)).toEqual({ destination: "https://example.com/dest", redirectType: "302" });
+    // Well under the 1 KB per-value KVS limit.
+    expect(value.length).toBeLessThan(1024);
   });
 });
 

--- a/packages/database/src/link-projection.test.ts
+++ b/packages/database/src/link-projection.test.ts
@@ -175,6 +175,41 @@ describe("isEdgeEligible", () => {
   it("is false when safe-browsing is not clean", () => {
     expect(isEdgeEligible({ ...plain, safeBrowsingStatus: "flagged" })).toBe(false);
   });
+
+  /* Transform behaviours the Lambda applies on the happy path and the edge
+     cannot reproduce — each independently makes a link ineligible so the raw
+     stored destination is never served in place of the transformed one. */
+  it("is false when the link forwards the incoming query", () => {
+    expect(isEdgeEligible({ ...plain, forwardQuery: true })).toBe(false);
+  });
+
+  it("is false when the link injects stored UTM params", () => {
+    expect(
+      isEdgeEligible({
+        ...plain,
+        utm: { source: "print", medium: "qr", campaign: null, content: null },
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when the link uses Android deep-linking", () => {
+    expect(isEdgeEligible({ ...plain, deepLink: true })).toBe(false);
+  });
+
+  it("is false when the link suppresses the referrer", () => {
+    expect(isEdgeEligible({ ...plain, hideReferrer: true })).toBe(false);
+  });
+
+  /* A 301's permanence (cacheHeadersFor => public, max-age=300) would not be
+     honoured by the edge's always-no-store response, so 301 links stay on the
+     Lambda. Only 302/307 are edge-served. */
+  it("is false when the redirect is a 301 (permanence not honoured at the edge)", () => {
+    expect(isEdgeEligible({ ...plain, redirectType: "301" })).toBe(false);
+  });
+
+  it("is true for a 307 (same non-permanent semantics as 302)", () => {
+    expect(isEdgeEligible({ ...plain, redirectType: "307" })).toBe(true);
+  });
 });
 
 describe("kvsKey / kvsValue", () => {

--- a/packages/database/src/link-projection.test.ts
+++ b/packages/database/src/link-projection.test.ts
@@ -200,15 +200,21 @@ describe("isEdgeEligible", () => {
     expect(isEdgeEligible({ ...plain, hideReferrer: true })).toBe(false);
   });
 
-  /* A 301's permanence (cacheHeadersFor => public, max-age=300) would not be
-     honoured by the edge's always-no-store response, so 301 links stay on the
-     Lambda. Only 302/307 are edge-served. */
+  /* Only a plain 302 is edge-served. A 301's permanence (cacheHeadersFor =>
+     public, max-age=300) would not be honoured by the edge's always-no-store
+     response, and a 307's exact status the edge Function cannot emit (its
+     status mapping collapses every non-301 to 302), so both 301 and 307 stay
+     on the authoritative Lambda. */
   it("is false when the redirect is a 301 (permanence not honoured at the edge)", () => {
     expect(isEdgeEligible({ ...plain, redirectType: "301" })).toBe(false);
   });
 
-  it("is true for a 307 (same non-permanent semantics as 302)", () => {
-    expect(isEdgeEligible({ ...plain, redirectType: "307" })).toBe(true);
+  it("is false when the redirect is a 307 (edge Function cannot emit 307 exactly)", () => {
+    expect(isEdgeEligible({ ...plain, redirectType: "307" })).toBe(false);
+  });
+
+  it("is true for a plain 302", () => {
+    expect(isEdgeEligible({ ...plain, redirectType: "302" })).toBe(true);
   });
 });
 

--- a/packages/database/src/link-projection.ts
+++ b/packages/database/src/link-projection.ts
@@ -254,13 +254,30 @@ export function kvsKey(host: string, slug: string): string {
 
 /** Whether a link may be served from the edge fast path.
  *
- *  Edge-eligible iff it is a plain unconditional redirect: no password, no
- *  routing rules, no click limit, and no time gate at all (neither expiry nor
- *  activation — the edge cannot reliably evaluate time), not archived, and
- *  safe-browsing clean. Everything else falls through to the Lambda, which
- *  remains authoritative for click accounting and every conditional gate. This
- *  is the click-accounting decision (option c): the edge only serves links
- *  where per-click accuracy does not matter. */
+ *  Edge-eligible iff it is a plain unconditional redirect the edge can answer
+ *  byte-for-byte the way the Lambda would. That means:
+ *
+ *  - No BLOCKING gate: no password, no routing rules, no click limit, and no
+ *    time gate at all (neither expiry nor activation — the edge cannot reliably
+ *    evaluate time), not archived, and safe-browsing clean. This is the
+ *    click-accounting decision (option c): the edge only serves links where
+ *    per-click accuracy does not matter.
+ *
+ *  - No TRANSFORM the Lambda applies on the happy path and the edge cannot
+ *    reproduce: the redirect Lambda runs buildDestination (which merges the
+ *    forwarded query when `forwardQuery` and injects stored `utm`), buildDeepLink
+ *    (when `deepLink`), and sets `Referrer-Policy: no-referrer` (when
+ *    `hideReferrer`). The edge returns only the raw stored destination, so any of
+ *    `forwardQuery`, a non-null `utm`, `deepLink`, or `hideReferrer` would make
+ *    the edge response materially wrong. Keep those links on the Lambda.
+ *
+ *  - Not a 301: cacheHeadersFor("301") honours the author's chosen permanence
+ *    with `public, max-age=300`, whereas the edge answers every hit with
+ *    `no-store`. Rather than special-case the Function, only 302/307 links are
+ *    edge-served; a 301 stays on the Lambda so its permanence is honoured.
+ *
+ *  Everything else falls through to the Lambda, which remains authoritative for
+ *  click accounting and every conditional gate. */
 export function isEdgeEligible(link: ProjectedLink): boolean {
   return (
     link.hasPassword === false &&
@@ -269,7 +286,12 @@ export function isEdgeEligible(link: ProjectedLink): boolean {
     link.expiresAt == null &&
     link.activatesAt == null &&
     link.archived === false &&
-    link.safeBrowsingStatus === "clean"
+    link.safeBrowsingStatus === "clean" &&
+    link.forwardQuery === false &&
+    link.utm == null &&
+    link.deepLink === false &&
+    link.hideReferrer === false &&
+    link.redirectType !== "301"
   );
 }
 

--- a/packages/database/src/link-projection.ts
+++ b/packages/database/src/link-projection.ts
@@ -215,6 +215,73 @@ export function fromLinkItem(item: LinkItem): ProjectedLink {
   };
 }
 
+/* ============================================================
+   The CloudFront + KeyValueStore edge fast path (#289).
+
+   For a plain, unconditional link — no password, no routing
+   rules, no click limit, not expired, not scheduled, not
+   archived, safe-browsing clean — the redirect can be answered at
+   the edge from a CloudFront KeyValueStore, with no Lambda
+   invocation, no DynamoDB read and no VPC round-trip. The same
+   outbox drain that writes the DynamoDB projection writes one KVS
+   entry per edge-eligible link; anything the edge cannot answer
+   falls through to the Lambda, which stays authoritative.
+
+   These three functions are the single source of truth shared by
+   the worker's KVS writer and the CloudFront Function's reader:
+   the key format, the eligibility rule and the stored value must
+   match byte-for-byte on both sides, so they are defined ONCE here
+   (SDK-free, in the package both apps import) rather than
+   duplicated. The CloudFront Function cannot import this module
+   (its `cloudfront` runtime is not Node), so it re-implements
+   kvsKey inline — the shared test in infra/functions guards the
+   two against drift.
+   ============================================================ */
+
+/** The KeyValueStore key for a link, derived from the viewer host and slug.
+ *
+ *  Format: `<normalised-host>/<lowercased-slug>` — e.g. `snap.to/foo`.
+ *
+ *  Deliberately built from only what a CloudFront Function can reproduce with
+ *  no extra normalisation: the host lowercased+trimmed (normaliseHost) and the
+ *  slug lowercased, joined by a single '/'. The Function derives the identical
+ *  key from `request.headers.host.value` and the single path segment, so a
+ *  write here and a read there resolve the same entry. Do NOT change this
+ *  format without changing the Function (and the drift-guard test) in lockstep. */
+export function kvsKey(host: string, slug: string): string {
+  return `${normaliseHost(host)}/${slug.toLowerCase()}`;
+}
+
+/** Whether a link may be served from the edge fast path.
+ *
+ *  Edge-eligible iff it is a plain unconditional redirect: no password, no
+ *  routing rules, no click limit, and no time gate at all (neither expiry nor
+ *  activation — the edge cannot reliably evaluate time), not archived, and
+ *  safe-browsing clean. Everything else falls through to the Lambda, which
+ *  remains authoritative for click accounting and every conditional gate. This
+ *  is the click-accounting decision (option c): the edge only serves links
+ *  where per-click accuracy does not matter. */
+export function isEdgeEligible(link: ProjectedLink): boolean {
+  return (
+    link.hasPassword === false &&
+    link.rules.length === 0 &&
+    link.clickLimit == null &&
+    link.expiresAt == null &&
+    link.activatesAt == null &&
+    link.archived === false &&
+    link.safeBrowsingStatus === "clean"
+  );
+}
+
+/** The KeyValueStore value for a link: the minimum the edge needs to answer a
+ *  redirect. JSON `{ destination, redirectType }` — a URL plus a 3-char code is
+ *  far under the 1 KB per-value limit (and 5 MB per-store), so no truncation
+ *  guard is needed. The CloudFront Function JSON.parses this and reads exactly
+ *  these two fields. */
+export function kvsValue(link: ProjectedLink): string {
+  return JSON.stringify({ destination: link.destination, redirectType: link.redirectType });
+}
+
 /** ProjectedDomain -> stored DomainItem. */
 export function toDomainItem(host: string, domain: ProjectedDomain): DomainItem {
   return {

--- a/packages/database/src/link-projection.ts
+++ b/packages/database/src/link-projection.ts
@@ -271,10 +271,14 @@ export function kvsKey(host: string, slug: string): string {
  *    `forwardQuery`, a non-null `utm`, `deepLink`, or `hideReferrer` would make
  *    the edge response materially wrong. Keep those links on the Lambda.
  *
- *  - Not a 301: cacheHeadersFor("301") honours the author's chosen permanence
- *    with `public, max-age=300`, whereas the edge answers every hit with
- *    `no-store`. Rather than special-case the Function, only 302/307 links are
- *    edge-served; a 301 stays on the Lambda so its permanence is honoured.
+ *  - Only a plain 302: 301 and 307 both fall through to the Lambda. A 301's
+ *    permanence is honoured on the Lambda with `public, max-age=300`
+ *    (cacheHeadersFor("301")), which the edge's always-`no-store` response
+ *    would not preserve. A 307's exact status the edge Function cannot emit —
+ *    its status mapping collapses every non-301 hit to 302, so an edge-served
+ *    307 would answer 302 where the Lambda answers 307 (via REDIRECT_STATUS).
+ *    Rather than special-case the Function, only plain 302 links are
+ *    edge-served; 301 and 307 stay authoritative on the Lambda.
  *
  *  Everything else falls through to the Lambda, which remains authoritative for
  *  click accounting and every conditional gate. */
@@ -291,7 +295,7 @@ export function isEdgeEligible(link: ProjectedLink): boolean {
     link.utm == null &&
     link.deepLink === false &&
     link.hideReferrer === false &&
-    link.redirectType !== "301"
+    link.redirectType === "302"
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
 
   infra:
     devDependencies:
+      '@snapurl/database':
+        specifier: workspace:*
+        version: link:../packages/database
       '@types/node':
         specifier: ^22
         version: 22.20.1
@@ -191,6 +194,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
 
   packages/cache:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
 
   apps/worker:
     dependencies:
+      '@aws-sdk/client-cloudfront-keyvaluestore':
+        specifier: ^3.1121.0
+        version: 3.1121.0
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1121.0
         version: 3.1121.0
@@ -417,6 +420,10 @@ packages:
     bundledDependencies:
       - jsonschema
       - semver
+
+  '@aws-sdk/client-cloudfront-keyvaluestore@3.1121.0':
+    resolution: {integrity: sha512-FXZMg5jvH3QwXcmE6kgQKaIl/wvp53TS5almXdjeM7Tkwow45/ffmKfbcdp2jZ0QIZCo/6s8f4jS5EvP6a7dYQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-dynamodb@3.1121.0':
     resolution: {integrity: sha512-q8s4cKsn0TdQ+QByWEUeajZMFrmF2GzDovrlfWMA7Pv3GfG5sADjbWAZxJXA9JsLGb4QT5ovTpOdArNqjbojZw==}
@@ -3798,6 +3805,18 @@ snapshots:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
 
   '@aws-cdk/cloud-assembly-schema@54.21.0': {}
+
+  '@aws-sdk/client-cloudfront-keyvaluestore@3.1121.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
 
   '@aws-sdk/client-dynamodb@3.1121.0':
     dependencies:


### PR DESCRIPTION
Closes #289. Phase 7.3 of epic #267 — **the last epic feature**. AWS-profile-only + opt-in; non-AWS profiles unchanged.

## What it does
For plain unconditional links the redirect is answered **at the edge, no origin fetch** (no Lambda, no DB, no VPC): a per-link CloudFront **KeyValueStore** entry `{destination,redirectType}`, written by the same worker outbox that writes the DynamoDB projection (#288), read by the extended viewer-request **CloudFront Function**, which 302s a bare-slug GET and **falls through to the Lambda for everything else** — so correctness never depends on the fast path being complete. Expected p50 in India ~10–20ms vs ~245ms.

## Blocking decision — settled as option (c) (also recorded in the epic)
Only edge-eligible links (per-click accuracy doesn't matter) go on the fast path; the **Lambda stays authoritative** for the rest, preserving the salted-hash privacy design and the budget that (a) Kinesis (~$11/mo) or (b) S3-log IP-parsing would blow/compromise. Recorded in `docs/DECISIONS.md`.

## Edge-eligibility (shared SDK-free helper, one source of truth)
Eligible iff `redirectType==='302'` AND no password AND no rules AND no clickLimit AND no expiresAt AND no activatesAt AND not archived AND `safeBrowsingStatus==='clean'` AND no forwardQuery/UTM/deepLink/hideReferrer. Everything the edge can't reproduce (query forwarding, UTM, deep links, no-referrer, 301 permanence, exact 307) stays on the Lambda — these exclusions were tightened during the review loop.

## Pieces
- **CloudFront Function** (`infra/functions/redirect-viewer-request.js`, JS_2_0): keeps the #274 x-forwarded-host on every path; for a bare GET of a non-root/non-'+'/no-`?k=` slug does `cf.kvs().get(key)` → 302 on hit, unchanged (fall-through) on miss/error/guard. Pure logic mirrored in a drift-guarded `.logic.mjs` twin so it's unit-testable (14 tests, incl. a drift guard + `edgeKey===kvsKey`).
- **Worker KVS writer** (`kvs-projection.ts`): on the same outbox drain, PutKey eligible links / DeleteKey ineligible-or-removed ones, with the DescribeKeyValueStore→ETag→IfMatch optimistic-concurrency flow (bounded conflict retry). DynamoDB written first so a KVS failure never loses the authoritative projection. 18 mock-based tests.
- **CDK**: a `KeyValueStore` associated with the function; the managed `CACHING_DISABLED` replaced with a short-TTL cache policy (default 1s / max 5s) — safe because `cacheHeadersFor()` already sends `no-store` to the browser; worker IAM grant (PutKey/DeleteKey/DescribeKeyValueStore scoped to the KVS ARN) + `LINK_PROJECTION_KVS_ARN` env on the worker only.

## Verify-first finding
`cloudfront-keyvaluestore` is a global public API with no PrivateLink; the worker reaches it over NAT egress (#281) — same path as Safe Browsing/webhooks. SDK `@aws-sdk/client-cloudfront-keyvaluestore@^3.1121.0`, CDK 2.266.0 `cloudfront.KeyValueStore` + `Function.keyValueStore` confirmed.

## How to test
- `corepack pnpm install --frozen-lockfile` clean; `type-check`; `test` (infra 14, worker kvs 18, database link-projection) — verified. `cdk synth` confirms the KeyValueStore, function↔KVS association (fromFile = the tested source), worker grant+env, and the short-TTL policy replacing CACHING_DISABLED.
- Non-AWS profiles: KVS is opt-in on `LINK_PROJECTION_KVS_ARN`; NoProjection/single-node/k8s/compose make zero KVS calls and the redirect app is unchanged (test-proven). All existing CI jobs stay green.

## Deploy-deferred (stated honestly)
The Done-when edge behaviors — 'zero Lambda invocations for a simple link' and 'password/country link still falls through' — are verified here at the code + unit-test + cdk-synth level; a real CloudFront Function + KVS can't run in CI, so they're fully proven only on a real deploy.

Dep added (apps/worker): `@aws-sdk/client-cloudfront-keyvaluestore@^3.1121.0`.