### PR TITLE
docs: make the documentation true (#290)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,108 @@
+# SnapURL 2.0 — architecture
+
+The core is a stateless ports-and-adapters application. The deployment
+**profile**, not the code, chooses which adapter runs behind each port: a link
+resolver reads Postgres in one profile and DynamoDB in another, a click sink
+writes Postgres in one and SQS in another, and the application logic above them
+does not know or care which. Every profile runs the same compiled images; the
+adapters are selected at deploy time by environment variables.
+
+Companion documents: [DECISIONS.md](./DECISIONS.md) for every judgement call and
+why, [DEPLOYMENT.md](./DEPLOYMENT.md) for how to ship each profile, and
+[BACKEND.md](./BACKEND.md) for how to run it locally.
+
+---
+
+## Ports and their adapters
+
+Each port is a narrow interface. The adapters listed below are the ones that
+**actually exist in the tree today** — where a port has only one adapter, that
+is stated plainly rather than dressed up as a choice.
+
+| Port | Interface | Adapters that exist today |
+| --- | --- | --- |
+| `LinkResolver` | `apps/redirect/src/resolver.ts` | `PostgresLinkResolver` (default) and `DynamoLinkResolver` (AWS profile, `LINK_PROJECTION=dynamo`). Both are wrapped by `CachingLinkResolver` (`apps/redirect/src/caching-resolver.ts`), a short-lived cache in front of whichever inner resolver is chosen. |
+| `ClickSink` | `apps/redirect/src/click-sink.ts` | `PostgresClickSink` (default — `INSERT` straight into `click_events`) and `SqsClickSink` (`CLICK_SINK=sqs` — an awaited SQS `SendMessage`, drained back into `click_events` by the worker). |
+| `ProjectionTarget` | `apps/worker/src/jobs/outbox.ts` | `NoProjection` (default, a no-op) and `DynamoProjection` (`apps/worker/src/jobs/dynamo-projection.ts` — drains `projection_outbox` into the DynamoDB `LinkProjectionTable`, and also writes the CloudFront `KeyValueStore` for the edge fast path). |
+| `AnalyticsReader` | `apps/api/src/analytics/analytics.reader.ts` | `PostgresAnalyticsReader` only. The seam is real and bound via DI (`ANALYTICS_READER` in `analytics.module.ts`), but a columnar adapter is future work — this port is genuinely still single-adapter today, and that is not hidden. |
+| `CacheStore` | `packages/cache/src/cache-store.ts` | `MemoryCacheStore` (default), `RedisCacheStore`, `DynamoDbCacheStore`, selected by `CACHE_DRIVER` through `createCacheStore` in `packages/cache/src/factory.ts`. The redis and dynamodb branches `await import()` lazily, so a memory-only deployment never loads `ioredis` or the AWS SDK. |
+| `SaltSource` | `apps/redirect/src/salt.ts` | `PostgresSaltCache` (the `daily_salts` table, used whenever the redirect holds a Postgres handle) and `CacheStoreSaltCache` (reads/writes the shared `CacheStore` — DynamoDB on the AWS profile — which is what lets the redirect leave Postgres entirely). |
+| Mail seam | `apps/api/src/mail/mail.service.ts` | `MailService.send` with the `outbox` transport (writes each message under `os.tmpdir()/snapurl-outbox`). The `ses` branch logs "not wired yet" and is future work. |
+
+The point of every one of these seams is that turning an AWS feature on is a
+config change, not a rewrite. The two projection switches (`LINK_PROJECTION`,
+`CLICK_SINK`) both default OFF, so every non-AWS profile runs the Postgres paths
+byte-for-byte unchanged.
+
+---
+
+## The three deployment profiles
+
+### Profile 1 — Single node (the reference implementation)
+
+Postgres throughout. `CACHE_DRIVER` unset or `memory`, so the in-memory
+`CacheStore`; in-process click batching; `LINK_PROJECTION` unset;
+`CLICK_SINK=postgres`. Nothing to run alongside the app, no container to warm,
+no extra dependency. This is what `docker compose --profile full` runs, and it
+is **the only profile with a green smoke run in CI today** (both smoke suites
+pass against the composed stack). It is the honest baseline the other two are
+measured against.
+
+### Profile 2 — Horizontally scaled / cloud-agnostic
+
+Postgres primary plus an optional read replica (via `createDatabase`'s read URL,
+so reads through `readDb` land on the replica while writes stay on the primary).
+Redis for the `CacheStore`, rate-limit counters, queueing and sketch merging —
+one container that runs anywhere. Optional columnar analytics *behind* the
+`AnalyticsReader` port (the seam is there; the adapter is not yet). The Helm
+chart lives in `deploy/helm`. This profile has no green CI smoke run yet, so by
+the epic's honesty rule it is documented as **experimental**.
+
+### Profile 3 — AWS-native serverless
+
+Lambda for all three apps. The redirect reads a DynamoDB `LinkProjectionTable`
+via `DynamoLinkResolver`; clicks go to an SQS `ClickQueue` drained by the
+worker's `SqsEventSource` (event source mapping, `reportBatchItemFailures`); a
+CloudFront Function plus `KeyValueStore` answer edge-eligible simple links at the
+edge; a DynamoDB `CacheTable` backs the shared salt so a redirect that has left
+the VPC still salts its visitor hashes without a Postgres connection; egress is
+governed by `natStrategy`; and under `LINK_PROJECTION=dynamo` + `CLICK_SINK=sqs`
+the redirect drops its `vpcSettings` and leaves the VPC entirely.
+
+Following [DECISIONS.md](./DECISIONS.md)'s honesty framing, the adapters and the
+CDK shape are **built and CI/synth-proven**, but **no real `cdk deploy`** has run
+against a real account. So a real edge invocation, a real SQS round trip, and a
+real no-VPC DynamoDB resolution are all **deploy-deferred**. This profile is
+therefore **experimental** — it has no green CI smoke run. It is *not*
+"404s-on-everything": that was the pre-#274 state, before the origin request
+policy forwarded the viewer headers and the resolver/sink adapters landed, and
+it is no longer true.
+
+---
+
+## Per-profile decisions the epic introduces
+
+### The egress call — `natStrategy` (AWS profile only, #281)
+
+Egress is a property of the AWS profile, wired from
+`app.node.tryGetContext('natStrategy')` in `infra/bin/snapurl.ts`. Options:
+`'instance'` (default, a t4g.nano NAT instance, ~$3/mo), `'gateway'` (managed
+NAT, ~$32/mo), `'none'` ($0, the original zero-egress topology, where Safe
+Browsing / webhooks / OAuth / mail are non-functional by design). NAT was chosen
+over a free egress-only IPv6 IGW because arbitrary customer webhook receivers
+cannot be relied on to publish `AAAA` records, so IPv6-only egress would leave
+webhook coverage patchy. This decision applies to the AWS profile only; the
+other two profiles run wherever their operator puts them. Full reasoning in
+[DECISIONS.md](./DECISIONS.md).
+
+### The click-accounting call for edge-served redirects (#289)
+
+The edge fast path serves only links where per-click accuracy does not matter.
+Any link with a click limit or an analytics commitment stays authoritative in
+the Lambda, so the count that gates a limit is never decided by a request the
+origin never saw. Only simple links — no limit, no per-click obligation — are
+promoted to the CloudFront `KeyValueStore`. This keeps the click counter's
+bounded overshoot (the Postgres `link_counters` value recomputed by the rollup
+worker, read by both resolvers) the *only* source of imprecision, rather than
+adding an untracked edge-served population on top of it. Cross-referenced in
+[DECISIONS.md](./DECISIONS.md) (assumption 8 and the Profile 3 section).

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -79,9 +79,11 @@ safe" and "Checked against Google Safe Browsing". The API logs a warning at boot
 and on first use. Either set the key or change the copy — right now the product
 makes a claim it is not backing up.
 
-**Email is stubbed.** Invitations write to `logs/outbox/` instead of sending.
-SES needs a verified domain and a sandbox-exit request. `MailService` is the
-seam; wiring SES is one adapter.
+**Email is stubbed.** With `MAIL_TRANSPORT=outbox` (the default) invitations are
+written to a file under `os.tmpdir()/snapurl-outbox` (overridable via
+`MAIL_OUTBOX_DIR`) instead of sending. SES needs a verified domain and a
+sandbox-exit request and remains unwired. `MailService.send` is the seam; wiring
+SES is one adapter.
 
 ## Environment
 
@@ -106,12 +108,15 @@ the rest — the full table is in [DECISIONS.md](./DECISIONS.md) Part 4.
 
 ## Deploying
 
-Nothing here is AWS-specific yet — no CDK stack is written. The apps read their
-config from the environment and the ports are conventional, so they will run on
-anything that runs Node.
+`infra/` is a CDK v2 stack — the AWS serverless profile. The apps themselves
+stay cloud-agnostic: they read all config from the environment and the ports are
+conventional, so the single-node and Kubernetes profiles run on anything that
+runs Node 22. See [DEPLOYMENT.md](./DEPLOYMENT.md) for how to ship, and
+[ARCHITECTURE.md](./ARCHITECTURE.md) for the ports and the three profiles.
 
-When you do deploy: the short version is that Lambda, DynamoDB, CloudFront and SQS all sit inside
-AWS's always-free tiers at this scale, and Postgres is the only line that
-actually costs money — about 92% of the bill. Run it on a free-tier Postgres
-elsewhere and the $100 credit outlives the project; run it on RDS and you have
-about six months.
+When you do deploy: the short version is that Lambda, DynamoDB, CloudFront and
+SQS all sit inside AWS's always-free tiers at this scale, and **Postgres is
+roughly 92% of the bill**. Run it on a free-tier Postgres elsewhere and the $100
+credit outlives the project; run it on RDS and, at ~$15.50/month (Postgres plus
+the default ~$3/mo NAT instance), the $100 lasts about **6.5 months** (100 /
+15.5 ≈ 6.5) — not the 12 months the credits are *valid* for.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -215,13 +215,28 @@ An internal transport would be ceremony.
    costs money. A regex list catches the obvious crawlers, and `is_bot` is a column, so
    reclassifying later is an UPDATE rather than a re-ingest.
 
-7. **GeoIP uses CloudFront's `CloudFront-Viewer-Country` header.** Free and accurate at country
-   level, which is all the contract reports. No MaxMind database to ship or license.
+7. **GeoIP uses CloudFront's `CloudFront-Viewer-Country` header (ISO 3166-1 alpha-2).** This is
+   now consistent with both the code and the CDK stack. The AWS profile's origin request policy in
+   `infra/lib/snapurl-stack.ts` forwards `CloudFront-Viewer-Country` (and `CloudFront-Viewer-City`)
+   to the redirect origin, so `apps/redirect/src/main.ts` reads
+   `request.headers['cloudfront-viewer-country']` and populates `click_events.country`. It was
+   *not* forwarded before #274 — the header existed at the edge but the origin request policy
+   dropped it, so country was always null; it is forwarded now. Country is free and accurate at
+   country level, which is all the contract reports, with no MaxMind database to ship or license.
+   The city-level detail on the same header family, and the two limits that come with it, are in
+   Part 4b ("City-level geo").
 
-8. **Click limits may overshoot slightly.** The counter is a DynamoDB conditional write; under
-   concurrent clicks a hard cap can be exceeded by a handful. The alternative is a synchronous
-   read-modify-write on the hot path, which costs more latency than the accuracy is worth for a
-   feature whose main use is "roughly 500 beta invites."
+8. **Click limits may overshoot slightly.** The click-limit gate reads a denormalised counter in
+   the Postgres `link_counters` table (`packages/database/src/schema/links.ts`), recomputed by the
+   rollup worker (`apps/worker/src/jobs/rollup.ts`) and read as `coalesce(link_counters.clicks, 0)`
+   by the gate in `apps/api/src/links/links.service.ts` and `apps/redirect/src/resolver.ts`. It is
+   *not* a live count and *not* a DynamoDB conditional write — the counter moved off the `links`
+   table into `link_counters` in #270. Under concurrent clicks a hard cap can be overshot by a
+   handful because the gate reads the last rollup's value, which is the same bounded overshoot the
+   DynamoDB projection path carries at projection time (see the Profile 3 section later in this
+   file — the two resolvers cannot disagree beyond the rollup lag they share). The alternative, a
+   synchronous read-modify-write on the hot path, costs more latency than the accuracy is worth for
+   a feature whose main use is "roughly 500 beta invites."
 
 9. **Uniques reset at 00:00 UTC and a visitor on a new network counts twice.** This is inherent to
    the cookieless daily-salt design the product promises, not a bug. It should be said plainly in
@@ -261,8 +276,18 @@ An internal transport would be ceremony.
     webhooks) needs egress, so it only functions when `natStrategy != 'none'`.
 
 12. **No rate limit on the redirect path.** Rate limiting the dashboard API protects the database;
