### PR TITLE
Replace retention's session advisory lock with an expiring lease

### DIFF
--- a/apps/worker/src/jobs/lease.test.ts
+++ b/apps/worker/src/jobs/lease.test.ts
@@ -39,7 +39,10 @@ describeDb("withLease", () => {
   }
 
   beforeEach(async () => {
-    handle ??= createDatabase({ url: DATABASE_URL!, max: 2 });
+    // Room for several genuinely concurrent callers: the overlap tests need
+    // more than one connection in flight or they serialise on the pool and
+    // stop testing overlap at all.
+    handle ??= createDatabase({ url: DATABASE_URL!, max: 4 });
     db = handle.db;
     await db.execute(sql`delete from job_leases where name like 'test_lease%'`);
   });
@@ -132,6 +135,78 @@ describeDb("withLease", () => {
     // otherwise lock itself out permanently.
     const next = await withLease(db, NAME, 60, async () => "after failure");
     expect(next.acquired).toBe(true);
+  });
+
+  it("derives the expiry from ttlSeconds, so the lease frees itself on time", async () => {
+    /* Every other test writes `locked_until` by hand, which means none of them
+       touch the TTL — reading the argument as minutes instead of seconds, or
+       ignoring it entirely, would pass the whole suite. This is the only case
+       that pins the unit. */
+    const held = await withLease(db, NAME, 1, async () => "held");
+    expect(held.acquired).toBe(true);
+
+    // Immediately after release the lease is free, so re-take it and let this
+    // one lapse on the clock rather than by releasing.
+    await db.execute(sql`
+      update job_leases set locked_until = now() + make_interval(secs => 1), holder = 'ttl-holder'
+      where name = ${NAME}
+    `);
+
+    const tooSoon = await withLease(db, NAME, 60, async () => "should not run");
+    expect(tooSoon.acquired).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    const afterExpiry = await withLease(db, NAME, 60, async () => "expired naturally");
+    expect(afterExpiry.acquired).toBe(true);
+    expect(afterExpiry.value).toBe("expired naturally");
+  });
+
+  it("does not release a lease taken over by another pass in the same process", async () => {
+    /* The sibling of the test below, and the one that actually bites, because
+     * the guard cannot see it: both passes live in one process.
+     *
+     * The release matches on a holder token. Were that token per *process*
+     * rather than per *acquisition*, two overlapping passes inside one worker
+     * would share the string — so the overrunning pass's release would match the
+     * takeover's row and free a lease that is still in use, letting a third pass
+     * run alongside it.
+     *
+     * The takeover has to still be **in flight** when the outer pass exits. An
+     * earlier version of this test awaited the takeover inside the outer job; it
+     * released itself first, leaving nothing live to stomp, and the test passed
+     * against the per-process bug it was written to catch. Verified by mutation:
+     * pin the token to a constant and this fails. */
+    let takeoverInFlight = false;
+    let takeoverAcquired = false;
+    let takeoverPromise: Promise<unknown> = Promise.resolve();
+
+    await withLease(db, NAME, 60, async () => {
+      // This pass overruns: its lease lapses while it is still working.
+      await expireLease();
+
+      // Deliberately not awaited — it must outlive the outer pass.
+      takeoverPromise = withLease(db, NAME, 60, async () => {
+        takeoverInFlight = true;
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        takeoverInFlight = false;
+      }).then((r) => {
+        takeoverAcquired = r.acquired;
+      });
+
+      // Long enough for the takeover to have acquired and entered its job.
+      await new Promise((resolve) => setTimeout(resolve, 80));
+    });
+
+    // The outer pass's release has now run. The takeover is still working.
+    const intruder = await withLease(db, NAME, 60, async () => "third pass");
+
+    await takeoverPromise;
+
+    expect(takeoverAcquired).toBe(true);
+    // The assertion: nobody got in while the takeover held the lease.
+    expect(intruder.acquired && takeoverInFlight).toBe(false);
+    expect(intruder.acquired).toBe(false);
   });
 
   it("does not release a lease that has already been taken by someone else", async () => {

--- a/apps/worker/src/jobs/lease.test.ts
+++ b/apps/worker/src/jobs/lease.test.ts
@@ -1,0 +1,197 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { createDatabase, sql, type Database } from "@snapurl/database";
+import { withLease } from "./lease.js";
+
+/* ============================================================
+   Job leases, against a real Postgres.
+
+   The property that matters is the one a session-scoped advisory
+   lock did not have: a holder that vanishes must not keep the
+   job from ever running again. That is why the expiry case has
+   its own test — it is the regression this file exists for.
+
+   Runs only when DATABASE_URL is set, matching the other worker
+   suites.
+   ============================================================ */
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeDb = DATABASE_URL ? describe : describe.skip;
+
+describeDb("withLease", () => {
+  let handle: ReturnType<typeof createDatabase>;
+  let db: Database;
+
+  const NAME = "test_lease";
+
+  /** Force the stored lease into the past, standing in for a holder that died
+   *  without releasing. Nothing else can produce that state on demand. */
+  async function expireLease(name = NAME) {
+    await db.execute(sql`
+      update job_leases set locked_until = now() - interval '1 second' where name = ${name}
+    `);
+  }
+
+  async function storedHolder(name = NAME): Promise<string | null> {
+    const rows = (await db.execute(sql`
+      select holder from job_leases where name = ${name}
+    `)) as unknown as Array<{ holder: string | null }>;
+    return rows[0]?.holder ?? null;
+  }
+
+  beforeEach(async () => {
+    handle ??= createDatabase({ url: DATABASE_URL!, max: 2 });
+    db = handle.db;
+    await db.execute(sql`delete from job_leases where name like 'test_lease%'`);
+  });
+
+  afterAll(async () => {
+    if (db) await db.execute(sql`delete from job_leases where name like 'test_lease%'`);
+    await handle?.close();
+  });
+
+  it("runs the job and reports it acquired the lease", async () => {
+    const result = await withLease(db, NAME, 60, async () => "done");
+
+    expect(result.acquired).toBe(true);
+    expect(result.value).toBe("done");
+  });
+
+  it("releases on the way out, so the next pass can take it", async () => {
+    await withLease(db, NAME, 60, async () => "first");
+    const second = await withLease(db, NAME, 60, async () => "second");
+
+    // Sequential passes are the normal case and must not block each other.
+    expect(second.acquired).toBe(true);
+    expect(second.value).toBe("second");
+  });
+
+  it("refuses a second holder while the lease is live", async () => {
+    let innerRan = false;
+
+    // The nested call stands in for a concurrent pass: the outer lease is held
+    // and has not lapsed, so the inner one must decline.
+    await withLease(db, NAME, 60, async () => {
+      const inner = await withLease(db, NAME, 60, async () => {
+        innerRan = true;
+      });
+      expect(inner.acquired).toBe(false);
+      expect(inner.value).toBeUndefined();
+    });
+
+    expect(innerRan).toBe(false);
+  });
+
+  it("does not run the job at all when the lease is unavailable", async () => {
+    // Held by someone else, far into the future.
+    await db.execute(sql`
+      insert into job_leases (name, locked_until, holder, acquired_at)
+      values (${NAME}, now() + interval '1 hour', 'someone-else', now())
+    `);
+
+    let ran = false;
+    const result = await withLease(db, NAME, 60, async () => {
+      ran = true;
+    });
+
+    expect(result.acquired).toBe(false);
+    expect(ran).toBe(false);
+    // The other holder's claim is untouched.
+    expect(await storedHolder()).toBe("someone-else");
+  });
+
+  it("lets the next pass take over after a holder dies without releasing", async () => {
+    /* **The regression this replaces.**
+     *
+     * A session-scoped advisory lock is held by the connection, so a worker
+     * killed mid-pass — a Lambda frozen or reclaimed — left it held on a backend
+     * Postgres still considered healthy, and every later pass declined forever.
+     * Retention simply stopped, with no error to notice.
+     *
+     * A lease expires by the clock, so the same crash costs one late pass. */
+    await db.execute(sql`
+      insert into job_leases (name, locked_until, holder, acquired_at)
+      values (${NAME}, now() + interval '1 hour', 'holder-that-died', now())
+    `);
+    await expireLease();
+
+    const result = await withLease(db, NAME, 60, async () => "recovered");
+
+    expect(result.acquired).toBe(true);
+    expect(result.value).toBe("recovered");
+    expect(await storedHolder()).not.toBe("holder-that-died");
+  });
+
+  it("releases even when the job throws, and does not swallow the error", async () => {
+    await expect(
+      withLease(db, NAME, 60, async () => {
+        throw new Error("job blew up");
+      }),
+    ).rejects.toThrow("job blew up");
+
+    // The failure must not strand the lease — a job that throws every pass would
+    // otherwise lock itself out permanently.
+    const next = await withLease(db, NAME, 60, async () => "after failure");
+    expect(next.acquired).toBe(true);
+  });
+
+  it("does not release a lease that has already been taken by someone else", async () => {
+    /* The overrun case, and the reason release is matched on holder.
+     *
+     * A pass that outlives its TTL no longer owns the lease. Releasing
+     * unconditionally would hand the new holder's lease away and let a third
+     * pass start alongside it — manufacturing exactly the concurrent execution
+     * the lease exists to prevent. */
+    await withLease(db, NAME, 60, async () => {
+      // Simulate this pass overrunning: its lease lapses and another process
+      // legitimately claims it while the job is still running.
+      await expireLease();
+      await db.execute(sql`
+        update job_leases
+        set locked_until = now() + interval '1 hour', holder = 'took-over', acquired_at = now()
+        where name = ${NAME}
+      `);
+    });
+
+    // The takeover survived our exit, so nothing was handed away.
+    expect(await storedHolder()).toBe("took-over");
+    const intruder = await withLease(db, NAME, 60, async () => "should not run");
+    expect(intruder.acquired).toBe(false);
+  });
+
+  it("keeps leases for different jobs independent", async () => {
+    await withLease(db, NAME, 60, async () => {
+      const other = await withLease(db, `${NAME}_other`, 60, async () => "other ran");
+      // One job holding its lease must not block an unrelated one.
+      expect(other.acquired).toBe(true);
+      expect(other.value).toBe("other ran");
+    });
+  });
+
+  it("never lets two racing callers run the job at the same time", async () => {
+    /* Mutual exclusion is the actual property, and it is worth stating that way
+       rather than as "exactly one acquires". Two passes acquiring in *sequence*
+       is correct and expected — the first releases on its way out — so counting
+       acquisitions proves nothing. What must never happen is two jobs in flight
+       together, which is what the peak counter measures. */
+    let inFlight = 0;
+    let peak = 0;
+
+    const job = async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      // Long enough that a second caller attempting mid-run would overlap if
+      // the guard did not hold. Without the pause both jobs finish before the
+      // other starts and the test proves nothing.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      inFlight--;
+    };
+
+    await Promise.all([
+      withLease(db, NAME, 60, job),
+      withLease(db, NAME, 60, job),
+      withLease(db, NAME, 60, job),
+    ]);
+
+    expect(peak).toBe(1);
+  });
+});

--- a/apps/worker/src/jobs/lease.ts
+++ b/apps/worker/src/jobs/lease.ts
@@ -17,9 +17,20 @@ import { sql, type Database } from "@snapurl/database";
    than "never again".
    ============================================================ */
 
-/** Identifies this process in the lease row. Diagnostics only — correctness
- *  comes from it being unique per holder, not from what it says. */
-const HOLDER = `${process.env.AWS_LAMBDA_FUNCTION_NAME ?? "worker"}:${process.pid}:${randomUUID().slice(0, 8)}`;
+/** Readable prefix identifying the process, for reading the table later. The
+ *  unique part is appended per acquisition — see `holderToken`. */
+const PROCESS_TAG = `${process.env.AWS_LAMBDA_FUNCTION_NAME ?? "worker"}:${process.pid}`;
+
+/** A token unique to one acquisition, not one process.
+ *
+ *  Per-acquisition matters, and per-process is a trap: the release below matches
+ *  on this value so an overrunning holder cannot release a lease that has since
+ *  been taken by somebody else. A process-wide constant makes that guard blind
+ *  to the case where the somebody else is *another pass in the same process* —
+ *  the two would share the string, the overrunning pass would release the new
+ *  holder's lease, and a third pass could then start alongside it. Which is
+ *  precisely the concurrent execution the guard exists to prevent. */
+const holderToken = () => `${PROCESS_TAG}:${randomUUID()}`;
 
 export interface LeaseResult<T> {
   /** False when another holder had it. The job did not run; nothing is wrong. */
@@ -51,12 +62,14 @@ export async function withLease<T>(
   ttlSeconds: number,
   job: () => Promise<T>,
 ): Promise<LeaseResult<T>> {
+  const holder = holderToken();
+
   const rows = (await db.execute(sql`
     insert into job_leases (name, locked_until, holder, acquired_at)
-    values (${name}, now() + make_interval(secs => ${ttlSeconds}), ${HOLDER}, now())
+    values (${name}, now() + make_interval(secs => ${ttlSeconds}), ${holder}, now())
     on conflict (name) do update
       set locked_until = now() + make_interval(secs => ${ttlSeconds}),
-          holder = ${HOLDER},
+          holder = ${holder},
           acquired_at = now()
       where job_leases.locked_until < now()
     returning name
@@ -81,8 +94,8 @@ export async function withLease<T>(
      * must never mask the job's own error. */
     await db
       .execute(sql`
-        update job_leases set locked_until = now()
-        where name = ${name} and holder = ${HOLDER}
+        update job_leases set locked_until = now(), holder = null
+        where name = ${name} and holder = ${holder}
       `)
       .catch(() => undefined);
   }

--- a/apps/worker/src/jobs/lease.ts
+++ b/apps/worker/src/jobs/lease.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+import { sql, type Database } from "@snapurl/database";
+
+/* ============================================================
+   Running a job at most once at a time, when the job spans
+   more than one transaction.
+
+   For single-transaction work, use pg_try_advisory_xact_lock
+   instead — it is cheaper and it cleans itself up on commit.
+   This exists for the other case.
+
+   See packages/database/src/schema/jobs.ts for why a lease
+   rather than a session-scoped advisory lock: a session lock
+   lives on the connection, and a holder that vanishes leaves it
+   held on a backend Postgres still thinks is healthy. A lease
+   expires by the clock, so the failure mode is "late" rather
+   than "never again".
+   ============================================================ */
+
+/** Identifies this process in the lease row. Diagnostics only — correctness
+ *  comes from it being unique per holder, not from what it says. */
+const HOLDER = `${process.env.AWS_LAMBDA_FUNCTION_NAME ?? "worker"}:${process.pid}:${randomUUID().slice(0, 8)}`;
+
+export interface LeaseResult<T> {
+  /** False when another holder had it. The job did not run; nothing is wrong. */
+  acquired: boolean;
+  /** The job's return value, present only when `acquired`. */
+  value?: T;
+}
+
+/**
+ * Run `job` while holding a named lease, or don't run it at all.
+ *
+ * The lease is taken in a single statement, which is what makes it safe under
+ * concurrency: `insert ... on conflict do update ... where locked_until < now()`
+ * lets Postgres serialise the contenders on the row, and the loser's update is
+ * filtered out rather than overwriting the winner's claim. Two callers racing
+ * cannot both come away believing they hold it.
+ *
+ * `ttlSeconds` has to comfortably exceed the job's worst-case runtime, or a slow
+ * pass will have its lease taken from underneath it and end up running twice.
+ * Sizing it against the process's own ceiling — a Lambda timeout, say — is the
+ * reliable way to pick it, since the holder cannot outlive that anyway.
+ *
+ * Releasing is best-effort by design. A crash skips it, and that is precisely
+ * the case the expiry exists for.
+ */
+export async function withLease<T>(
+  db: Database,
+  name: string,
+  ttlSeconds: number,
+  job: () => Promise<T>,
+): Promise<LeaseResult<T>> {
+  const rows = (await db.execute(sql`
+    insert into job_leases (name, locked_until, holder, acquired_at)
+    values (${name}, now() + make_interval(secs => ${ttlSeconds}), ${HOLDER}, now())
+    on conflict (name) do update
+      set locked_until = now() + make_interval(secs => ${ttlSeconds}),
+          holder = ${HOLDER},
+          acquired_at = now()
+      where job_leases.locked_until < now()
+    returning name
+  `)) as unknown as Array<{ name: string }>;
+
+  // No row means the ON CONFLICT update was filtered out: someone else holds a
+  // lease that has not lapsed.
+  if (rows.length === 0) return { acquired: false };
+
+  try {
+    return { acquired: true, value: await job() };
+  } finally {
+    /* Guarded on holder.
+     *
+     * If this pass overran its TTL, another holder may legitimately own the
+     * lease by now. Releasing unconditionally would hand that holder's lease
+     * away and let a third pass start alongside it — turning an overrun into
+     * exactly the concurrent execution the lease exists to prevent. Matching on
+     * holder means an expired owner releases nothing.
+     *
+     * Failing to release is survivable (the lease lapses on its own), so this
+     * must never mask the job's own error. */
+    await db
+      .execute(sql`
+        update job_leases set locked_until = now()
+        where name = ${name} and holder = ${HOLDER}
+      `)
+      .catch(() => undefined);
+  }
+}

--- a/apps/worker/src/jobs/rollup.ts
+++ b/apps/worker/src/jobs/rollup.ts
@@ -308,14 +308,23 @@ const MAX_RETAINED_DAYS = Number(process.env.CLICK_EVENTS_MAX_RETAINED_DAYS ?? 1
 
 /** How long a retention pass holds its lease.
  *
- *  Has to exceed the worst-case pass or a slow one has its lease taken from
- *  underneath it and ends up running twice. The ceiling is bounded by design:
- *  MAX_PARTITION_DROPS drops across the two loops, each capped by a 2s
- *  lock_timeout, so a pass cannot run long even when every drop times out.
+ *  Five minutes, matching the worker Lambda's own timeout. That is the honest
+ *  bound: on AWS a holder cannot outlive it, so a pass that overran is already
+ *  dead rather than slow, and its lease should become available shortly after.
  *
- *  Five minutes because that is the worker Lambda's own timeout, which is the
- *  real limit on how long a pass can be alive at all — a holder that has hit it
- *  is gone, not slow, and its lease should be available again shortly after. */
+ *  Worth being precise about what is *not* bounded, because it is tempting to
+ *  argue from the drop loops. Those are bounded — MAX_PARTITION_DROPS drops,
+ *  each capped by a 2s lock_timeout, so roughly 40s worst case. The row-level
+ *  DELETE the pass ends on is not: it carries no lock_timeout, and
+ *  createDatabase sets no statement_timeout. It only does real work when
+ *  workspaces use mixed retention settings, but that is exactly when a pass
+ *  could exceed this TTL.
+ *
+ *  So on AWS the Lambda ceiling covers it. On the compose and Helm profiles
+ *  there is no process ceiling, and a long enough pass can be overtaken. The
+ *  damage is bounded rather than absent: the drop helper is a single statement,
+ *  so DETACH and DROP are atomic, and a loser either times out on the parent
+ *  lock or finds the partition already gone and reports false. */
 const RETENTION_LEASE_SECONDS = 300;
 
 export interface RetentionResult {

--- a/apps/worker/src/jobs/rollup.ts
+++ b/apps/worker/src/jobs/rollup.ts
@@ -1,5 +1,6 @@
 import { sql, type Database } from "@snapurl/database";
 import { addHashed, createSketch, deserialize, estimate, merge, serialize } from "@snapurl/domain";
+import { withLease } from "./lease.js";
 
 /* ============================================================
    Turning raw clicks into the numbers the dashboards read.
@@ -305,6 +306,18 @@ const MAX_PARTITION_DROPS = 20;
  *  ingest rate demands a tighter cap. */
 const MAX_RETAINED_DAYS = Number(process.env.CLICK_EVENTS_MAX_RETAINED_DAYS ?? 1100);
 
+/** How long a retention pass holds its lease.
+ *
+ *  Has to exceed the worst-case pass or a slow one has its lease taken from
+ *  underneath it and ends up running twice. The ceiling is bounded by design:
+ *  MAX_PARTITION_DROPS drops across the two loops, each capped by a 2s
+ *  lock_timeout, so a pass cannot run long even when every drop times out.
+ *
+ *  Five minutes because that is the worker Lambda's own timeout, which is the
+ *  real limit on how long a pass can be alive at all — a holder that has hit it
+ *  is gone, not slow, and its lease should be available again shortly after. */
+const RETENTION_LEASE_SECONDS = 300;
+
 export interface RetentionResult {
   /** Whole days removed by dropping a partition. Constant-time, near-zero WAL. */
   partitionsDropped: number;
@@ -395,19 +408,25 @@ export async function pruneRetention(
      default. */
   maxRetainedDays = MAX_RETAINED_DAYS,
 ): Promise<RetentionResult> {
-  /* One expiry pass at a time. Without this, two overlapping passes both read
-     the same list of spent partitions and the second fails on one the first
-     already dropped — which would abort every maintenance job queued behind it.
-     EventBridge fires every minute with retryAttempts: 2 and the Lambda path has
-     no equivalent of the in-process overlap guard, so this is reachable.
-     pg_try_advisory_lock rather than the _xact_ variant, because the drops
-     deliberately span several transactions. */
-  const [{ locked }] = (await db.execute(sql`
-    select pg_try_advisory_lock(hashtext('click_events_prune_retention')) as locked
-  `)) as unknown as [{ locked: boolean }];
-  if (!locked) return { partitionsDropped: 0, rowsDeleted: 0 };
-
-  try {
+  /* One expiry pass at a time.
+   *
+   * Two overlapping passes would both read the same list of spent partitions,
+   * and the cap pass below adds a second, independent drop loop whose targets
+   * `click_events_spent_partitions` never listed — so per-drop idempotence is
+   * not enough on its own and the guard has to be at pass level. EventBridge
+   * fires every minute with retryAttempts: 2 and the Lambda path has no
+   * equivalent of the in-process overlap guard, so this is reachable.
+   *
+   * A lease rather than a session-scoped advisory lock, which is what this used
+   * to be. The drops deliberately span several transactions, so a *_xact_* lock
+   * would release at the first commit — but a session lock lives on the
+   * connection, and the worker pools connections with DATABASE_POOL_MAX=1 on
+   * the AWS profile. A pass that vanished mid-run (a Lambda frozen or
+   * reclaimed) stranded the lock on a backend Postgres still considered
+   * healthy, and every later pass declined: retention stopped for good, with no
+   * error and nothing in the logs to distinguish it from having nothing to do.
+   * A lease expires by the clock, so the same crash costs one late pass. */
+  const lease = await withLease(db, "click_events_prune_retention", RETENTION_LEASE_SECONDS, async () => {
     /* The longest retention in use decides which partitions are safe to drop.
        No workspaces at all still needs a sane answer, hence the coalesce: a
        fresh install has nothing to expire and should not drop today's data.
@@ -537,9 +556,11 @@ export async function pruneRetention(
     `)) as unknown as [{ n: number }];
 
     return { partitionsDropped, rowsDeleted: n ?? 0 };
-  } finally {
-    await db.execute(sql`select pg_advisory_unlock(hashtext('click_events_prune_retention'))`);
-  }
+  });
+
+  /* Another holder had the lease, so this pass did nothing. Reported as zeroes
+     rather than as a failure, because it is the mechanism working. */
+  return lease.value ?? { partitionsDropped: 0, rowsDeleted: 0 };
 }
 
 /**

--- a/packages/database/drizzle/0012_job_leases.sql
+++ b/packages/database/drizzle/0012_job_leases.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "job_leases" (
+	"name" varchar(64) PRIMARY KEY NOT NULL,
+	"locked_until" timestamp with time zone DEFAULT now() NOT NULL,
+	"holder" varchar(120),
+	"acquired_at" timestamp with time zone
+);

--- a/packages/database/drizzle/meta/0012_snapshot.json
+++ b/packages/database/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,3246 @@
+{
+  "id": "c2aaf044-947c-44b4-aa65-7f2fed567d51",
+  "prevId": "8cd073ff-5d27-4aae-8052-772139081f45",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invite_token_hash": {
+          "name": "invite_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_workspace_email_key": {
+          "name": "memberships_workspace_email_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_identities": {
+      "name": "oauth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_identities_provider_subject_key": {
+          "name": "oauth_identities_provider_subject_key",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_identities_user_id_users_id_fk": {
+          "name": "oauth_identities_user_id_users_id_fk",
+          "tableFrom": "oauth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recovery_codes": {
+      "name": "recovery_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recovery_codes_user_idx": {
+          "name": "recovery_codes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recovery_codes_user_id_users_id_fk": {
+          "name": "recovery_codes_user_id_users_id_fk",
+          "tableFrom": "recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_id": {
+          "name": "replaced_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_hash_key": {
+          "name": "refresh_tokens_hash_key",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_user_idx": {
+          "name": "refresh_tokens_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_family_idx": {
+          "name": "refresh_tokens_family_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totp_enabled_at": {
+          "name": "totp_enabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Free'"
+        },
+        "default_domain_id": {
+          "name": "default_domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_redirect": {
+          "name": "default_redirect",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "clicks_included": {
+          "name": "clicks_included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000000
+        },
+        "retention_years": {
+          "name": "retention_years",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "cookieless_analytics": {
+          "name": "cookieless_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "scan_on_create": {
+          "name": "scan_on_create",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_previews": {
+          "name": "public_previews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_slug_key": {
+          "name": "workspaces_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'verifying'"
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ssl_renews_at": {
+          "name": "ssl_renews_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_redirect": {
+          "name": "root_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_redirect": {
+          "name": "not_found_redirect",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domains_domain_key": {
+          "name": "domains_domain_key",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domains_workspace_idx": {
+          "name": "domains_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_workspace_id_workspaces_id_fk": {
+          "name": "domains_workspace_id_workspaces_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.link_counters": {
+      "name": "link_counters",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_clicks": {
+          "name": "unique_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "link_counters_link_id_links_id_fk": {
+          "name": "link_counters_link_id_links_id_fk",
+          "tableFrom": "link_counters",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "folder": {
+          "name": "folder",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_type": {
+          "name": "redirect_type",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'302'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_to": {
+          "name": "expires_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activates_at": {
+          "name": "activates_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_to": {
+          "name": "scheduled_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_limit": {
+          "name": "click_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forward_query": {
+          "name": "forward_query",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_referrer": {
+          "name": "hide_referrer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_preview": {
+          "name": "public_preview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cloaked": {
+          "name": "cloaked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safe_browsing_status": {
+          "name": "safe_browsing_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "safe_browsing_checked_at": {
+          "name": "safe_browsing_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "links_domain_slug_key": {
+          "name": "links_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_created_idx": {
+          "name": "links_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_workspace_tags_idx": {
+          "name": "links_workspace_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "links_expires_idx": {
+          "name": "links_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_activates_idx": {
+          "name": "links_activates_idx",
+          "columns": [
+            {
+              "expression": "activates_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"links\".\"activates_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "links_workspace_id_workspaces_id_fk": {
+          "name": "links_workspace_id_workspaces_id_fk",
+          "tableFrom": "links",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "links_domain_id_domains_id_fk": {
+          "name": "links_domain_id_domains_id_fk",
+          "tableFrom": "links",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "links_created_by_users_id_fk": {
+          "name": "links_created_by_users_id_fk",
+          "tableFrom": "links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projection_outbox": {
+      "name": "projection_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projection_outbox_pending_idx": {
+          "name": "projection_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"projection_outbox\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routing_rules": {
+      "name": "routing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "when_country": {
+          "name": "when_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_device": {
+          "name": "when_device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when_language": {
+          "name": "when_language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "then": {
+          "name": "then",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routing_rules_link_position_key": {
+          "name": "routing_rules_link_position_key",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routing_rules_link_id_links_id_fk": {
+          "name": "routing_rules_link_id_links_id_fk",
+          "tableFrom": "routing_rules",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.breakdown_daily": {
+      "name": "breakdown_daily",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "breakdown_daily_key": {
+          "name": "breakdown_daily_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"link_id\", '00000000-0000-0000-0000-000000000000'::uuid)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "breakdown_daily_lookup_idx": {
+          "name": "breakdown_daily_lookup_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "breakdown_daily_workspace_id_workspaces_id_fk": {
+          "name": "breakdown_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "breakdown_daily_link_id_links_id_fk": {
+          "name": "breakdown_daily_link_id_links_id_fk",
+          "tableFrom": "breakdown_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily": {
+      "name": "click_daily",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uniques": {
+          "name": "uniques",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scans": {
+          "name": "scans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "click_daily_workspace_day_idx": {
+          "name": "click_daily_workspace_day_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_daily_link_id_links_id_fk": {
+          "name": "click_daily_link_id_links_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_daily_workspace_id_workspaces_id_fk": {
+          "name": "click_daily_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_daily",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_link_id_day_pk": {
+          "name": "click_daily_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_daily_uniques": {
+      "name": "click_daily_uniques",
+      "schema": "",
+      "columns": {
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sketch": {
+          "name": "sketch",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "click_daily_uniques_link_id_links_id_fk": {
+          "name": "click_daily_uniques_link_id_links_id_fk",
+          "tableFrom": "click_daily_uniques",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_daily_uniques_link_id_day_pk": {
+          "name": "click_daily_uniques_link_id_day_pk",
+          "columns": [
+            "link_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.click_events": {
+      "name": "click_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer_host": {
+          "name": "referrer_host",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_qr": {
+          "name": "is_qr",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_rule_id": {
+          "name": "matched_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_up_at": {
+          "name": "rolled_up_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "click_events_link_time_idx": {
+          "name": "click_events_link_time_idx",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_workspace_time_idx": {
+          "name": "click_events_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "click_events_pending_idx": {
+          "name": "click_events_pending_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"click_events\".\"rolled_up_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "click_events_link_id_links_id_fk": {
+          "name": "click_events_link_id_links_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "click_events_workspace_id_workspaces_id_fk": {
+          "name": "click_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "click_events",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "click_events_id_occurred_at_pk": {
+          "name": "click_events_id_occurred_at_pk",
+          "columns": [
+            "id",
+            "occurred_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversions": {
+      "name": "conversions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "value_minor": {
+          "name": "value_minor",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INR'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitor_hash": {
+          "name": "visitor_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversions_workspace_time_idx": {
+          "name": "conversions_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversions_external_key": {
+          "name": "conversions_external_key",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversions\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversions_workspace_id_workspaces_id_fk": {
+          "name": "conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversions_link_id_links_id_fk": {
+          "name": "conversions_link_id_links_id_fk",
+          "tableFrom": "conversions",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_salts": {
+      "name": "daily_salts",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_last4": {
+          "name": "key_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_hash_key": {
+          "name": "api_keys_hash_key",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_workspace_idx": {
+          "name": "api_keys_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_users_id_fk": {
+          "name": "api_keys_created_by_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_workspace_time_idx": {
+          "name": "audit_log_workspace_time_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_workspace_id_workspaces_id_fk": {
+          "name": "audit_log_workspace_id_workspaces_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_actor_id_users_id_fk": {
+          "name": "audit_log_actor_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_blocks": {
+      "name": "bio_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "bio_page_id": {
+          "name": "bio_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked": {
+          "name": "locked",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'::jsonb"
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "bio_blocks_page_position_key": {
+          "name": "bio_blocks_page_position_key",
+          "columns": [
+            {
+              "expression": "bio_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_blocks_bio_page_id_bio_pages_id_fk": {
+          "name": "bio_blocks_bio_page_id_bio_pages_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "bio_pages",
+          "columnsFrom": [
+            "bio_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_blocks_link_id_links_id_fk": {
+          "name": "bio_blocks_link_id_links_id_fk",
+          "tableFrom": "bio_blocks",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bio_pages": {
+      "name": "bio_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "profile_name": {
+          "name": "profile_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_bio": {
+          "name": "profile_bio",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bio_pages_domain_slug_key": {
+          "name": "bio_pages_domain_slug_key",
+          "columns": [
+            {
+              "expression": "domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bio_pages_workspace_id_workspaces_id_fk": {
+          "name": "bio_pages_workspace_id_workspaces_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bio_pages_domain_id_domains_id_fk": {
+          "name": "bio_pages_domain_id_domains_id_fk",
+          "tableFrom": "bio_pages",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_responses": {
+      "name": "form_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "form_responses_form_idx": {
+          "name": "form_responses_form_idx",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_responses_form_id_forms_id_fk": {
+          "name": "form_responses_form_id_forms_id_fk",
+          "tableFrom": "form_responses",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_responses_workspace_id_workspaces_id_fk": {
+          "name": "form_responses_workspace_id_workspaces_id_fk",
+          "tableFrom": "form_responses",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "response_count": {
+          "name": "response_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forms_slug_key": {
+          "name": "forms_slug_key",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_workspace_id_workspaces_id_fk": {
+          "name": "forms_workspace_id_workspaces_id_fk",
+          "tableFrom": "forms",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_webhook_idx": {
+          "name": "webhook_deliveries_webhook_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_workspace_idx": {
+          "name": "webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_workspace_id_workspaces_id_fk": {
+          "name": "webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.abuse_reports": {
+      "name": "abuse_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_contact": {
+          "name": "reporter_contact",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abuse_reports_status_idx": {
+          "name": "abuse_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abuse_reports_slug_idx": {
+          "name": "abuse_reports_slug_idx",
+          "columns": [
+            {
+              "expression": "lower(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abuse_reports_workspace_idx": {
+          "name": "abuse_reports_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "abuse_reports_link_id_links_id_fk": {
+          "name": "abuse_reports_link_id_links_id_fk",
+          "tableFrom": "abuse_reports",
+          "tableTo": "links",
+          "columnsFrom": [
+            "link_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "abuse_reports_workspace_id_workspaces_id_fk": {
+          "name": "abuse_reports_workspace_id_workspaces_id_fk",
+          "tableFrom": "abuse_reports",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_leases": {
+      "name": "job_leases",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "holder": {
+          "name": "holder",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1788074200290,
       "tag": "0011_illegal_kabuki",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788102275275,
+      "tag": "0012_job_leases",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -3,3 +3,4 @@ export * from "./links.js";
 export * from "./analytics.js";
 export * from "./developers.js";
 export * from "./abuse.js";
+export * from "./jobs.js";

--- a/packages/database/src/schema/jobs.ts
+++ b/packages/database/src/schema/jobs.ts
@@ -1,0 +1,56 @@
+import { pgTable, timestamp, varchar } from "drizzle-orm/pg-core";
+
+/* ============================================================
+   Leases for jobs that must not run twice at once.
+
+   The obvious tool is a Postgres advisory lock, and for work
+   that fits in one transaction `pg_try_advisory_xact_lock` is
+   the right answer — it disappears on commit or rollback, with
+   nothing to clean up.
+
+   This table exists for the case that does not fit in one
+   transaction. Partition retention deliberately spans several,
+   so the ACCESS EXCLUSIVE lock a DETACH takes on the parent is
+   released between drops rather than held across the batch. A
+   *session*-scoped advisory lock would cover that, and it is
+   what this replaced — but a session lock lives on the
+   connection, and nothing bounds how long it is held. The
+   worker pools connections and the AWS profile runs
+   DATABASE_POOL_MAX=1, so a process that vanishes mid-pass —
+   a Lambda frozen or reclaimed, which this codebase documents
+   as a real hazard — strands the lock on a backend Postgres
+   still considers healthy. Every later pass then declines, and
+   the job stops running for good with no error to notice.
+
+   A lease cannot outlive its holder, because it expires by the
+   clock rather than by anyone remembering to release it. The
+   worst case degrades to "somebody runs it a few minutes late"
+   instead of "nobody runs it ever again".
+   ============================================================ */
+
+export const jobLeases = pgTable("job_leases", {
+  /** Stable job identifier, e.g. "click_events_prune_retention". */
+  name: varchar("name", { length: 64 }).primaryKey(),
+
+  /**
+   * When the lease lapses and another holder may take it.
+   *
+   * This is the whole mechanism: acquiring is a conditional write against this
+   * column, and releasing sets it to `now()`. A crashed holder needs no
+   * cleanup, because the row is already timestamped to expire.
+   */
+  lockedUntil: timestamp("locked_until", { withTimezone: true }).notNull().defaultNow(),
+
+  /**
+   * Who holds it, for two reasons.
+   *
+   * Diagnostics is the lesser one. The reason it is load-bearing: releasing
+   * checks it, so a holder whose lease already expired — and was taken by
+   * someone else — cannot release a lease it no longer owns and hand a second
+   * process a free run alongside the first.
+   */
+  holder: varchar("holder", { length: 120 }),
+
+  /** When the current holder took it. Purely for reading the logs later. */
+  acquiredAt: timestamp("acquired_at", { withTimezone: true }),
+});


