### PR TITLE
fix(reports): drop reporter contact for unresolved-slug abuse reports (#308)

### DIFF
--- a/apps/api/src/reports/reports.service.integration.test.ts
+++ b/apps/api/src/reports/reports.service.integration.test.ts
@@ -50,13 +50,17 @@ describeDb("ReportsService.submitReport", () => {
 
   afterAll(async () => {
     if (workspaceId) await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
-    // The report for the non-existent slug has no workspace to cascade from.
+    // The reports for non-existent slugs have no workspace to cascade from.
     await db.delete(abuseReports).where(eq(abuseReports.slug, `${slug}-missing`));
+    await db.delete(abuseReports).where(eq(abuseReports.slug, `${slug}-missing-pii`));
     await handle?.close();
   });
 
   it("resolves the link and workspace for an existing slug", async () => {
-    const result = await service.submitReport(slug, { reason: "This is a phishing page." });
+    const result = await service.submitReport(slug, {
+      reason: "This is a phishing page.",
+      reporterContact: "reporter@example.com",
+    });
     expect(result).toEqual({ ok: true });
 
     const [row] = await db.select().from(abuseReports).where(eq(abuseReports.linkId, linkId)).limit(1);
@@ -65,6 +69,27 @@ describeDb("ReportsService.submitReport", () => {
     expect(row!.status).toBe("open");
     expect(row!.linkId).toBe(linkId);
     expect(row!.workspaceId).toBe(workspaceId);
+    // #308 counter-case: a resolved slug still persists a supplied contact
+    // unchanged — the null-for-unresolved rule must be scoped to unresolved
+    // slugs only. This assertion fails if the conditional wrongly nulled it here.
+    expect(row!.reporterContact).toBe("reporter@example.com");
+  });
+
+  it("does not store reporterContact for a slug that does not resolve (#308)", async () => {
+    const missing = `${slug}-missing-pii`;
+    const result = await service.submitReport(missing, {
+      reason: "Reporting a link that isn't here.",
+      reporterContact: "reporter@example.com",
+    });
+    expect(result).toEqual({ ok: true });
+
+    const [row] = await db.select().from(abuseReports).where(eq(abuseReports.slug, missing)).limit(1);
+    expect(row).toBeDefined();
+    expect(row!.workspaceId).toBeNull();
+    expect(row!.linkId).toBeNull();
+    // The contact is dropped: a null-workspace report has no operator who can
+    // ever see or act on it, so retaining the email would be orphaned PII.
+    expect(row!.reporterContact).toBeNull();
   });
 
   it("returns ok:true and stores null link/workspace for a non-existent slug (no enumeration)", async () => {

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -32,7 +32,16 @@ export class ReportsService {
       .where(sql`lower(${links.slug}) = ${slug.toLowerCase()}`)
       .limit(1);
 
-    const contact = input.reporterContact?.trim() ? input.reporterContact.trim() : null;
+    const trimmed = input.reporterContact?.trim() ? input.reporterContact.trim() : null;
+    // #308: never persist a reporterContact for a slug that did not resolve.
+    // An unresolved slug stores a null workspaceId, and list() filters strictly
+    // on eq(abuseReports.workspaceId, workspaceId), so a null-workspace report
+    // belongs to no operator and is surfaced to none. Keeping the reporter's
+    // email on such a row would be PII with no owner, no view, and no deletion
+    // path (the workspace cascade never reaches it), which is inconsistent with
+    // the project's privacy posture. The raw slug and null link/workspace are
+    // still stored so the endpoint stays a non-oracle; only the contact drops.
+    const contact = link ? trimmed : null;
 
     await this.db.insert(abuseReports).values({
       slug,


### PR DESCRIPTION
Closes #308.

## Problem
`abuse_reports` rows for a slug that does not resolve to a link are stored with `workspace_id = null`. `ReportsService.list()` filters strictly on `eq(abuseReports.workspaceId, workspaceId)`, so a null-workspace report is surfaced to **no** operator, and the workspace `ON DELETE` cascade never reaches it. Any `reporter_contact` (email) on such a row was therefore PII with no owner, no view, and no deletion path — inconsistent with the project's privacy posture.

## Fix — Option 1 (drop at intake)
In `ReportsService.submitReport`, the reporter contact is now gated on slug resolution:
```ts
const trimmed = input.reporterContact?.trim() ? input.reporterContact.trim() : null;
const contact = link ? trimmed : null;   // #308: never persist contact for an unresolved slug
```
This **fully eliminates** the orphaned PII (zero residual window) at the exact point the contact is already computed. The `{ ok: true }` return, raw-slug storage, and null `linkId`/`workspaceId` for unresolved slugs are unchanged, so the endpoint's non-oracle (anti-enumeration) behavior is preserved.

**Why not Option 2/3:** a worker retention job only *bounds* the PII window and needs a new migration + lease + maintenance wiring, for a contact no operator can ever read; an admin surface is explicitly larger scope. Option 1 is the issue author's first recommendation and the smallest correct change.

## No migration
`reporter_contact` was already nullable; nothing under `packages/database/drizzle/` changed.

## Verified invariant
`links.workspaceId` is `.notNull()` (`packages/database/src/schema/links.ts`), so a resolved link always carries a workspace — gating on `link` existing is equivalent to gating on a non-null workspace. No residual orphan-PII path.

## Scoping note for reviewers
This fixes **intake going forward**. Any pre-existing null-workspace rows written before this commit that carry a `reporter_contact` are not purged. If such rows exist in production, a one-off cleanup (or the Option 2 retention job) can close that separately.

## Files changed
- `apps/api/src/reports/reports.service.ts` — gate contact on slug resolution + rationale comment.
- `apps/api/src/reports/reports.service.integration.test.ts` — new test asserting null contact for an unresolved slug submitted *with* a valid email; counter-case added to the resolved-slug test asserting the email is still persisted; matching `afterAll` cleanup.

## Testing
Tests are integration-level (`describeDb`, require `DATABASE_URL` + Postgres/Testcontainers). They were **written but could not be executed** in the delegated INTEGRATIONS_ONLY sandbox (no network for `pnpm install`, no docker). **CI must run `pnpm build:packages && pnpm --filter @snapurl/api test` with a `DATABASE_URL` to execute them.** Static validation confirmed the diff touches only the two intended files. Semantic review: APPROVED.