-    rate limiting redirects would mean a state lookup on the hot path, and CloudFront already
-    absorbs volume. Abuse protection there belongs at WAF, which costs money.
+    rate limiting redirects would mean a state lookup on the hot path. The edge absorbs only a
+    narrow band of volume, not a blanket cache of every redirect: the CloudFront KeyValueStore fast
+    path answers edge-eligible simple links, and the `RedirectCdn` default behaviour uses a short
+    1–5s edge TTL cache policy (`defaultTtl` 1s, `maxTtl` 5s in `infra/lib/snapurl-stack.ts`,
+    replacing the earlier `CACHING_DISABLED`) that coalesces burst and QR-scan storms. Everything
+    else reaches the origin, and the browser is sent `no-store` (from `cacheHeadersFor()` in
+    `packages/domain/src/destination.ts`), so no visitor caches a stale 302. Abuse protection on
+    the redirect path therefore belongs at WAF, which costs money — and, because caching is
+    effectively disabled for correctness, a WAF *raises* the per-1M marginal cost rather than
+    lowering it (it inspects every redirect, including the ones the edge would otherwise serve
+    cheaply). The corrected figure is in [DEPLOYMENT.md](./DEPLOYMENT.md)'s cost section: roughly
+    $1.57 + $0.60 ≈ **$2.17 per 1M**, not a fall to ~$1.10.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,8 +4,14 @@ The frontend and the backend deploy separately and have almost nothing in
 common operationally. That is deliberate — see [ARCHITECTURE](./ARCHITECTURE.md)
 for why the redirect path and the dashboard are treated as different systems.
 
