### PR TITLE
docs(forms): record the global-slug-namespace decision (#264)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -446,6 +446,32 @@ existing claims stay literally true (a form sets no cookies and stores no IP), a
 new obligations that come with holding volunteered data are the ones this module has to
 meet: the public page names the workspace collecting it, and responses are deletable.
 
+### Forms: the slug namespace is global, and squattable — left that way
+
+**Asked by #264, a security review of #239 that filed this as a design consequence to
+decide on, not as a defect to fix.**
+
+`forms_slug_key` is a unique index on `lower(slug)` alone, the same shape as the
+shared-short-domain decision above and for the same reason: `publicForm(slug)` and
+`submit(slug, …)` resolve a form from the slug alone, with no workspace in the URL, so
+exactly one form may ever hold `contact`. That has two consequences. The first
+workspace to claim an obvious slug — `contact`, `feedback`, `signup` — holds it against
+every other workspace forever, for free. And because `create()` reports the conflict by
+name (`"/f/<slug> is already taken"`), any authenticated user can test candidate slugs
+one request at a time and learn whether a form exists anywhere in the system, across
+workspace boundaries — existence only, no title or owner, but still a cross-tenant leak
+from an authenticated endpoint.
+
+**Left as-is, deliberately.** Namespacing the path by workspace (`/f/<workspace>/<slug>`
+with the unique index scoped to `(workspaceId, lower(slug))`) removes both consequences
+outright, but uglifies the public URL and needs a migration for any form already
+created — and the squatting risk has no exploiter yet, with forms used by at most one
+workspace today. Cheaper alternatives (reserving common words, expiring long-`draft`
+slugs, rate-limiting `create`) blunt the edges without closing either hole, so they
+would add surface area for a partial fix rather than a real one. Revisit the moment
+forms are used by more than one paying workspace — at that point the enumeration leak
+stops being theoretical and the URL-uglification cost stops being the deciding factor.
+
 ### Billing: the controls are removed rather than faked
 
 **Asked by #242, whose own answer — "removing is the honest interim state" — is the one

--- a/packages/database/src/schema/developers.ts
+++ b/packages/database/src/schema/developers.ts
@@ -225,6 +225,8 @@ export const forms = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
+  // Global, not scoped to workspaceId — deliberately, and squattable as a result.
+  // See "Forms: the slug namespace is global, and squattable" in DECISIONS.md (#264).
   (t) => [uniqueIndex("forms_slug_key").on(sql`lower(${t.slug})`)],
 );
 


### PR DESCRIPTION
Closes #264.

## What
Forms' unique index on `lower(slug)` is global, not scoped to `workspaceId`. Confirmed still accurate: `publicForm(slug)` / `submit(slug, ...)` in `apps/api/src/forms/forms.service.ts` resolve by slug alone, and `create()` reports conflicts by name (existence-enumeration leak across workspaces).

## Why this fix, not a bigger one
The issue itself frames this as a design consequence to decide on, not a defect, and recommends option 1 (leave the behavior, record the decision) over namespacing the URL by workspace or blunting the edges with reservations/rate-limits — the squatting risk has no exploiter yet with forms used by at most one workspace today, and the URL-uglification/migration cost of scoping the index is real. Revisit when forms see multi-workspace usage.

## Changes
- `docs/DECISIONS.md`: new entry under Part 4b, matching the existing shared-short-domain precedent this mirrors.
- `packages/database/src/schema/developers.ts`: one-line comment on `forms_slug_key` pointing at the decision, matching this file's existing convention of linking schema choices to DECISIONS.md.

No behavior change. `pnpm --filter @snapurl/database build` and `type-check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