### PR DESCRIPTION
## What does this PR do?

Replaces the session-scoped advisory lock guarding `pruneRetention` with a lease that expires by the clock, so a worker that dies mid-pass can no longer stop retention from ever running again.

Fixes #323

## Why

`pruneRetention` guarded its pass with `pg_try_advisory_lock`. Session-scoped rather than transaction-scoped was the right instinct — the drops deliberately span several transactions so the `ACCESS EXCLUSIVE` lock a `DETACH` takes on the parent is released between them, and a `_xact_` variant would release at the first commit.

The problem is that a session advisory lock lives on the **connection**, and nothing bounds how long it is held. The `finally` covers a thrown error but not the process disappearing. `postgres.js` pools connections and the AWS profile runs `DATABASE_POOL_MAX=1`, so a worker frozen or reclaimed mid-pass — the same hazard that motivated awaiting click writes in #277 — strands the lock on a backend Postgres still considers healthy. Every later pass then takes the early return.

Retention stops permanently, and **silently**: no error, nothing in the logs, and `partitionsDropped: 0` reads identically to "nothing to drop". The first symptom would be a disk graph, or RDS going read-only at the 50 GB autoscale ceiling.

## Why not just remove the guard

That was my first instinct and it is wrong. #283 added `MAX_RETAINED_DAYS`, a volume cap with its **own** drop loop targeting partitions `click_events_spent_partitions` never lists. With two independent drop loops in one function, per-drop idempotence (`click_events_drop_partition` catching `undefined_table`) is not sufficient — the guard has to be at pass level.