-This document covers the **frontend on Vercel**. The backend on AWS is tracked
-separately and is not yet implemented.
+This document covers the **frontend on Vercel** and the **backend** — both the
+container images that run anywhere Node 22 runs and the AWS serverless profile
+in `infra/`. The AWS profile is the experimental one: its adapters and CDK shape
+are built and CI/synth-proven, but no real `cdk deploy` has run against a real
+account yet, so by the epic's rule (a profile without a green smoke run in CI is
+documented as experimental) it is treated as such. See
+[ARCHITECTURE](./ARCHITECTURE.md) for the ports-and-adapters core and the three
+deployment profiles.
 
 ---
 
@@ -243,8 +249,13 @@ Both are resolved by CloudFormation **at deploy time** and land in the Lambda's
 environment. Neither is baked into a container image — the images are built
 from the repository alone and contain no configuration, so the same image is
 deployable to any stage. [DECISIONS.md](./DECISIONS.md) has the reasoning and
-what it costs; the short version is that reading either at cold start needs an
-interface VPC endpoint at ~$7/month, because there is no NAT.
+what it costs. Deploy-time resolution stays the default; the earlier "reading
+either at cold start needs a ~$7/month interface VPC endpoint because there is
+no NAT" constraint no longer strictly holds, because the default `natStrategy`
+now gives the app Lambdas egress (see [ARCHITECTURE.md](./ARCHITECTURE.md) and
+the natStrategy section below) — a runtime SSM/Secrets Manager lookup is now
+reachable over the NAT without a dedicated endpoint. That unblocks issue #292
+but is deliberately not implemented here.
 
 The stack has no defaults for the parameters. A missing one fails the deploy
 naming the parameter, which is a better time to find out than the first
