### PR TITLE
fix(clicks): retry a click insert once when a concurrent ATTACH invalidates the route

### DIFF
--- a/apps/api/src/common/postgres-error.filter.ts
+++ b/apps/api/src/common/postgres-error.filter.ts
@@ -19,10 +19,10 @@ import { isForeignKeyViolation, isUniqueViolation, postgresErrorCode } from "@sn
 
 /* Re-exported, not redefined.
  *
- * These moved to @snapurl/database because the redirect and worker now need the
- * same cause-chain walk to recognise a transient partition-routing failure on the
- * click write. Two copies of it would be two things to keep in step, and the bug
- * this walk exists to prevent — a code sitting one level down being missed — is
+ * These moved to @snapurl/database because the shared click INSERT lives there
+ * and needs the same cause-chain walk to recognise a transient partition-routing
+ * failure. Two copies of it would be two things to keep in step, and the bug this
+ * walk exists to prevent — a code sitting one level down being missed — is
  * exactly the kind that drift reintroduces. Re-exporting keeps every existing
  * importer in this app working unchanged. */
 export { postgresErrorCode, isUniqueViolation, isForeignKeyViolation };

--- a/apps/api/src/common/postgres-error.filter.ts
+++ b/apps/api/src/common/postgres-error.filter.ts
@@ -1,5 +1,6 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Logger } from "@nestjs/common";
 import type { FastifyReply } from "fastify";
+import { isForeignKeyViolation, isUniqueViolation, postgresErrorCode } from "@snapurl/database";
 
 /* ============================================================
    A backstop so a database constraint can never reach a user as
@@ -16,24 +17,15 @@ import type { FastifyReply } from "fastify";
    message that does not leak schema details.
    ============================================================ */
 