So the guard stays, and stops being able to outlive its holder.

## How it works

A `job_leases` row carries `locked_until`. Acquiring is a single conditional upsert, releasing sets it to `now()`, and a crash needs no cleanup because the row is already timestamped to expire. The worst case degrades from *"nobody runs it ever again"* to *"somebody runs it a few minutes late"*.

Two details that are easy to get wrong, both covered by tests:

**Acquire is one statement.** `insert ... on conflict do update ... where locked_until < now()` lets Postgres serialise contenders on the row, and the loser's update is filtered out rather than overwriting the winner's claim. A read-then-write would let both callers come away believing they hold it.

**Release matches on `holder`.** A pass that overruns its TTL no longer owns the lease. Releasing unconditionally would hand the new holder's lease away and let a third pass start alongside it — manufacturing exactly the concurrent execution the lease exists to prevent.

The table is deliberately generic rather than retention-specific: any job that must not overlap and cannot fit in one transaction has the same problem. For work that *does* fit in one transaction, `pg_try_advisory_xact_lock` is still the better tool and the code says so.

## On the TTL

300 seconds, matching the worker Lambda's own timeout — the real ceiling on how long a pass can be alive at all. A pass cannot legitimately run long anyway: `MAX_PARTITION_DROPS` drops across the two loops, each bounded by a 2s `lock_timeout`, so even a pass where every drop times out finishes well inside the lease.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