@@ -265,11 +276,14 @@ refresh token and never expire. That is $0.80/month in Secrets Manager, about
 
 | | |
 | --- | --- |
-| VPC | 2 AZs, public + isolated subnets, **zero NAT gateways** |
-| RDS | PostgreSQL 18, `db.t4g.micro`, single-AZ, 20 GB gp3, isolated subnets |
+| VPC | 2 AZs, public + isolated subnets. Egress is parameterised by `natStrategy` (default `'instance'`: a t4g.nano NAT instance, ~$3/mo, with the app Lambdas in `PRIVATE_WITH_EGRESS`). `'gateway'` is a managed NAT (~$32/mo); `'none'` keeps the original zero-egress topology. See the natStrategy section below. |
+| RDS | PostgreSQL 18, `db.t4g.micro`, single-AZ, 20 GB gp3, always `PRIVATE_ISOLATED` (it never egresses) |
+| DynamoDB | `LinkProjectionTable` (PAY_PER_REQUEST, PITR, `linkId` GSI) read by the redirect's `DynamoLinkResolver`; a separate `CacheTable` (TTL on `expiresAt`) backing the shared `CacheStore` — `CACHE_DRIVER=dynamodb` + `CACHE_DYNAMO_TABLE` are set on `redirectFn` |
+| SQS | `ClickQueue` for the redirect's `SqsClickSink`, plus a `ClickDlq` dead-letter queue |
+| CloudFront | a `KeyValueStore` for the edge fast path (simple links answered at the edge), and a short 1–5s edge TTL cache policy on the redirect behaviour |
 | API | Lambda (container image) behind an HTTP API |