-/** Walks the cause chain — the code can be several levels down. */
-export function postgresErrorCode(err: unknown): string | null {
-  let current: unknown = err;
-  for (let depth = 0; depth < 5 && current; depth++) {
-    const code = (current as { code?: unknown }).code;
-    if (typeof code === "string" && /^\d{5}$/.test(code)) return code;
-    current = (current as { cause?: unknown }).cause;
-  }
-  return null;
-}
-
-export function isUniqueViolation(err: unknown): boolean {
-  return postgresErrorCode(err) === "23505";
-}
-
-export function isForeignKeyViolation(err: unknown): boolean {
-  return postgresErrorCode(err) === "23503";
-}
+/* Re-exported, not redefined.
+ *
+ * These moved to @snapurl/database because the redirect and worker now need the
+ * same cause-chain walk to recognise a transient partition-routing failure on the
+ * click write. Two copies of it would be two things to keep in step, and the bug
+ * this walk exists to prevent — a code sitting one level down being missed — is
+ * exactly the kind that drift reintroduces. Re-exporting keeps every existing
+ * importer in this app working unchanged. */
+export { postgresErrorCode, isUniqueViolation, isForeignKeyViolation };
 
 const STATUS_FOR: Record<string, { status: number; message: string }> = {
   "23505": { status: 409, message: "That already exists." },

--- a/apps/redirect/src/click-sink.ts
+++ b/apps/redirect/src/click-sink.ts
@@ -27,10 +27,18 @@ export interface ClickSink {
 }
 
 export class PostgresClickSink implements ClickSink {
-  constructor(private readonly db: Database) {}
+  /** `onRetry` surfaces a click that had to be re-inserted because a concurrent
+   *  partition ATTACH invalidated its route (#329). Optional so a test can build
+   *  the sink with a bare handle; main.ts wires it to the app logger, because a
+   *  retry firing constantly means partition provisioning has stopped and the
+   *  DEFAULT partition is absorbing live traffic. */
+  constructor(
+    private readonly db: Database,
+    private readonly onRetry?: (err: unknown) => void,
+  ) {}
 
   async record(event: ClickEvent): Promise<void> {
-    await insertClickEvents(this.db, [event]);
+    await insertClickEvents(this.db, [event], { onRetry: this.onRetry });
   }
 }
 

--- a/apps/redirect/src/main.ts
+++ b/apps/redirect/src/main.ts
@@ -224,7 +224,13 @@ async function init(): Promise<void> {
       CLICK_QUEUE_URL,
     );
   } else {
-    clicks = new PostgresClickSink(database!.db);
+    /* Warn rather than error: a retry means the click was *saved*, so nothing is
+       broken. It is the rate that carries information — steady retries mean
+       partition provisioning has fallen behind and the DEFAULT partition is
+       taking live traffic, which is what a metric filter on this line is for. */
+    clicks = new PostgresClickSink(database!.db, (err) =>
+      app.log.warn({ err }, "click insert lost its partition route to a concurrent attach — retried"),
+    );
   }
 
   /* The salt source: the daily_salts table when a Postgres handle exists,

--- a/apps/worker/src/jobs/partitions.test.ts
+++ b/apps/worker/src/jobs/partitions.test.ts
@@ -1,5 +1,18 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { clickEvents, createDatabase, domains, eq, links, sql, workspaces, type Database } from "@snapurl/database";
+import {
+  clickEvents,
+  createDatabase,
+  domains,
+  eq,
+  insertClickEvents,
+  isTransientPartitionRoutingError,
+  links,
+  postgresErrorCode,
+  sql,
+  workspaces,
+  type ClickEvent,
+  type Database,
+} from "@snapurl/database";
 import { ensureClickPartitions, pruneRetention } from "./rollup.js";
 
 /* ============================================================
@@ -29,6 +42,17 @@ const DATABASE_URL = process.env.DATABASE_URL;
 const describeDb = DATABASE_URL ? describe : describe.skip;
 
 const PARENT = "public.click_events";
+
+/** Poll until a condition holds, rather than sleeping and hoping. Used for lock
+ *  state, where a fixed head start has to cover a lazy TCP connect plus auth and
+ *  losing that race makes a test assert the wrong thing. */
+async function waitUntil(what: string, holds: () => Promise<boolean>, tries = 200): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    if (await holds()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
 
 describeDb("click_events partitioning", () => {
   let handle: ReturnType<typeof createDatabase>;
@@ -78,7 +102,7 @@ describeDb("click_events partitioning", () => {
 
   /** The far-future and retention-boundary days these tests provision. */
   async function dropProbePartitions() {
-    for (const offset of [400, 401]) await dropPartition(partitionName(offset));
+    for (const offset of [400, 401, 500]) await dropPartition(partitionName(offset));
 
     const rows = (await db.execute(sql`
       select to_char(d, 'YYYYMMDD') as stamp
@@ -795,4 +819,211 @@ describeDb("click_events partitioning", () => {
 
     expect(await isAttached(straddlingPartition)).toBe(true);
   });
+
+  /* ============================================================
+     #329: a click whose partition route is invalidated mid-insert.
+
+     These two are the premise the unit tests in
+     packages/database/src/click-events.test.ts stand on. Those use
+     a fake `db` and error fixtures — which is the right shape for
+     asserting branches, but it means the detector and its fixtures
+     were written from the same assumption and cannot contradict
+     each other. If Postgres words the failure differently, or does
+     not raise it at all, every one of those tests still passes and
+     the retry never fires in production.
+
+     So: one test that provokes each 23514 a real server can raise
+     here and checks the detector tells them apart, and one that
+     runs the actual race and checks the retry lands the row.
+     ============================================================ */
+
+  it("tells a partition-routing failure apart from the other things that raise 23514", async () => {
+    /* Four producers of 23514 reach this schema, and only the first two are worth
+       retrying. Provoked rather than asserted from fixtures, so the routine names
+       and message text in `isTransientPartitionRoutingError` are checked against
+       the server instead of against my recollection of it. */
+    await ensureClickPartitions(db);
+    const stamp = Date.now();
+    const noon = utcDay(0);
+    noon.setUTCHours(12);
+    const probeTable = `probe_check_${stamp}`;
+    const attachTable = `probe_attach_${stamp}`;
+    // Far enough out that no provisioning pass will ever attach it.
+    const orphanDay = utcDay(4000);
+    orphanDay.setUTCHours(12);
+
+    try {
+      /* 1. The #329 failure itself. Writing straight into the DEFAULT partition a
+            row whose day IS attached reproduces the same error, routine and
+            message as losing the race, without having to orchestrate one. */
+      const routed = await db
+        .execute(
+          sql`insert into click_events_default (link_id, workspace_id, occurred_at, visitor_hash)
+              values (${linkId}, ${workspaceId}, ${noon.toISOString()}, ${`shape-${stamp}`})`,
+        )
+        .then(() => null)
+        .catch((err: unknown) => err);
+
+      expect(routed).not.toBeNull();
+      expect(postgresErrorCode(routed)).toBe("23514");
+      expect(isTransientPartitionRoutingError(routed)).toBe(true);
+
+      /* 2. No partition at all. Unreachable on click_events, which always has a
+            default, so it is provoked on a throwaway table that has none. */
+      await db.execute(sql.raw(`create table "${attachTable}_np" (id int, d date not null) partition by range (d)`));
+      const unrouted = await db
+        .execute(sql.raw(`insert into "${attachTable}_np" values (1, '2020-01-01')`))
+        .then(() => null)
+        .catch((err: unknown) => err);
+
+      expect(postgresErrorCode(unrouted)).toBe("23514");
+      expect(isTransientPartitionRoutingError(unrouted)).toBe(true);
+
+      /* 3. An ordinary CHECK constraint. Retrying this would cost a round trip to
+            fail identically and make a real data problem look intermittent. */
+      await db.execute(sql.raw(`create table "${probeTable}" (n int check (n > 0))`));
+      const checked = await db
+        .execute(sql.raw(`insert into "${probeTable}" values (-1)`))
+        .then(() => null)
+        .catch((err: unknown) => err);
+
+      expect(postgresErrorCode(checked)).toBe("23514");
+      expect(isTransientPartitionRoutingError(checked)).toBe(false);
+
+      /* 4. An ATTACH refused because the default already holds a row for the
+            incoming range. Permanent — the fix is to drain the default, which is
+            what click_events_ensure_partition does — and its message mentions a
+            partition constraint too, so a looser message test would sweep it in
+            and retry DDL that can only fail again. */
+      await db.execute(
+        sql`insert into click_events_default (link_id, workspace_id, occurred_at, visitor_hash)
+            values (${linkId}, ${workspaceId}, ${orphanDay.toISOString()}, ${`orphan-${stamp}`})`,
+      );
+      await db.execute(
+        sql.raw(`create table "${attachTable}" (like "click_events" including defaults including constraints)`),
+      );
+      const refused = await db
+        .execute(
+          sql.raw(`alter table "click_events" attach partition "${attachTable}"
+                   for values from ('${orphanDay.toISOString().slice(0, 10)}')
+                   to ('${new Date(orphanDay.getTime() + 86_400_000).toISOString().slice(0, 10)}')`),
+        )
+        .then(() => null)
+        .catch((err: unknown) => err);
+
+      expect(postgresErrorCode(refused)).toBe("23514");
+      expect(isTransientPartitionRoutingError(refused)).toBe(false);
+    } finally {
+      await db.execute(sql.raw(`drop table if exists "${probeTable}"`));
+      await db.execute(sql.raw(`drop table if exists "${attachTable}"`));
+      await db.execute(sql.raw(`drop table if exists "${attachTable}_np"`));
+      await db.execute(sql`delete from click_events where visitor_hash = ${`orphan-${stamp}`}`);
+    }
+  }, 30_000);
+
+  it("retries a click into the partition that arrived mid-insert instead of losing it", async () => {
+    /* **The #329 regression, run for real.**
+     *
+     * The window is not "an insert happened to run during an ATTACH" — inserts
+     * routed to the DEFAULT partition are already serialised against the attach,
+     * because ATTACH takes ACCESS EXCLUSIVE on the table it drains. The window is
+     * an insert released from that lock at the worst possible moment: it routed to
+     * the default before the attach, so it cannot re-route, and by the time its
+     * partition constraint is evaluated the row belongs somewhere else.
+     *
+     * Staged exactly that way, so it is deterministic rather than a load test:
+     * hold the default's lock, let an insert for an unprovisioned day pile up
+     * behind it, attach that day, commit. Before the retry existed this insert
+     * failed and the click was gone. */
+    const stamp = Date.now();
+    const target = partitionName(500);
+    const day = utcDay(500);
+    const noon = utcDay(500);
+    noon.setUTCHours(12);
+    const visitor = `race-${stamp}`;
+
+    await dropPartition(target);
+    expect(await partitionExists(target)).toBe(false);
+
+    const blocker = createDatabase({ url: DATABASE_URL!, max: 1 });
+    const writer = createDatabase({ url: DATABASE_URL!, max: 1 });
+    let releaseAttach: () => void = () => {};
+    const attachGate = new Promise<void>((resolve) => {
+      releaseAttach = resolve;
+    });
+    const retried: unknown[] = [];
+
+    const lockOn = async (mode: string, granted: boolean) => {
+      const [row] = (await db.execute(sql`
+        select exists(
+          select 1 from pg_locks
+          where relation = 'public.click_events_default'::regclass
+            and mode = ${mode} and granted = ${granted}
+        ) as present
+      `)) as unknown as [{ present: boolean }];
+      return row.present;
+    };
+
+    try {
+      const held = blocker.db.transaction(async (tx) => {
+        // What ATTACH itself would take, held open so the ordering is ours.
+        await tx.execute(sql`lock table click_events_default in access exclusive mode`);
+        await attachGate;
+        await tx.execute(
+          sql`select click_events_ensure_partition(${day.toISOString().slice(0, 10)}::date)`,
+        );
+      });
+
+      await waitUntil("the default's ACCESS EXCLUSIVE lock to be granted", () =>
+        lockOn("AccessExclusiveLock", true),
+      );
+
+      const event: ClickEvent = {
+        linkId,
+        workspaceId,
+        occurredAt: noon,
+        visitorHash: visitor,
+        country: null,
+        city: null,
+        device: null,
+        browser: null,
+        os: null,
+        referrerHost: null,
+        isQr: false,
+        isBot: false,
+        blockedReason: null,
+        matchedRuleId: null,
+        variant: null,
+      };
+      const insert = insertClickEvents(writer.db, [event], {
+        onRetry: (err) => retried.push(err),
+      });
+
+      // The insert has routed to the default and is queued behind the lock. It
+      // cannot re-route from here, which is the whole point.
+      await waitUntil("the click insert to queue behind it", () =>
+        lockOn("RowExclusiveLock", false),
+      );
+
+      releaseAttach();
+      await held;
+      await insert;
+
+      // Retried exactly once, and reported — a silent retry would leave no way to
+      // tell whether provisioning has fallen behind.
+      expect(retried).toHaveLength(1);
+      expect(isTransientPartitionRoutingError(retried[0])).toBe(true);
+
+      // And the click is in the partition that arrived, not lost and not stranded
+      // in the default.
+      expect(await isAttached(target)).toBe(true);
+      expect(await partitionOf(visitor)).toBe(target);
+    } finally {
+      releaseAttach();
+      await blocker.close();
+      await writer.close();
+      await db.execute(sql`delete from click_events where visitor_hash = ${visitor}`);
+      await dropPartition(target);
+    }
+  }, 30_000);
 });

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -1,5 +1,5 @@
 import { deserializeClickEvent, insertClickEvents, resolveDatabaseUrl, runMigrations, type Database } from "@snapurl/database";
-import { initDb, runFrequent, runMaintenance } from "./main.js";
+import { initDb, log, runFrequent, runMaintenance } from "./main.js";
 
 /* The worker as a Lambda, dispatched by a `task` discriminator.
  *
@@ -79,7 +79,16 @@ async function drainClickBatch(db: Database, records: SqsRecord[]): Promise<SqsB
   for (const record of records) {
     try {
       const event = deserializeClickEvent(record.body);
-      await insertClickEvents(db, [event]);
+      /* A retry means the click was saved, so this is a warn, not an error. The
+         rate is the signal: steady retries mean partition provisioning has
+         fallen behind and the DEFAULT partition is taking live traffic (#329). */
+      await insertClickEvents(db, [event], {
+        onRetry: (err) =>
+          log.warn(
+            { err, messageId: record.messageId },
+            "click insert lost its partition route to a concurrent attach — retried",
+          ),
+      });
     } catch {
       /* Report this one for redrive and keep going. The mapping retries only
          the reported ids up to the queue's maxReceiveCount, after which they

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -18,7 +18,9 @@ import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
    test. Nothing about the schedule lives inside the jobs.
    ============================================================ */
 
-const log = pino({ level: process.env.LOG_LEVEL ?? "info" });
+/* Exported so the Lambda entrypoint logs through the same instance rather than
+   creating a second pino with its own level and destination. */
+export const log = pino({ level: process.env.LOG_LEVEL ?? "info" });
 const ROLLUP_SECONDS = Number(process.env.ROLLUP_INTERVAL_SECONDS ?? 30);
 const MAINTENANCE_SECONDS = Number(process.env.MAINTENANCE_INTERVAL_SECONDS ?? 3600);
 

--- a/packages/database/src/click-events.test.ts
+++ b/packages/database/src/click-events.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import { deserializeClickEvent, insertClickEvents, serializeClickEvent, type ClickEvent } from "./click-events.js";
+import type { Database } from "./client.js";
+
+/* ============================================================
+   The shared click INSERT, and its one retry.
+
+   No live Postgres here: the point is the control flow around
+   the insert, not the SQL. A fake `db` records how many times
+   `values()` was reached and can be told to throw a chosen
+   driver error on the first attempt.
+   ============================================================ */
+
+const event: ClickEvent = {
+  linkId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  workspaceId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  occurredAt: new Date("2026-08-30T11:00:00.000Z"),
+  visitorHash: "hash",
+  country: "IN",
+  city: "Pune",
+  device: "desktop",
+  browser: "Chrome",
+  os: "Windows",
+  referrerHost: null,
+  isQr: false,
+  isBot: false,
+  blockedReason: null,
+  matchedRuleId: null,
+  variant: null,
+};
+
+/** Drizzle wraps driver errors and puts the SQLSTATE on `.cause`, so the fake
+ *  has to fail in that shape or the detector would never match. */
+const driverError = (code: string, message: string) =>
+  Object.assign(new Error("Failed query: insert into click_events"), {
+    cause: Object.assign(new Error(message), { code }),
+  });
+
+const PARTITION_RACE = () =>
+  driverError("23514", 'new row for relation "click_events_default" violates partition constraint');
+
+/** A `db` that counts insert attempts and optionally throws on the first. */
+function fakeDb(failFirstWith?: () => Error) {
+  const attempts: unknown[][] = [];
+  const db = {
+    insert: () => ({
+      values: (rows: unknown[]) => {
+        attempts.push(rows);
+        if (failFirstWith && attempts.length === 1) return Promise.reject(failFirstWith());
+        return Promise.resolve();
+      },
+    }),
+  } as unknown as Database;
+  return { db, attempts };
+}
+
+describe("insertClickEvents", () => {
+  it("inserts once when nothing goes wrong", async () => {
+    const { db, attempts } = fakeDb();
+
+    await insertClickEvents(db, [event]);
+
+    expect(attempts).toHaveLength(1);
+    // The whole ClickEvent is mapped, not just the identifiers.
+    expect(attempts[0]![0]).toMatchObject({
+      linkId: event.linkId,
+      workspaceId: event.workspaceId,
+      occurredAt: event.occurredAt,
+      visitorHash: "hash",
+      country: "IN",
+      city: "Pune",
+    });
+  });
+
+  it("is a no-op on an empty batch", async () => {
+    const { db, attempts } = fakeDb();
+    await insertClickEvents(db, []);
+    expect(attempts).toHaveLength(0);
+  });
+
+  it("retries once and succeeds when a concurrent ATTACH invalidates the route", async () => {
+    /* The #329 regression. The row was routed to the DEFAULT partition, an ATTACH
+       for its day committed, and the partition constraint was evaluated after
+       that. Transient by nature: the second attempt plans against fresh
+       catalogue state and lands the row in the partition that now exists.
+       
+       Without the retry this click is lost outright — click writes are awaited,
+       so the caller logs the failure and moves on with the count short. */
+    const { db, attempts } = fakeDb(PARTITION_RACE);
+
+    await expect(insertClickEvents(db, [event])).resolves.toBeUndefined();
+
+    expect(attempts).toHaveLength(2);
+    // The retry sends the same row, not a mutated one.
+    expect(attempts[1]).toEqual(attempts[0]);
+  });
+
+  it("gives up after one retry rather than looping", async () => {
+    // A row failing the same way twice is failing for some other reason, and
+    // should surface instead of being retried into silence.
+    let calls = 0;
+    const db = {
+      insert: () => ({
+        values: () => {
+          calls++;
+          return Promise.reject(PARTITION_RACE());
+        },
+      }),
+    } as unknown as Database;
+
+    await expect(insertClickEvents(db, [event])).rejects.toThrow(/Failed query/);
+    expect(calls).toBe(2);
+  });
+
+  it("does not retry an ordinary check violation", async () => {
+    /* 23514 is shared with every CHECK constraint. Retrying one would cost a
+       round trip to fail identically, and would make a real data problem look
+       intermittent. */
+    const { db, attempts } = fakeDb(() =>
+      driverError("23514", 'new row for relation "workspaces" violates check constraint "x"'),
+    );
+
+    await expect(insertClickEvents(db, [event])).rejects.toThrow(/Failed query/);
+    expect(attempts).toHaveLength(1);
+  });
+
+  it("does not retry an unrelated failure", async () => {
+    const { db, attempts } = fakeDb(() => driverError("23503", "violates foreign key constraint"));
+
+    await expect(insertClickEvents(db, [event])).rejects.toThrow(/Failed query/);
+    expect(attempts).toHaveLength(1);
+  });
+
+  it("round-trips a click through the SQS wire shape unchanged", async () => {
+    // The retry must not have changed what a serialised click looks like, since
+    // the worker's consumer inserts the revived row into the same table.
+    const revived = deserializeClickEvent(serializeClickEvent(event));
+    expect(revived).toEqual(event);
+    expect(revived.occurredAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("insertClickEvents retry logging", () => {
+  it("does not swallow the first error's identity when it gives up", async () => {
+    // The error the caller sees must be a real driver error, so the log line
+    // downstream still carries the SQLSTATE.
+    const db = {
+      insert: () => ({ values: () => Promise.reject(PARTITION_RACE()) }),
+    } as unknown as Database;
+
+    const err = await insertClickEvents(db, [event]).catch((e: unknown) => e);
+    expect((err as { cause?: { code?: string } }).cause?.code).toBe("23514");
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/database/src/click-events.test.ts
+++ b/packages/database/src/click-events.test.ts
@@ -1,14 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
-import { deserializeClickEvent, insertClickEvents, serializeClickEvent, type ClickEvent } from "./click-events.js";
+import { describe, expect, it } from "vitest";
+import {
+  deserializeClickEvent,
+  insertClickEvents,
+  serializeClickEvent,
+  type ClickEvent,
+} from "./click-events.js";
 import type { Database } from "./client.js";
 
 /* ============================================================
    The shared click INSERT, and its one retry.
 
-   No live Postgres here: the point is the control flow around
-   the insert, not the SQL. A fake `db` records how many times
-   `values()` was reached and can be told to throw a chosen
-   driver error on the first attempt.
+   No live Postgres here: the subject is the control flow around
+   the insert, not the SQL. A fake `db` records what reached
+   `values()` on each attempt and can be told to throw a chosen
+   driver error on the first one.
+
+   The real error shapes, and that the retry actually lands the
+   row after a concurrent ATTACH, are pinned against a live
+   server in apps/worker/src/jobs/partitions.test.ts. This file
+   covers the branches; that one covers the premise.
    ============================================================ */
 
 const event: ClickEvent = {
@@ -29,22 +39,31 @@ const event: ClickEvent = {
   variant: null,
 };
 
+const eventAt = (visitorHash: string): ClickEvent => ({ ...event, visitorHash });
+
 /** Drizzle wraps driver errors and puts the SQLSTATE on `.cause`, so the fake
- *  has to fail in that shape or the detector would never match. */
-const driverError = (code: string, message: string) =>
+ *  has to fail in that shape or the detector would never match. Routine and
+ *  message are Postgres 18.6's actual output. */
+const driverError = (code: string, message: string, routine: string) =>
   Object.assign(new Error("Failed query: insert into click_events"), {
-    cause: Object.assign(new Error(message), { code }),
+    cause: Object.assign(new Error(message), { code, routine }),
   });
 
 const PARTITION_RACE = () =>
-  driverError("23514", 'new row for relation "click_events_default" violates partition constraint');
+  driverError(
+    "23514",
+    'new row for relation "click_events_default" violates partition constraint',
+    "ExecPartitionCheckEmitError",
+  );
 
-/** A `db` that counts insert attempts and optionally throws on the first. */
+/** A `db` that records the rows of every insert attempt and optionally throws on
+ *  the first. Recording the rows, not just a count, is what lets the batch
+ *  contract be asserted. */
 function fakeDb(failFirstWith?: () => Error) {
-  const attempts: unknown[][] = [];
+  const attempts: Array<Array<{ visitorHash: string }>> = [];
   const db = {
     insert: () => ({
-      values: (rows: unknown[]) => {
+      values: (rows: Array<{ visitorHash: string }>) => {
         attempts.push(rows);
         if (failFirstWith && attempts.length === 1) return Promise.reject(failFirstWith());
         return Promise.resolve();
@@ -72,6 +91,20 @@ describe("insertClickEvents", () => {
     });
   });
 
+  it("sends every event in the batch, in order", async () => {
+    /* The parameter is an array and the retry resends all of it, so cardinality
+       is part of the contract rather than an implementation detail. Without this,
+       silently inserting only the first row of a batch would pass every other
+       test in this file. */
+    const { db, attempts } = fakeDb();
+    const batch = [eventAt("a"), eventAt("b"), eventAt("c")];
+
+    await insertClickEvents(db, batch);
+
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]!.map((row) => row.visitorHash)).toEqual(["a", "b", "c"]);
+  });
+
   it("is a no-op on an empty batch", async () => {
     const { db, attempts } = fakeDb();
     await insertClickEvents(db, []);
@@ -79,20 +112,55 @@ describe("insertClickEvents", () => {
   });
 
   it("retries once and succeeds when a concurrent ATTACH invalidates the route", async () => {
-    /* The #329 regression. The row was routed to the DEFAULT partition, an ATTACH
-       for its day committed, and the partition constraint was evaluated after
-       that. Transient by nature: the second attempt plans against fresh
-       catalogue state and lands the row in the partition that now exists.
-       
-       Without the retry this click is lost outright — click writes are awaited,
-       so the caller logs the failure and moves on with the count short. */
+    /* **The #329 regression.** The row was routed to the DEFAULT partition, an
+       ATTACH for its day committed, and the partition constraint was evaluated
+       after that. Transient by nature: the failing statement had already pinned
+       its partition descriptor, and a fresh statement builds a new one.
+
+       Without the retry the click is lost outright on the Postgres sink — click
+       writes are awaited, so the caller logs the failure and the count is short. */
     const { db, attempts } = fakeDb(PARTITION_RACE);
 
     await expect(insertClickEvents(db, [event])).resolves.toBeUndefined();
 
     expect(attempts).toHaveLength(2);
-    // The retry sends the same row, not a mutated one.
+  });
+
+  it("resends the whole batch on the retry, unchanged", async () => {
+    // Safe only because the multi-row INSERT is one statement, so the rejected
+    // attempt committed nothing. If that ever stops being true, these rows
+    // duplicate — and `id` is a per-row server-side uuidv7, so nothing detects it.
+    const { db, attempts } = fakeDb(PARTITION_RACE);
+    const batch = [eventAt("a"), eventAt("b"), eventAt("c")];
+
+    await insertClickEvents(db, batch);
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[1]!.map((row) => row.visitorHash)).toEqual(["a", "b", "c"]);
     expect(attempts[1]).toEqual(attempts[0]);
+  });
+
+  it("reports the retry so it is not invisible", async () => {
+    /* The case for the retry is a rate, so there has to be something to count.
+       Called before the second attempt and regardless of whether it succeeds:
+       "how often is the default partition being raced" is the question, and a
+       retry that then fails is still an answer to it. */
+    const { db } = fakeDb(PARTITION_RACE);
+    const seen: unknown[] = [];
+
+    await insertClickEvents(db, [event], { onRetry: (err) => seen.push(err) });
+
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as { cause?: { code?: string } }).cause?.code).toBe("23514");
+  });
+
+  it("does not report a retry when there was none", async () => {
+    const { db } = fakeDb();
+    let calls = 0;
+
+    await insertClickEvents(db, [event], { onRetry: () => calls++ });
+
+    expect(calls).toBe(0);
   });
 
   it("gives up after one retry rather than looping", async () => {
@@ -117,7 +185,11 @@ describe("insertClickEvents", () => {
        round trip to fail identically, and would make a real data problem look
        intermittent. */
     const { db, attempts } = fakeDb(() =>
-      driverError("23514", 'new row for relation "workspaces" violates check constraint "x"'),
+      driverError(
+        "23514",
+        'new row for relation "workspaces" violates check constraint "x"',
+        "ExecConstraints",
+      ),
     );
 
     await expect(insertClickEvents(db, [event])).rejects.toThrow(/Failed query/);
@@ -125,10 +197,24 @@ describe("insertClickEvents", () => {
   });
 
   it("does not retry an unrelated failure", async () => {
-    const { db, attempts } = fakeDb(() => driverError("23503", "violates foreign key constraint"));
+    const { db, attempts } = fakeDb(() =>
+      driverError("23503", "violates foreign key constraint", "ri_ReportViolation"),
+    );
 
     await expect(insertClickEvents(db, [event])).rejects.toThrow(/Failed query/);
     expect(attempts).toHaveLength(1);
+  });
+
+  it("surfaces a driver error the caller can still read the SQLSTATE off", async () => {
+    // The error that escapes must be a real driver error, so the log line
+    // downstream still carries the code.
+    const db = {
+      insert: () => ({ values: () => Promise.reject(PARTITION_RACE()) }),
+    } as unknown as Database;
+
+    const err = await insertClickEvents(db, [event]).catch((e: unknown) => e);
+
+    expect((err as { cause?: { code?: string } }).cause?.code).toBe("23514");
   });
 
   it("round-trips a click through the SQS wire shape unchanged", async () => {
@@ -137,19 +223,5 @@ describe("insertClickEvents", () => {
     const revived = deserializeClickEvent(serializeClickEvent(event));
     expect(revived).toEqual(event);
     expect(revived.occurredAt).toBeInstanceOf(Date);
-  });
-});
-
-describe("insertClickEvents retry logging", () => {
-  it("does not swallow the first error's identity when it gives up", async () => {
-    // The error the caller sees must be a real driver error, so the log line
-    // downstream still carries the SQLSTATE.
-    const db = {
-      insert: () => ({ values: () => Promise.reject(PARTITION_RACE()) }),
-    } as unknown as Database;
-
-    const err = await insertClickEvents(db, [event]).catch((e: unknown) => e);
-    expect((err as { cause?: { code?: string } }).cause?.code).toBe("23514");
-    vi.restoreAllMocks();
   });
 });

--- a/packages/database/src/click-events.ts
+++ b/packages/database/src/click-events.ts
@@ -57,6 +57,18 @@ export function deserializeClickEvent(body: string): ClickEvent {
   return { ...wire, occurredAt: new Date(wire.occurredAt) };
 }
 
+export interface InsertClickEventsOptions {
+  /** Called when the first attempt lost its race with a concurrent `ATTACH` and
+   *  a retry was issued, whether or not the retry then succeeded.
+   *
+   *  This exists so the retry is not invisible. The case for the retry is a rate
+   *  — a fraction of inserts failing under load — and without a signal there is
+   *  no way to tell whether that rate moved, or whether the retry is firing far
+   *  more often than expected because provisioning has stopped running. Both
+   *  callers log it at warn, the same way partition contention is reported. */
+  onRetry?: (err: unknown) => void;
+}
+
 /**
  * The single INSERT path into click_events, shared by PostgresClickSink and the
  * worker's SQS consumer so a click recorded either way is the same row. A no-op
@@ -66,33 +78,56 @@ export function deserializeClickEvent(body: string): ClickEvent {
  * by day with a DEFAULT partition, and the worker attaches new day-partitions
  * while the redirect path is inserting. A row routed to the default can fail its
  * partition constraint when an `ATTACH` for that row's day commits in between —
- * measured at roughly 0.6% of inserts under load, and clustering exactly when
- * provisioning has fallen behind, which is when the default is receiving traffic
- * in the first place.
+ * #329 measured roughly 0.6% of inserts during a loaded provisioning pass, and
+ * the failures cluster exactly when provisioning has fallen behind, which is when
+ * the default is receiving traffic in the first place.
  *
  * That matters more than it sounds. Since click writes became awaited, this is a
- * failed write rather than a delayed one: the visitor still gets their redirect,
- * the error is caught and logged, and the click is simply gone. It is also the
- * exact case the DEFAULT partition exists to prevent — the whole argument for
- * keeping a default is that an insert must never fail for want of a partition,
- * and here one fails *because* a partition arrived.
+ * failed write rather than a delayed one. On the Postgres sink the caller catches
+ * and logs, and the click is simply gone. (On the AWS profile the worker reports
+ * the record in `batchItemFailures` and SQS redrives it, so there the same
+ * failure costs a redrive rather than the click — still worth removing, but not
+ * data loss.) It is also the exact case the DEFAULT partition exists to prevent:
+ * the whole argument for keeping a default is that an insert must never fail for
+ * want of a partition, and here one fails *because* a partition arrived.
  *
- * One retry, not more. The failure is a single relcache invalidation, so the
- * second attempt plans against fresh catalogue state and routes the row to the
- * partition that now exists. A row that fails twice is failing for some other
- * reason and should surface rather than be retried into silence.
+ * One retry, not more. The failing statement had already pinned its partition
+ * descriptor before the invalidation reached it, so it could not re-route; a
+ * fresh statement builds a fresh descriptor and lands the row in the partition
+ * that now exists. A row that fails twice is failing for some other reason and
+ * should surface rather than be retried into silence.
  *
- * The alternative was making `ATTACH` take ACCESS EXCLUSIVE on the parent, which
- * would serialise the insert against the attach and close the window — at the
- * cost of blocking every insert for the duration of every attach. That trade was
- * considered and rejected when the lock modes were chosen.
+ * **Two preconditions, both currently true, both easy to break:**
+ *
+ * 1. `db` must be a pool handle, not a transaction. Inside an explicit
+ *    transaction the 23514 aborts it and the retry fails with `25P02`, which is
+ *    not a code this retries — so the fix would quietly become a no-op. The
+ *    signature asking for `Database` rather than the `Executor` union is what
+ *    enforces this; widening it would need the retry rethought.
+ * 2. Resending the whole batch is safe because Drizzle emits one multi-row
+ *    `INSERT ... VALUES (...), (...)`, and in autocommit that statement is
+ *    all-or-nothing: a rejected attempt commits no rows. There is no second line
+ *    of defence if that ever changes — `id` is a server-side per-row `uuidv7()`,
+ *    so a duplicated click would carry a fresh key, be indistinguishable from a
+ *    real one, and be folded into the rollups.
+ *
+ * The alternative to all of this was making `ATTACH` take ACCESS EXCLUSIVE on the
+ * parent, which would close the window by serialising inserts against the attach
+ * — at the cost of blocking every insert for the duration of every attach. That
+ * trade was considered and rejected when the lock modes were chosen (see
+ * `drizzle/0014_retention_outcomes.sql`).
  */
-export async function insertClickEvents(db: Database, events: ClickEvent[]): Promise<void> {
+export async function insertClickEvents(
+  db: Database,
+  events: ClickEvent[],
+  options?: InsertClickEventsOptions,
+): Promise<void> {
   if (events.length === 0) return;
   try {
     await insertOnce(db, events);
   } catch (err) {
     if (!isTransientPartitionRoutingError(err)) throw err;
+    options?.onRetry?.(err);
     await insertOnce(db, events);
   }
 }

--- a/packages/database/src/click-events.ts
+++ b/packages/database/src/click-events.ts
@@ -1,5 +1,6 @@
 import { clickEvents } from "./schema/index.js";
 import type { Database } from "./client.js";
+import { isTransientPartitionRoutingError } from "./postgres-errors.js";
 
 /* ============================================================
    The click event, and the one INSERT that lands it.
@@ -56,11 +57,47 @@ export function deserializeClickEvent(body: string): ClickEvent {
   return { ...wire, occurredAt: new Date(wire.occurredAt) };
 }
 
-/** The single INSERT path into click_events, shared by PostgresClickSink and
- *  the worker's SQS consumer so a click recorded either way is the same row.
- *  A no-op on an empty batch. */
+/**
+ * The single INSERT path into click_events, shared by PostgresClickSink and the
+ * worker's SQS consumer so a click recorded either way is the same row. A no-op
+ * on an empty batch.
+ *
+ * **Retried once on a partition-routing failure.** `click_events` is partitioned
+ * by day with a DEFAULT partition, and the worker attaches new day-partitions
+ * while the redirect path is inserting. A row routed to the default can fail its
+ * partition constraint when an `ATTACH` for that row's day commits in between —
+ * measured at roughly 0.6% of inserts under load, and clustering exactly when
+ * provisioning has fallen behind, which is when the default is receiving traffic
+ * in the first place.
+ *
+ * That matters more than it sounds. Since click writes became awaited, this is a
+ * failed write rather than a delayed one: the visitor still gets their redirect,
+ * the error is caught and logged, and the click is simply gone. It is also the
+ * exact case the DEFAULT partition exists to prevent — the whole argument for
+ * keeping a default is that an insert must never fail for want of a partition,
+ * and here one fails *because* a partition arrived.
+ *
+ * One retry, not more. The failure is a single relcache invalidation, so the
+ * second attempt plans against fresh catalogue state and routes the row to the
+ * partition that now exists. A row that fails twice is failing for some other
+ * reason and should surface rather than be retried into silence.
+ *
+ * The alternative was making `ATTACH` take ACCESS EXCLUSIVE on the parent, which
+ * would serialise the insert against the attach and close the window — at the
+ * cost of blocking every insert for the duration of every attach. That trade was
+ * considered and rejected when the lock modes were chosen.
+ */
 export async function insertClickEvents(db: Database, events: ClickEvent[]): Promise<void> {
   if (events.length === 0) return;
+  try {
+    await insertOnce(db, events);
+  } catch (err) {
+    if (!isTransientPartitionRoutingError(err)) throw err;
+    await insertOnce(db, events);
+  }
+}
+
+async function insertOnce(db: Database, events: ClickEvent[]): Promise<void> {
   await db.insert(clickEvents).values(
     events.map((event) => ({
       linkId: event.linkId,

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./client.js";
 export * from "./secrets.js";
+export * from "./postgres-errors.js";
 export * from "./schema/index.js";
 export * from "./events.js";
 export * from "./click-events.js";

--- a/packages/database/src/postgres-errors.test.ts
+++ b/packages/database/src/postgres-errors.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { isTransientPartitionRoutingError, postgresErrorCode } from "./postgres-errors.js";
+
+/* ============================================================
+   Recognising the one insert failure that is worth retrying.
+
+   The detector has to be narrow. 23514 is what *any* CHECK
+   constraint raises, and retrying one of those would burn a
+   round trip to arrive at the same answer. So the message is
+   checked too, and these tests pin both halves — including that
+   a plain check violation is NOT retried, which is the assertion
+   that stops the detector quietly widening later.
+   ============================================================ */
+
+/** How the error actually arrives: Drizzle wraps the driver error and the
+ *  SQLSTATE sits on `.cause`. Every case here goes through that shape rather
+ *  than a bare object, because a detector that only works on the unwrapped
+ *  error is the original bug this walk exists to prevent. */
+const wrapped = (code: string, message: string) =>
+  Object.assign(new Error("Failed query: insert into click_events"), {
+    cause: Object.assign(new Error(message), { code }),
+  });
+
+describe("isTransientPartitionRoutingError", () => {
+  it("matches a row that lost its race with a concurrent ATTACH", () => {
+    // The measured failure: the router picked the default, an ATTACH for that
+    // row's day committed, and the constraint was evaluated after it.
+    const err = wrapped(
+      "23514",
+      'new row for relation "click_events_default" violates partition constraint',
+    );
+    expect(isTransientPartitionRoutingError(err)).toBe(true);
+  });
+
+  it("matches a row with nowhere to go", () => {
+    // Only reachable if the DEFAULT partition is missing, but a retry is still
+    // the right response: a provisioning pass may have just created the day.
+    const err = wrapped("23514", 'no partition of relation "click_events" found for row');
+    expect(isTransientPartitionRoutingError(err)).toBe(true);
+  });
+
+  it("does NOT match an ordinary check constraint violation", () => {
+    /* The assertion that keeps the detector narrow. 23514 is shared with every
+       CHECK constraint, and retrying a genuinely invalid row would cost a round
+       trip to fail identically — while making a real data problem look
+       intermittent. */
+    const err = wrapped("23514", 'new row for relation "workspaces" violates check constraint "retention_years_check"');
+    expect(isTransientPartitionRoutingError(err)).toBe(false);
+  });
+
+  it("does not match other SQLSTATEs, even with a partition-shaped message", () => {
+    // Code and message both have to agree, so a message that happens to mention
+    // partitions cannot drag an unrelated failure into the retry path.
+    expect(isTransientPartitionRoutingError(wrapped("23505", "violates partition constraint"))).toBe(false);
+    expect(isTransientPartitionRoutingError(wrapped("42P01", "no partition of relation found"))).toBe(false);
+  });
+
+  it("finds the code through several levels of wrapping", () => {
+    const deep = {
+      message: "outer",
+      cause: { message: "middle", cause: { code: "23514", message: "violates partition constraint" } },
+    };
+    expect(isTransientPartitionRoutingError(deep)).toBe(true);
+  });
+
+  it("returns false for things that are not driver errors", () => {
+    expect(isTransientPartitionRoutingError(new Error("just an error"))).toBe(false);
+    expect(isTransientPartitionRoutingError(null)).toBe(false);
+    expect(isTransientPartitionRoutingError(undefined)).toBe(false);
+  });
+
+  it("terminates on a circular cause chain", () => {
+    // The walk is depth-bounded; a self-referencing cause must not hang it.
+    const a: Record<string, unknown> = { message: "violates partition constraint" };
+    a.cause = a;
+    expect(postgresErrorCode(a)).toBeNull();
+    expect(isTransientPartitionRoutingError(a)).toBe(false);
+  });
+});

--- a/packages/database/src/postgres-errors.test.ts
+++ b/packages/database/src/postgres-errors.test.ts
@@ -5,20 +5,27 @@ import { isTransientPartitionRoutingError, postgresErrorCode } from "./postgres-
    Recognising the one insert failure that is worth retrying.
 
    The detector has to be narrow. 23514 is what *any* CHECK
-   constraint raises, and retrying one of those would burn a
-   round trip to arrive at the same answer. So the message is
-   checked too, and these tests pin both halves — including that
-   a plain check violation is NOT retried, which is the assertion
-   that stops the detector quietly widening later.
+   constraint raises, and two of the four things that raise it
+   here are permanent failures. So `routine` is checked too, and
+   the negative cases below are the ones that matter: they are
+   what stops the check quietly widening later.
+
+   Every fixture is a real observation. The routine names and
+   message strings were provoked against Postgres 18.6 and copied
+   from its output, not recalled — a detector and its fakes
+   written from the same assumption cannot contradict each other,
+   and this one is only worth having if it fires in production.
+   `partitions.test.ts` pins the same strings against a live
+   server so this file cannot drift from reality unnoticed.
    ============================================================ */
 
 /** How the error actually arrives: Drizzle wraps the driver error and the
  *  SQLSTATE sits on `.cause`. Every case here goes through that shape rather
  *  than a bare object, because a detector that only works on the unwrapped
  *  error is the original bug this walk exists to prevent. */
-const wrapped = (code: string, message: string) =>
+const wrapped = (code: string, message: string, routine?: string) =>
   Object.assign(new Error("Failed query: insert into click_events"), {
-    cause: Object.assign(new Error(message), { code }),
+    cause: Object.assign(new Error(message), routine ? { code, routine } : { code }),
   });
 
 describe("isTransientPartitionRoutingError", () => {
@@ -28,37 +35,93 @@ describe("isTransientPartitionRoutingError", () => {
     const err = wrapped(
       "23514",
       'new row for relation "click_events_default" violates partition constraint',
+      "ExecPartitionCheckEmitError",
     );
     expect(isTransientPartitionRoutingError(err)).toBe(true);
   });
 
   it("matches a row with nowhere to go", () => {
-    // Only reachable if the DEFAULT partition is missing, but a retry is still
-    // the right response: a provisioning pass may have just created the day.
-    const err = wrapped("23514", 'no partition of relation "click_events" found for row');
+    /* Only reachable with no DEFAULT partition attached — which migration 0007
+       makes permanent, so in this schema it should never happen. Retried anyway
+       because the cost of being wrong is one round trip, and the alternative is
+       dropping a click on the one failure mode nobody predicted. */
+    const err = wrapped(
+      "23514",
+      'no partition of relation "click_events" found for row',
+      "ExecFindPartition",
+    );
     expect(isTransientPartitionRoutingError(err)).toBe(true);
   });
 
   it("does NOT match an ordinary check constraint violation", () => {
-    /* The assertion that keeps the detector narrow. 23514 is shared with every
-       CHECK constraint, and retrying a genuinely invalid row would cost a round
-       trip to fail identically — while making a real data problem look
-       intermittent. */
-    const err = wrapped("23514", 'new row for relation "workspaces" violates check constraint "retention_years_check"');
+    /* 23514 is shared with every CHECK constraint, and retrying a genuinely
+       invalid row would cost a round trip to fail identically — while making a
+       real data problem look intermittent. */
+    const err = wrapped(
+      "23514",
+      'new row for relation "workspaces" violates check constraint "retention_years_check"',
+      "ExecConstraints",
+    );
+    expect(isTransientPartitionRoutingError(err)).toBe(false);
+  });
+
+  it("does NOT match an ATTACH refused because the default already holds the row", () => {
+    /* The case that keeps the message test specific. This is a *permanent*
+       failure — the fix is to drain the default, not to try again — and its
+       message mentions a partition constraint, so a looser needle such as
+       `includes("partition")` would sweep it in. Raised by DDL rather than by an
+       insert, but `isTransientPartitionRoutingError` is exported from the package
+       under a general name, so it should be right for any caller. */
+    const err = wrapped(
+      "23514",
+      'updated partition constraint for default partition "click_events_default" would be violated by some row',
+      "ATRewriteTable",
+    );
     expect(isTransientPartitionRoutingError(err)).toBe(false);
   });
 
   it("does not match other SQLSTATEs, even with a partition-shaped message", () => {
     // Code and message both have to agree, so a message that happens to mention
     // partitions cannot drag an unrelated failure into the retry path.
-    expect(isTransientPartitionRoutingError(wrapped("23505", "violates partition constraint"))).toBe(false);
-    expect(isTransientPartitionRoutingError(wrapped("42P01", "no partition of relation found"))).toBe(false);
+    expect(
+      isTransientPartitionRoutingError(wrapped("23505", "violates partition constraint")),
+    ).toBe(false);
+    expect(
+      isTransientPartitionRoutingError(wrapped("42P01", "no partition of relation found")),
+    ).toBe(false);
+  });
+
+  it("falls back to the message when no routine reaches it", () => {
+    /* `routine` is preferred because it is not translated, but it is not
+       guaranteed to survive — an error rebuilt from a log, or a driver that drops
+       the field, still has to be recognised. */
+    const err = wrapped(
+      "23514",
+      'new row for relation "click_events_default" violates partition constraint',
+    );
+    expect(isTransientPartitionRoutingError(err)).toBe(true);
+  });
+
+  it("matches on the routine even when the message is not English", () => {
+    /* `errmsg()` output is translated through `lc_messages`. RDS and the official
+       Docker image both default to English, so today the message check holds —
+       but if that ever changed, matching only on text would stop the retry firing
+       with nothing failing to say so. */
+    const err = wrapped(
+      "23514",
+      'la nueva fila para la relación "click_events_default" viola la restricción de partición',
+      "ExecPartitionCheckEmitError",
+    );
+    expect(isTransientPartitionRoutingError(err)).toBe(true);
   });
 
   it("finds the code through several levels of wrapping", () => {
     const deep = {
       message: "outer",
-      cause: { message: "middle", cause: { code: "23514", message: "violates partition constraint" } },
+      cause: {
+        message: "middle",
+        cause: { code: "23514", message: "violates partition constraint" },
+      },
     };
     expect(isTransientPartitionRoutingError(deep)).toBe(true);
   });

--- a/packages/database/src/postgres-errors.ts
+++ b/packages/database/src/postgres-errors.ts
@@ -1,0 +1,75 @@
+/* ============================================================
+   Reading a SQLSTATE off a driver error.
+
+   Drizzle 0.44 wraps driver errors in a DrizzleQueryError and
+   puts the real PostgresError — the one carrying `code` — on
+   `.cause`. Anything checking `err.code` at the top level
+   silently stops matching, which is how a handled 409 once
+   turned into a 500.
+
+   This lives in the database package rather than in the API
+   because three different apps now need it: the API maps codes
+   to HTTP statuses, and the redirect and worker both need to
+   recognise a transient partition-routing failure on the click
+   write. `apps/api/src/common/postgres-error.filter.ts`
+   re-exports these so its existing importers are unchanged.
+   ============================================================ */
+
+/** Walks the cause chain — the code can be several levels down. */
+export function postgresErrorCode(err: unknown): string | null {
+  let current: unknown = err;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && /^\d{5}$/.test(code)) return code;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return null;
+}
+
+export function isUniqueViolation(err: unknown): boolean {
+  return postgresErrorCode(err) === "23505";
+}
+
+export function isForeignKeyViolation(err: unknown): boolean {
+  return postgresErrorCode(err) === "23503";
+}
+
+/** Same walk, for the message rather than the code. */
+function postgresErrorMessage(err: unknown): string {
+  let current: unknown = err;
+  const parts: string[] = [];
+  for (let depth = 0; depth < 5 && current; depth++) {
+    const message = (current as { message?: unknown }).message;
+    if (typeof message === "string") parts.push(message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return parts.join(" | ").toLowerCase();
+}
+
+/**
+ * Did this insert fail only because the table's partitions changed underneath it?
+ *
+ * `click_events` is partitioned by day with a DEFAULT partition as the safety
+ * net, and the worker attaches new day-partitions while the redirect path is
+ * inserting. A row routed to the DEFAULT partition can then fail its partition
+ * constraint: the router picked the default, an `ATTACH` for that row's day
+ * committed, and by the time the constraint was evaluated the row belonged to the
+ * new partition instead.
+ *
+ * Both failures are `23514 check_violation`:
+ *
+ *   - "new row for relation "click_events_default" violates partition constraint"
+ *   - "no partition of relation "click_events" found for row"
+ *
+ * The message is checked as well as the code, because 23514 is also what an
+ * ordinary CHECK constraint raises and retrying one of those would be pointless.
+ *
+ * This is genuinely transient — the second attempt plans against a fresh relcache
+ * and routes the row to the partition that now exists — which is what makes a
+ * retry the honest fix rather than papering over a race.
+ */
+export function isTransientPartitionRoutingError(err: unknown): boolean {
+  if (postgresErrorCode(err) !== "23514") return false;
+  const message = postgresErrorMessage(err);
+  return message.includes("partition constraint") || message.includes("no partition of relation");
+}

--- a/packages/database/src/postgres-errors.ts
+++ b/packages/database/src/postgres-errors.ts
@@ -8,11 +8,14 @@
    turned into a 500.
 
    This lives in the database package rather than in the API
-   because three different apps now need it: the API maps codes
-   to HTTP statuses, and the redirect and worker both need to
-   recognise a transient partition-routing failure on the click
-   write. `apps/api/src/common/postgres-error.filter.ts`
+   because the shared click INSERT needs the same walk to spot a
+   transient partition-routing failure, and that INSERT is in
+   this package. The API also needs it, to map codes to HTTP
+   statuses; `apps/api/src/common/postgres-error.filter.ts`
    re-exports these so its existing importers are unchanged.
+   Copying the walk instead would leave two versions to keep in
+   step, and a code sitting one level down being missed is
+   exactly the bug it exists to prevent.
    ============================================================ */
 
 /** Walks the cause chain — the code can be several levels down. */
@@ -34,7 +37,20 @@ export function isForeignKeyViolation(err: unknown): boolean {
   return postgresErrorCode(err) === "23503";
 }
 
-/** Same walk, for the message rather than the code. */
+/** Same walk, for the `routine` field: the name of the C function that raised
+ *  the error. postgres.js surfaces it from the wire's `R` field. */
+function postgresErrorRoutine(err: unknown): string | null {
+  let current: unknown = err;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    const routine = (current as { routine?: unknown }).routine;
+    if (typeof routine === "string" && routine.length > 0) return routine;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return null;
+}
+
+/** Same walk, for the message. Joined rather than first-wins because Drizzle's
+ *  wrapper carries its own message and either level may hold the useful text. */
 function postgresErrorMessage(err: unknown): string {
   let current: unknown = err;
   const parts: string[] = [];
@@ -46,30 +62,56 @@ function postgresErrorMessage(err: unknown): string {
   return parts.join(" | ").toLowerCase();
 }
 
+/* The two routines that raise 23514 during tuple routing. Both are worth
+   retrying; every other producer of 23514 is not.
+
+   Verified against Postgres 18.6 rather than recalled — see the table in
+   `isTransientPartitionRoutingError`. Matching on `routine` is what makes the
+   check locale-independent: `errmsg()` output is translated through
+   `lc_messages`, `routine` is not. */
+const PARTITION_ROUTING_ROUTINES = new Set(["ExecPartitionCheckEmitError", "ExecFindPartition"]);
+
 /**
  * Did this insert fail only because the table's partitions changed underneath it?
  *
  * `click_events` is partitioned by day with a DEFAULT partition as the safety
  * net, and the worker attaches new day-partitions while the redirect path is
- * inserting. A row routed to the DEFAULT partition can then fail its partition
- * constraint: the router picked the default, an `ATTACH` for that row's day
- * committed, and by the time the constraint was evaluated the row belonged to the
- * new partition instead.
+ * inserting. A row routed to the DEFAULT partition can then fail *its* partition
+ * constraint, because that constraint is "none of the attached ranges" and the
+ * set of attached ranges just changed. Postgres rechecks it precisely for this
+ * reason (commit `ef1e125`, backpatched to 12).
  *
- * Both failures are `23514 check_violation`:
+ * Everything below `23514 check_violation` is shared with ordinary CHECK
+ * constraints, so the code alone is not enough. These four cases were provoked
+ * against Postgres 18.6 and are what the check is built from:
  *
- *   - "new row for relation "click_events_default" violates partition constraint"
- *   - "no partition of relation "click_events" found for row"
+ * | routine                        | message                                                                          | retry |
+ * | ------------------------------ | -------------------------------------------------------------------------------- | ----- |
+ * | `ExecPartitionCheckEmitError`  | new row for relation "click_events_default" violates partition constraint        | yes   |
+ * | `ExecFindPartition`            | no partition of relation "x" found for row                                       | yes   |
+ * | `ExecConstraints`              | new row for relation "x" violates check constraint "y"                           | no    |
+ * | `ATRewriteTable`               | updated partition constraint for default partition "x" would be violated by ...  | no    |
  *
- * The message is checked as well as the code, because 23514 is also what an
- * ordinary CHECK constraint raises and retrying one of those would be pointless.
+ * That last row is why the message test is `violates partition constraint` and
+ * not `partition constraint`: an `ATTACH` refused because the default already
+ * holds a row for the incoming range is a *permanent* failure, and its message
+ * mentions a partition constraint too.
  *
- * This is genuinely transient — the second attempt plans against a fresh relcache
- * and routes the row to the partition that now exists — which is what makes a
- * retry the honest fix rather than papering over a race.
+ * `routine` is checked first because it is not translated. The message is a
+ * fallback for the case where no routine reaches us — an error rebuilt from a
+ * log, or a driver that drops the field — and the two are OR'd rather than
+ * routine being authoritative so that a future Postgres renaming the function
+ * degrades to the message check instead of silently never retrying.
+ *
+ * A retry is honest here rather than papering over a race: the failing statement
+ * had already pinned its partition descriptor before the invalidation arrived,
+ * so it could not re-route. A fresh statement builds a fresh one from the
+ * invalidated relcache and lands the row in the partition that now exists.
  */
 export function isTransientPartitionRoutingError(err: unknown): boolean {
   if (postgresErrorCode(err) !== "23514") return false;
+  const routine = postgresErrorRoutine(err);
+  if (routine !== null && PARTITION_ROUTING_ROUTINES.has(routine)) return true;
   const message = postgresErrorMessage(err);
-  return message.includes("partition constraint") || message.includes("no partition of relation");
+  return message.includes("violates partition constraint") || message.includes("no partition of relation");
 }


### PR DESCRIPTION
Closes #329

## The problem

`click_events` is partitioned by day, with a DEFAULT partition as the safety net for days that have not been provisioned yet. The worker attaches new day-partitions while the redirect path is inserting.

A row routed to the default can fail its own partition constraint, because that constraint is "none of the attached ranges" and the set of attached ranges just changed:

1. The tuple router looks at the catalogue, sees no partition for the row's day, picks `click_events_default`, and asks for `ROW EXCLUSIVE` on it.
2. `ATTACH` holds `ACCESS EXCLUSIVE` on the default while it drains, so the insert queues behind it.
3. The attach commits. The insert is released, processes the invalidation, and evaluates the default's constraint — which no longer covers that day. It cannot re-route, because its partition descriptor was pinned before the invalidation arrived.

```
SQLSTATE 23514: new row for relation "click_events_default" violates partition constraint
```

Postgres rechecks the default's constraint during routing precisely for this reason (commit `ef1e125`, backpatched to 12).

#329 measured **93 of 15164 inserts (~0.6%)** during a loaded provisioning pass. Same rate on `main`, so it is not a regression from a recent change.

It matters more than the rate suggests:

- Since #277 made click writes awaited, this is a **failed** write rather than a delayed one. On the Postgres sink the caller catches, logs, and the click is silently gone from analytics.
- It clusters exactly when provisioning has fallen behind, because that is when the default is receiving traffic at all. The failures arrive in a burst, on the busiest window, when the system is already degraded.
- It is the precise scenario the DEFAULT partition exists to prevent. The whole argument for keeping a default is that an insert must never fail for want of a partition — and here one fails *because* a partition arrived.

## The change

`insertClickEvents` retries once on that specific failure, and reports that it did.

```ts
try {
  await insertOnce(db, events);
} catch (err) {
  if (!isTransientPartitionRoutingError(err)) throw err;
  options?.onRetry?.(err);
  await insertOnce(db, events);
}
```

**In the shared insert, not in `PostgresClickSink`.** The worker's SQS consumer drains the queue back into the same table through the same function, so on the AWS profile the sink is not even on the path. Both writers need the retry; there is one place that is both of them.

**One retry, not a loop with backoff.** The failing statement had already pinned its partition descriptor, so it could not re-route. A fresh statement builds a fresh one and lands the row in the partition that now exists. A row that fails the same way twice is failing for some other reason and should surface rather than be retried into silence.

**Matched on `routine`, with the message as a fallback.** `23514` is `check_violation` — what every CHECK constraint raises. All four producers that reach this schema were provoked against Postgres 18.6:

| routine | message | retry |
| --- | --- | --- |
| `ExecPartitionCheckEmitError` | new row for relation "click_events_default" violates partition constraint | yes |
| `ExecFindPartition` | no partition of relation "x" found for row | yes |
| `ExecConstraints` | new row for relation "x" violates check constraint "y" | no |
| `ATRewriteTable` | updated partition constraint for default partition "x" would be violated by some row | no |

That last row is the interesting one: an `ATTACH` refused because the default already holds a row for the incoming range is a **permanent** failure, and its message mentions a partition constraint too. Matching on `partition constraint` would have swept it in.

`routine` is checked first because `errmsg()` output is translated through `lc_messages` and `routine` is not — a non-English server would otherwise stop retrying with no failing test and no log line, which is the same silence this fix exists to end. The message is kept as a fallback, OR'd rather than routine being authoritative, so a future Postgres renaming the function degrades to a text match instead of quietly never retrying.

**The retry is not invisible.** `onRetry` is optional and both writers log it at warn — the redirect through the Fastify logger, the worker through the shared pino instance. The case for this change is a rate, so there has to be something to count. Steady retries mean provisioning has stopped running and the DEFAULT partition is absorbing live traffic, which is the actual problem to go fix.

## What this deliberately does not do

It does not promote `ATTACH` to `ACCESS EXCLUSIVE` on the parent. That would close the window by serialising every insert against the attach, not just the ones routed to the default. #324 chose `SHARE UPDATE EXCLUSIVE` specifically so provisioning cannot stall the redirect path, and that trade still holds: a 0.6% retry costs one extra round trip on those rows, where the lock promotion costs latency on all of them.

## Two preconditions, documented because they are easy to break

1. **`db` must be a pool handle, not a transaction.** Inside an explicit transaction the 23514 aborts it and the retry fails with `25P02`, which this does not retry — the fix would quietly become a no-op. The signature asking for `Database` rather than the exported `Executor` union is what enforces it.
2. **Resending the batch is safe only because Drizzle emits one multi-row `INSERT ... VALUES (...), (...)`,** which is all-or-nothing in autocommit. There is no second line of defence if that changes: `id` is a server-side per-row `uuidv7()`, so a duplicated click would carry a fresh key, be indistinguishable from a real one, and be folded into the rollups.

## Refactor included

The Drizzle cause-chain walk (`postgresErrorCode`, `isUniqueViolation`, `isForeignKeyViolation`) moved from `apps/api/src/common/postgres-error.filter.ts` into a new `packages/database/src/postgres-errors.ts`, joined by `isTransientPartitionRoutingError`.

The detector belongs next to the statement it guards, and the walk it needs was in the wrong package. The filter re-exports all three names, so its existing importers (`links.service.ts`, `forms.service.ts`, `api.test.ts`) are untouched. Copying the ten-line walk instead would leave two versions to keep in step — and the bug it exists to prevent, a SQLSTATE sitting one level down being missed, is exactly the kind that drift reintroduces. It already turned a handled 409 into a 500 once.

## Testing

**24 tests added.**

Unit (`packages/database`, 12 + 10): the control flow around the insert and the branches of the detector, with a fake `db` that records the rows of every attempt. Retry-then-succeed; gives up after exactly two attempts; batch cardinality in and out; the retry resends the whole batch unchanged; `onRetry` fires once and only on a retry; a plain check violation is not retried; the `ATTACH`-refused wording is not retried; a non-English message still matches via `routine`; a missing `routine` still matches via the message; the walk finds the code several levels down and terminates on a circular cause chain; the surfaced error still carries the SQLSTATE.

Integration (`apps/worker/src/jobs/partitions.test.ts`, 2, live Postgres): the unit tests use fixtures the detector's author also wrote, so they cannot contradict it. These can.

- All four 23514s provoked against the real server, asserting the detector separates them. The routine names and message strings in the source are now checked against Postgres rather than against recollection.
- **The actual race, staged deterministically.** Hold the default's `ACCESS EXCLUSIVE` lock from a second connection, let an insert for an unprovisioned day queue behind it, attach that day, commit. The insert is released into exactly the window above. Asserts the retry fired *and* that the click ended up in the partition that arrived — not lost, not stranded in the default.

They live in `partitions.test.ts` rather than a new file so they serialise against the other partition-machinery tests instead of racing them for the same locks from a parallel vitest worker.

**Four mutations verified:**

| mutation | caught by |
| --- | --- |
| retry removed | 4 unit tests + the live race test |
| message needle widened to `"partition"` | 1 unit test + the live 23514 test |
| batch truncated to `events.slice(0, 1)` | 2 unit tests |
| `routine` match only, message fallback removed | 2 unit tests |

The "gives up after one retry" test asserts an exact attempt count of 2, so a change to the retry limit fails it by construction.

- `pnpm type-check` clean
- `pnpm test` — 527 passed, up from 503

## Reviewer's shortcut

The retry only fires for rows headed to the DEFAULT partition, so the honest way to make it unreachable is to keep provisioning ahead of traffic. This is a safety net under the safety net, and the `onRetry` warn is there to say when it is carrying more weight than it should.