No new environment variables. `DATABASE_URL` as usual; the lease suite skips without it, matching the other worker suites.

```
pnpm db:up && pnpm db:migrate   # 0012_job_leases
pnpm type-check && pnpm build && pnpm test
```

Migration `0012_job_leases` is additive — a new table, no changes to existing ones — so it applies cleanly to a populated database.

Ten new tests in `apps/worker/src/jobs/lease.test.ts`, including the regression this PR exists for:

- **a holder that dies without releasing does not stop the next pass** — the exact case the advisory lock got wrong, forced by expiring the row directly since nothing else produces that state on demand
- a second holder is refused while the lease is live, and the job does not run at all
- the lease is released on the way out, so sequential passes do not block each other
- a job that throws still releases, and the error is not swallowed
- an overrunning pass does not release a lease someone else has taken
- leases for different job names are independent
- **mutual exclusion under three racing callers**

That last one asserts *peak concurrency*, not "exactly one acquired". Worth calling out: my first version asserted the latter and failed, because two passes acquiring in **sequence** is correct — the first releases on its way out. Counting acquisitions proves nothing; only overlap does.

Results: **495 tests pass** across all packages. The worker suite was run three times consecutively to confirm the concurrency paths are stable.

## Notes for review

- `RETENTION_LEASE_SECONDS` sits next to `MAX_PARTITION_DROPS` and `MAX_RETAINED_DAYS` so the three bounds that shape a pass are read together.
- Not acquiring the lease returns `{ partitionsDropped: 0, rowsDeleted: 0 }` rather than throwing — it is the mechanism working, not a failure. Note this keeps the ambiguity #324 describes, where zeroes cannot be distinguished from lock contention; that is deliberately left to #324 rather than half-solved here.
- `HOLDER` includes the Lambda function name, pid and a random suffix. Correctness only needs it unique per holder; the readable prefix is for reading the table later.

## Checklist

- I haven't checked if my PR needs changes to the documentation

`docs/DECISIONS.md` should record why cross-transaction jobs use a lease while single-transaction ones use an advisory lock, but that belongs in #290, which is already correcting several other claims in one pass.