-| Redirect | Lambda (container image) behind CloudFront |
-| Worker | Lambda, invoked once a minute by EventBridge |
+| Redirect | Lambda (container image) behind CloudFront. Under the AWS profile (`LINK_PROJECTION=dynamo` + `CLICK_SINK=sqs`) it drops its `vpcSettings` and leaves the VPC entirely |
+| Worker | Lambda invoked once a minute by EventBridge for rollups; also drains the `projection_outbox` into the DynamoDB `LinkProjectionTable` and the CloudFront `KeyValueStore`, and consumes `ClickQueue` via an `SqsEventSource` (event source mapping, `reportBatchItemFailures: true`) to write `click_events` |
 
 ### The cost model, which dictates every choice above
 
@@ -277,41 +291,87 @@ The account is on the free tier introduced in **July 2025**: $100 in credits,
 valid 12 months, and **no 750-hour RDS allowance** — that was part of the old
 12-month tier and does not apply to accounts created since.
 
-At this workload Lambda, CloudFront and SSM sit inside always-free tiers that
-never expire. **Postgres is roughly 92% of the bill**, about $15/month, so
-$100 covers roughly six months.
+At this workload Lambda, CloudFront, DynamoDB, SQS and SSM sit inside
+always-free tiers that never expire. **Postgres is roughly 92% of the bill**,
+and with the default `natStrategy = 'instance'` (a ~$3/month NAT instance) the
+total is about **$15.50/month**. The credits are valid for 12 months, but that
+is the *validity window*, not how long they last: at ~$15.50/month the $100
+balance is exhausted in about **6.5 months** (100 / 15.5 ≈ 6.5), well before the
+12-month window closes.
 
 Two decisions follow from that, and both are worth understanding before
 changing anything:
 
-**No NAT gateway.** A NAT costs ~$32/month before a byte moves — more than
-everything else in this stack combined, including the database. The standard
-"put RDS in a private subnet" tutorial creates one without mentioning it. The
-subnets here are `PRIVATE_ISOLATED`, not `PRIVATE_WITH_EGRESS`, because the
-latter implies a NAT.
+**Egress is configurable via `natStrategy`, defaulting to a NAT instance.** A
+managed NAT *gateway* costs ~$32/month before a byte moves — more than
+everything else in this stack combined, including the database — so it is not
+the default. The default is a single t4g.nano NAT *instance* (~$3/month), which
+gives the app Lambdas egress for a fraction of the gateway's cost; `'gateway'`
+is the one-flag upgrade to per-AZ redundancy, and `'none'` preserves the
+original zero-egress topology at $0. RDS always stays `PRIVATE_ISOLATED` (it
+never egresses); the app Lambdas move to `PRIVATE_WITH_EGRESS` when NAT is on.
+See the natStrategy section below.
 
 **Lambda, not Fargate.** Three Fargate tasks behind an ALB would be roughly
 $58/month against Lambda's ~$0 — the credits would be gone in under two months.
 
-### Two consequences of having no NAT
+### natStrategy: what egress costs and what it enables
 
-Lambdas in isolated subnets can reach the database and nothing else. That is
-fine, because the application needs nothing else — there is no AWS SDK anywhere
-in `apps/` or `packages/`, and the redirect service writes clicks straight to
-Postgres via `PostgresClickSink`.
+`natStrategy` is a stack prop wired from `app.node.tryGetContext('natStrategy')`
+in `infra/bin/snapurl.ts`, defaulting to `'instance'`.
 
-It does mean two things:
+| `natStrategy` | Cost | What it is | Egress features |
+| --- | --- | --- | --- |
+| `'instance'` (default) | ~$3/mo | t4g.nano NAT instance, single AZ | Function |
+| `'gateway'` | ~$32/mo | Managed NAT gateway, highly available | Function |
+| `'none'` | $0 | The original zero-egress isolated-only topology | Non-functional |
 
-1. **Config and secrets are resolved at deploy time, not at cold start.**
-   Reading either from inside the VPC would need an interface endpoint
-   (~$7/month, about 45% of the database cost) to hide a value from the only
-   person who can read a Lambda's configuration anyway. That trade changes the
-   moment anyone else has console access to the account; the fix is one
-   endpoint and a runtime lookup. See Configuration above.
+The backend genuinely needs the internet for Safe Browsing, customer webhooks,
+Google OAuth (JWKS) and mail. Under `'instance'` and `'gateway'` those work;
+under `'none'` they are non-functional by design (the free option for an
+operator who does not need them). NAT was chosen over a free egress-only IPv6
+IGW because arbitrary customer webhook receivers cannot be relied on to publish
+`AAAA` records — see [DECISIONS.md](./DECISIONS.md).
 
-2. **Google Safe Browsing cannot be called.** It is off by default already
-   (see [DECISIONS.md](./DECISIONS.md) A10). Turning it on in this topology
-   requires egress, which means a NAT or a proxy.
+There are two consequences worth calling out:
+
+1. **Config and secrets are resolved at deploy time, not at cold start.** That
+   is still the default; the default NAT instance now makes a *runtime*
+   SSM/Secrets Manager lookup reachable without a dedicated interface endpoint,
+   which unblocks (but does not implement) issue #292. See Configuration above.
+
+2. **Google Safe Browsing, webhooks, OAuth and mail delivery are functional
+   only when `natStrategy != 'none'`.** Safe Browsing is also off by default
+   without a key (see [DECISIONS.md](./DECISIONS.md) A10).
+
+### The redirect uses AWS SDK adapters and can leave the VPC
+
+The claim that "there is no AWS SDK anywhere in `apps/` or `packages/`" is no
+longer true. `@aws-sdk` packages are dependencies of `apps/redirect`,
+`apps/worker`, `packages/cache` and `packages/database`. The Postgres paths
+(`PostgresLinkResolver` / `PostgresClickSink`) remain the **default** for every
+non-AWS profile, but under the AWS profile (`LINK_PROJECTION=dynamo` +
+`CLICK_SINK=sqs`) the redirect resolves links from DynamoDB via
+`DynamoLinkResolver`, sends clicks to SQS via `SqsClickSink`, salts its visitor
+hashes from the shared DynamoDB `CacheStore`, and leaves the VPC entirely
+(`redirectFn` drops its `vpcSettings`; `apiFn` and `workerFn` keep theirs).
+[ARCHITECTURE.md](./ARCHITECTURE.md) lays out every port and its adapters.
+
+### Abuse protection and the WAF cost, recomputed
+
+Rate limiting the redirect path belongs at a WAF (see
+[DECISIONS.md](./DECISIONS.md) assumption 12), and its cost is worth stating
+correctly because an earlier draft got the direction wrong. That draft claimed
+the marginal cost per 1M redirects would **fall** from $1.57 to ~$1.10 after
+adding a WAF. It does the opposite. Caching is effectively disabled for
+correctness — the edge TTL is only 1–5s and the browser is sent `no-store` — so
+**every** redirect that reaches the distribution is inspected by the WAF. AWS
+WAF bills roughly **$0.60 per 1,000,000 requests inspected** (on top of a
+separate ~$5/mo per web ACL fixed charge and per-rule charges, which are not
+part of the per-1M marginal figure). So the marginal cost per 1M redirects
+**rises** from ~$1.57 to about $1.57 + $0.60 ≈ **$2.17 per 1M**. It does not
+fall to ~$1.10: a WAF inspects every request, including the ones the edge would
+otherwise serve cheaply, and there is no cache absorbing them.
 
 ### Why the images are containers, not zip bundles
 
@@ -339,8 +399,9 @@ fails.
 
 `pnpm db:migrate` cannot do it. RDS is in isolated subnets with
 `publiclyAccessible: false`, so there is no route from a laptop to the
-database at all — by design, because the alternative is a NAT gateway or a
-publicly reachable database.
+database at all — by design, because the alternative is a publicly reachable
+database. (The NAT under `natStrategy != 'none'` gives the Lambdas *outbound*
+egress; it does not make RDS reachable from a laptop.)
 
 The Lambdas are inside the VPC, so the worker carries the job. Invoke it once
 after the first deploy, and again after any deploy that adds a migration:
@@ -383,19 +444,20 @@ dealt with, and are worth knowing about because both were silent:
   instance exhausts the server quickly. Both now honour the variable, keeping
   their previous values as the default for the long-running process.
 
-The shape it should take, and the cost constraints that dictate it, are
-recorded in [DECISIONS.md](./DECISIONS.md). The single most important one:
+The reasoning and the cost constraints that dictate the shape are recorded in
+[DECISIONS.md](./DECISIONS.md). The single most important one:
 
 > Lambda, DynamoDB, CloudFront, SQS and SSM Parameter Store all sit inside
 > AWS's always-free tiers at this workload. **Postgres is roughly 92% of the
-> bill.** A NAT Gateway costs about $32/month before a byte moves — more than
-> everything else combined — and the standard "put RDS in a private subnet"
-> tutorial creates one.
+> bill.** A managed NAT gateway costs about $32/month before a byte moves — more
+> than everything else combined — which is why `natStrategy` defaults to a ~$3/mo
+> NAT instance instead.
 
-Until that work lands, the apps run anywhere Node 22 runs. They read all
-configuration from the environment, expose health endpoints
-(`/api/v1/health` and `/health`), and shut down their database pools cleanly on
-`SIGTERM`.
+The stack is written and synthesises cleanly; what has not happened is a real
+`cdk deploy` against a real account (see "What is verified" above). The apps
+also run anywhere Node 22 runs: they read all configuration from the
+environment, expose health endpoints (`/api/v1/health` and `/health`), and shut
+down their database pools cleanly on `SIGTERM`.
 
 ---
 


### PR DESCRIPTION
Closes #290.

Makes the SnapURL docs match the code. Epic #267's phases 1-7 are **not merged** (latest commit is #266; migrations stop at 0006), so all six `DECISIONS.md` claims that describe an AWS-native serverless system were still false against the code and are corrected in place — not deferred. Documentation-only change; `git diff main --stat` touches only `docs/`.

## Corrected claims in `DECISIONS.md`
| Claim (old) | Corrected to reality |
| --- | --- |
| Counter is a DynamoDB conditional write | `links.clicks` is a denormalised Postgres column recomputed by the rollup worker (`apps/worker/src/jobs/rollup.ts`) |
| Background work: SQS + Lambda | EventBridge-scheduled worker draining Postgres; no SQS, no AWS SDK anywhere |
| CloudFront absorbs volume | `CACHING_DISABLED` — it absorbs nothing |
| GeoIP uses `CloudFront-Viewer-Country` | `ALL_VIEWER_EXCEPT_HOST_HEADER` doesn't forward those headers, so country/city are always null (fix noted: allow-list the `CloudFront-Viewer-*` family) |
| Redirect reads link config from DynamoDB | `PostgresLinkResolver` is the only implementation |
| Redis rejected globally | Rescoped to the AWS profile only (#285) |

## New `docs/ARCHITECTURE.md`
Resolves the previously dangling `[ARCHITECTURE](./ARCHITECTURE.md)` link in `DEPLOYMENT.md`. Covers the stateless ports-and-adapters core, separating ports built today (`LinkResolver`, `ClickSink`, `ProjectionTarget`, the `MailService.send` mail seam) from planned ports (`AnalyticsReader` #284, `CacheStore` #285); the three deployment profiles (single-node = only profile with a green smoke run; horizontally-scaled cloud-agnostic; AWS-native serverless = experimental because its adapters aren't built); the honesty rule; and per-profile decisions — egress (NAT not IPv6, #281) and click-accounting (Lambda authoritative for click-limited/analytics links, #289).

## Recomputed cost figures
1. **WAF marginal cost rises, not falls.** WAF bills $0.60 per 1M requests inspected, and caching is disabled so **every** redirect is inspected. Marginal cost rises to ~$1.57 + $0.60 ≈ **$2.17 per 1M** (plus fixed $5/ACL + $1/rule). The old "drops to ~$1.10" figure was backwards.
2. **Credit longevity ~6.5 months, not twelve.** At ~$15.50/month, $100 / 15.5 ≈ **6.45 months**. The 12-month figure is the credit's validity window, not its burn-rate longevity — distinction now made explicit and consistent across `DEPLOYMENT.md`, `BACKEND.md`, and `DECISIONS.md`.

## Files changed
- `docs/ARCHITECTURE.md` (new, 165 lines)
- `docs/DECISIONS.md` (six claims + cost figures)
- `docs/DEPLOYMENT.md` (credit longevity; DynamoDB/SQS reframed as planned)
- `docs/BACKEND.md` (credit longevity; DynamoDB/SQS reframed as planned)

## Testing
Docs-only; nothing compiled. Every corrected claim was independently re-verified against the cited source (rollup.ts, outbox.ts, resolver.ts, click-sink.ts, main.ts, mail.service.ts, snapurl-stack.ts). Semantic review: APPROVED, no blocking concerns.