### PR TITLE
feat(auth): Google sign-in, with the ID token bound to a nonce (#263)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -40,6 +40,18 @@ REDIRECT_ORIGIN=http://localhost:3002
 # claims they were checked. See docs/DECISIONS.md A10.
 # GOOGLE_SAFE_BROWSING_API_KEY=
 
+# Google sign-in (OAuthService). A provider with no client id configured is
+# switched off, not misconfigured — the button simply does not render on the
+# web app. Must be the same client id as the web app's
+# NEXT_PUBLIC_GOOGLE_CLIENT_ID; the API verifies ID tokens are audienced to
+# it. Create one at https://console.cloud.google.com/apis/credentials
+# ("OAuth client ID" of type "Web application").
+# GOOGLE_OAUTH_CLIENT_ID=
+# Apple sign-in is plumbed through (OAuthService accepts "apple" as a
+# provider) but has no client yet — see docs/DECISIONS.md "OAuth: Google
+# first, Apple plumbed but not shipped" (#263).
+# APPLE_OAUTH_CLIENT_ID=
+
 MAIL_TRANSPORT=outbox
 MAIL_FROM=SnapURL <no-reply@snapurl.local>
 

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -45,7 +45,7 @@ export class AuthController {
   @Public()
   @Post("oauth")
   oauth(@Body(zodBody(OAuthSignInInput)) input: OAuthSignInInput, @Req() req: FastifyRequest) {
-    return this.auth.oauthSignIn(input.provider, input.idToken, req.headers["user-agent"]);
+    return this.auth.oauthSignIn(input.provider, input.idToken, input.nonce, req.headers["user-agent"]);
   }
 
   @Public()

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -167,8 +167,13 @@ export class AuthService {
    * verify, and skipping ours would mean a compromised Google account walks
    * straight past a control the person deliberately added.
    */
-  async oauthSignIn(provider: OAuthProvider, idToken: string, userAgent?: string): Promise<LoginResult> {
-    const profile = await this.oauth.verify(provider, idToken);
+  async oauthSignIn(
+    provider: OAuthProvider,
+    idToken: string,
+    nonce: string,
+    userAgent?: string,
+  ): Promise<LoginResult> {
+    const profile = await this.oauth.verify(provider, idToken, nonce);
 
     const [linked] = await this.db
       .select({ userId: oauthIdentities.userId })

--- a/apps/api/src/auth/oauth.service.test.ts
+++ b/apps/api/src/auth/oauth.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { readKid, toProfile } from "./oauth.service.js";
+import { constantTimeEqual, readKid, toProfile } from "./oauth.service.js";
 
 const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
 
@@ -67,5 +67,29 @@ describe("toProfile", () => {
     expect(toProfile({ ...base, name: "   " })!.name).toBeNull();
     expect(toProfile(base)!.name).toBeNull();
     expect(toProfile({ ...base, name: " Ada " })!.name).toBe("Ada");
+  });
+});
+
+describe("constantTimeEqual", () => {
+  // #263: this is what verify() uses to bind an ID token to the nonce its own
+  // sign-in attempt generated, so a stolen-but-otherwise-valid token cannot be
+  // replayed under a different attempt's nonce.
+  it("is true for identical strings", () => {
+    expect(constantTimeEqual("abc123", "abc123")).toBe(true);
+  });
+
+  it("is false for a mismatch of the same length", () => {
+    expect(constantTimeEqual("abc123", "abc124")).toBe(false);
+  });
+
+  it("is false for different lengths rather than throwing", () => {
+    // node:crypto's timingSafeEqual throws on a length mismatch; a replay
+    // attempt sending a shorter or longer nonce must not crash the request.
+    expect(constantTimeEqual("short", "a-lot-longer-than-that")).toBe(false);
+    expect(constantTimeEqual("", "nonempty")).toBe(false);
+  });
+
+  it("is false when both are empty-vs-nonempty in either direction", () => {
+    expect(constantTimeEqual("nonempty", "")).toBe(false);
   });
 });

--- a/apps/api/src/auth/oauth.service.ts
+++ b/apps/api/src/auth/oauth.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger, UnauthorizedException } from "@nestjs/common";
-import { createPublicKey, type KeyObject } from "node:crypto";
+import { createPublicKey, timingSafeEqual, type KeyObject } from "node:crypto";
 import { JwtService } from "@nestjs/jwt";
 import { ENV, type Env } from "../config/env.js";
 
@@ -121,8 +121,15 @@ export class OAuthService {
    *
    * Throws for anything short of a complete match. There is deliberately no
    * "mostly valid" path.
+   *
+   * `expectedNonce` binds the token to the one sign-in attempt that requested
+   * it (#263). Audience pinning already stops a token minted for a different
+   * application; it does not stop a token minted for this application from
+   * being replayed a second time. Required, not optional — accepting a token
+   * without a nonce would silently reintroduce the replay window for any
+   * caller that omits one, and there is no caller that ever needed to.
    */
-  async verify(provider: OAuthProvider, idToken: string): Promise<OAuthProfile> {
+  async verify(provider: OAuthProvider, idToken: string, expectedNonce: string): Promise<OAuthProfile> {
     const { issuers, algorithms, audience } = this.config(provider);
     if (!audience) throw new UnauthorizedException(`${provider} sign-in is not configured.`);
 
@@ -147,10 +154,31 @@ export class OAuthService {
       throw new UnauthorizedException("That sign-in token is not valid.");
     }
 
+    const nonce = claims.nonce;
+    if (typeof nonce !== "string" || !constantTimeEqual(nonce, expectedNonce)) {
+      throw new UnauthorizedException("That sign-in attempt could not be verified. Try signing in again.");
+    }
+
     const profile = toProfile(claims);
     if (!profile) throw new UnauthorizedException("The sign-in provider did not return an email address.");
     return profile;
   }
+}
+
+/**
+ * String comparison in constant time relative to the compared length, so a
+ * mismatch cannot be timed to learn how many leading characters matched.
+ * Guards the length check itself with a same-length compare rather than
+ * short-circuiting, for the same reason.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
 }
 
 /** The `kid` from a JWT header, without trusting anything else in the token. */

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -941,6 +941,53 @@ runs decoupled and chunk-committing rather than inside the schema transaction.
 `max_locks_per_transaction`), or if a future drizzle release offered a way to bound the
 lock hold of a structural migration itself, which would let the runbook shrink.
 
+### OAuth: the nonce and the button shipped together, and Google went first
+
+**Found by a security review (#263): `OAuthService` verified the algorithm, audience,
+issuer and JWKS signature on an ID token, but never checked a `nonce`.** Audience
+pinning stops a token minted for a different application; it does nothing to stop a
+token minted for *this* application from being replayed a second time. For as long as
+Google's tokens stay valid — about an hour — anyone who obtained one (a compromised
+client, a logged URL, a leaky proxy) could `POST` it to `/auth/oauth` and get a session.
+
+**Why this sat filed rather than fixed until now.** The realistic exposure was low: no
+sign-in button existed anywhere in the web app, so the only callers were deliberate
+ones. But a *half* fix — accepting a nonce when present, warning when absent — would
+have meant shipping a version that still accepted an unbound token from whichever
+caller forgot to send one, which is worse than not fixing it at all: it looks fixed
+without being fixed. So the nonce and the client that generates it had to ship in the
+same change, and did not until there was a reason to build the client.
+
+**The nonce lives in the browser's memory, not a cookie.** `GoogleButton` generates 32
+random bytes once per mount, hands them to Google's Identity Services SDK as the
+`nonce` config (which the SDK embeds in its authorize request, and Google mints into
+the returned token's `nonce` claim), and sends the same value to `POST /auth/oauth`
+alongside the ID token. `OAuthService.verify` now requires the token's `nonce` claim to
+match, in constant time, or refuses the sign-in. An httpOnly cookie set by a
+server-minted-nonce endpoint would be marginally more robust against a proxy that logs
+full request bodies — but it is also a new endpoint, a new cookie, and everything that
+comes with one, to close a gap narrower than the one this closes: a bare stolen ID
+token (a log, a URL, a shared device) can no longer be replayed, because the attacker
+does not also have the in-memory nonce the legitimate attempt generated. Required from
+the day the button ships, not optional: there was never a released version of this
+endpoint that accepted an unbound token from a real caller, so there is no
+compatibility to preserve.
+
+**Google first, Apple plumbed but not shipped.** `OAuthService` already carried Apple's
+issuer, JWKS endpoint and algorithms — cheap to keep, since the verifier is generic —
+but nothing here builds an Apple button. Apple's native flow expects the SHA-256 *of*
+the nonce rather than the nonce itself, a wrinkle this change does not resolve because
+there is no Apple client yet to resolve it for. `OAuthService.enabled("apple")` stays
+`false` until `APPLE_OAUTH_CLIENT_ID` is set, which it never is out of the box — same
+"a provider with no client id is switched off, not misconfigured" rule Google used to
+follow before today.
+
+**Revisit if** an Apple button gets built. `verify()`'s nonce check is already
+provider-agnostic (it compares the claim to what the caller supplies); what is missing
+is a per-provider hashing step before that comparison for Apple's native SDK, and it
+should be added in the same change as the Apple button, for the same reason Google's
+nonce shipped with Google's button.
+
 ---
 
 ## Part 5 — Open questions for you

--- a/packages/contract/src/auth.ts
+++ b/packages/contract/src/auth.ts
@@ -92,9 +92,18 @@ export type TotpDisableInput = z.infer<typeof TotpDisableInput>;
  * challenge: a second factor the user turned on is not skipped because the
  * first factor came from somewhere else.
  */
+/* #263 — the ID token alone is a bearer credential for as long as it is
+   valid (about an hour for Google), so anyone who obtains one — a compromised
+   client, a logged URL, a leaky proxy — can replay it here and get a session.
+   `nonce` is generated fresh per sign-in attempt and embedded in the
+   provider's authorize request; OAuthService requires the returned token's
+   `nonce` claim to match it, which a replayed token minted for a different
+   attempt cannot. Required, not optional: there is no released version of
+   this endpoint that ever accepted an unbound token from a real caller. */
 export const OAuthSignInInput = z.object({
   provider: z.enum(["google", "apple"]),
   idToken: z.string().min(1),
+  nonce: z.string().min(16).max(256),
 });
 export type OAuthSignInInput = z.infer<typeof OAuthSignInInput>;
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -244,12 +244,17 @@ echo "== oauth sign-in =="
 # CI configures no client id, so both providers are switched off. A provider
 # that is off must refuse rather than half-run — this is the state most
 # deployments are in, and it is the one worth pinning.
+#
+# A nonce (#263) is required on every request regardless of provider state —
+# it is the contract's own validation, checked before OAuthService ever sees
+# the request — so these each carry one just to reach the case they pin.
+NONCE="smoke-test-nonce-0000000000000000"
 BODY=$(curl -s -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \
-  -d '{"provider":"google","idToken":"eyJhbGciOiJSUzI1NiIsImtpZCI6IngifQ.e30.sig"}')
+  -d "{\"provider\":\"google\",\"idToken\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IngifQ.e30.sig\",\"nonce\":\"$NONCE\"}")
 check "an unconfigured provider is refused" 'not configured' "$BODY"
 
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \
-  -d '{"provider":"google","idToken":"not-a-jwt"}')
+  -d "{\"provider\":\"google\",\"idToken\":\"not-a-jwt\",\"nonce\":\"$NONCE\"}")
 status "a malformed token is refused" "401" "$CODE" ""
 
 CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$API/auth/oauth" -H 'Content-Type: application/json' \

--- a/web/.env.example
+++ b/web/.env.example
@@ -14,3 +14,9 @@ NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1
 #
 # Leave unset to talk to the real API.
 # NEXT_PUBLIC_USE_FIXTURES=true
+
+# Google sign-in on /login and /register. Optional — the button only renders
+# when this is set. Must be the same client id as the API's
+# GOOGLE_OAUTH_CLIENT_ID, or ID tokens this app requests will fail the API's
+# audience check.
+# NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { AuthShell } from "@/components/auth/auth-shell";
+import { GoogleButton, hasGoogleAuth } from "@/components/auth/google-button";
 import { Button, Field, Input } from "@/components/ui";
 import { useLogin } from "@/lib/api/hooks";
 
@@ -31,6 +32,16 @@ export default function LoginPage() {
 
   return (
     <AuthShell title="Welcome back" sub="Sign in to your SnapURL workspace.">
+      {hasGoogleAuth ? (
+        <>
+          <GoogleButton text="signin_with" />
+          <div className="flex items-center gap-3 my-4">
+            <span className="h-px flex-1 bg-line" />
+            <span className="text-[11.5px] text-ink-3">or</span>
+            <span className="h-px flex-1 bg-line" />
+          </div>
+        </>
+      ) : null}
       <form onSubmit={onSubmit} className="flex flex-col gap-3.5">
         <Field label="Email" error={formState.errors.email?.message}>
           <Input {...register("email")} type="email" autoComplete="email" placeholder="you@company.com" />

--- a/web/src/app/(auth)/register/page.tsx
+++ b/web/src/app/(auth)/register/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { AuthShell } from "@/components/auth/auth-shell";
+import { GoogleButton, hasGoogleAuth } from "@/components/auth/google-button";
 import { Button, Field, Input } from "@/components/ui";
 import { useRegister } from "@/lib/api/hooks";
 
@@ -36,6 +37,16 @@ export default function RegisterPage() {
 
   return (
     <AuthShell title="Start free" sub="No card. Links, QR codes and edits are never metered.">
+      {hasGoogleAuth ? (
+        <>
+          <GoogleButton text="signup_with" />
+          <div className="flex items-center gap-3 my-4">
+            <span className="h-px flex-1 bg-line" />
+            <span className="text-[11.5px] text-ink-3">or</span>
+            <span className="h-px flex-1 bg-line" />
+          </div>
+        </>
+      ) : null}
       <form onSubmit={onSubmit} className="flex flex-col gap-3.5">
         <Field label="Name" error={formState.errors.name?.message}>
           <Input {...register("name")} autoComplete="name" placeholder="Priya Raman" />

--- a/web/src/components/auth/google-button.tsx
+++ b/web/src/components/auth/google-button.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Script from "next/script";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+import { useOAuthSignIn } from "@/lib/api/hooks";
+
+const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+
+/** Whether the page should show anything Google-shaped at all — the button,
+ *  and the "or" divider above the password form that would otherwise divide
+ *  the form from nothing. */
+export const hasGoogleAuth = Boolean(CLIENT_ID);
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize(config: {
+            client_id: string;
+            nonce: string;
+            auto_select?: boolean;
+            callback: (response: { credential: string }) => void;
+          }): void;
+          renderButton(
+            parent: HTMLElement,
+            options: {
+              theme?: "outline" | "filled_blue" | "filled_black";
+              size?: "large" | "medium" | "small";
+              shape?: "rectangular" | "pill";
+              width?: number;
+              text?: "signin_with" | "signup_with" | "continue_with";
+              logo_alignment?: "left" | "center";
+            },
+          ): void;
+        };
+      };
+    };
+  }
+}
+
+function generateNonce(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * "Continue with Google". Renders nothing when NEXT_PUBLIC_GOOGLE_CLIENT_ID is
+ * unset — matching OAuthService.enabled() on the API side, a provider with no
+ * client id configured is switched off, not half-shown.
+ *
+ * The nonce (#263) is generated once per mount and handed to Google's SDK as
+ * the ID token's `nonce` claim; the same value goes to POST /auth/oauth so the
+ * API can confirm this exact attempt produced the token rather than replaying
+ * an earlier one. It lives only in this component's memory: a reload
+ * abandons the in-flight attempt and the next mount generates its own, so
+ * there is nothing that needs to survive one.
+ */
+export function GoogleButton({ text = "continue_with" }: { text?: "signin_with" | "signup_with" | "continue_with" }) {
+  const router = useRouter();
+  const oauthSignIn = useOAuthSignIn();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const nonceRef = useRef<string | null>(null);
+  nonceRef.current ??= CLIENT_ID ? generateNonce() : null;
+  const [error, setError] = useState<string | null>(null);
+  const [blocked, setBlocked] = useState(false);
+
+  if (!CLIENT_ID) return null;
+
+  const renderGoogleButton = () => {
+    const google = window.google;
+    const nonce = nonceRef.current;
+    if (!google || !containerRef.current || !nonce) return;
+
+    google.accounts.id.initialize({
+      client_id: CLIENT_ID,
+      nonce,
+      // Selecting silently would sign someone in without a click they can
+      // point to — the button exists so consent is unambiguous.
+      auto_select: false,
+      callback: (response) => {
+        setError(null);
+        oauthSignIn
+          .mutateAsync({ provider: "google", idToken: response.credential, nonce })
+          .then((result) => {
+            // Same union, same narrowing as password login (useLogin):
+            // a 2FA challenge is not yet a session.
+            if ("challenge" in result) return;
+            router.push("/links");
+          })
+          .catch((err: unknown) => setError(err instanceof Error ? err.message : "Google sign-in failed. Try again."));
+      },
+    });
+    google.accounts.id.renderButton(containerRef.current, {
+      theme: "outline",
+      size: "large",
+      shape: "rectangular",
+      width: Math.min(containerRef.current.clientWidth || 352, 400),
+      text,
+      logo_alignment: "left",
+    });
+  };
+
+  return (
+    <div>
+      <Script
+        src="https://accounts.google.com/gsi/client"
+        strategy="afterInteractive"
+        onReady={renderGoogleButton}
+        onError={() => setBlocked(true)}
+      />
+      <div ref={containerRef} className="[&>div]:!w-full" />
+      {blocked ? (
+        <p className="text-[12.5px] text-ink-3 m-0 mt-2">
+          Google sign-in didn&apos;t load — an ad blocker or content blocker may be preventing it.
+        </p>
+      ) : null}
+      {error ? <p className="text-[12.5px] text-bad m-0 mt-2">{error}</p> : null}
+    </div>
+  );
+}

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -611,7 +611,7 @@ export async function fixtureRequest<T>(
   let data: unknown;
 
   /* ---- auth ---- */
-  if (m(/^\/auth\/(login|register)$/)) data = SESSION;
+  if (m(/^\/auth\/(login|register|oauth)$/)) data = SESSION;
   else if (m(/^\/auth\/me$/)) data = SESSION.user;
   else if (m(/^\/auth\/logout$/)) data = undefined;
   else if (m(/^\/auth\/2fa\/setup$/)) {

--- a/web/src/lib/api/hooks/auth.ts
+++ b/web/src/lib/api/hooks/auth.ts
@@ -9,6 +9,7 @@ import {
   TotpRecoveryCodes,
   TotpSetup,
   type LoginInput,
+  type OAuthSignInInput,
   type RegisterInput,
   type TotpDisableInput,
   type TotpEnableInput,
@@ -38,6 +39,28 @@ export function useLogin() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: LoginInput) => request("/auth/login", LoginResult, { method: "POST", body, anonymous: true }),
+    onSuccess: (result) => {
+      if ("challenge" in result) return;
+      tokens.set(result.accessToken, result.refreshToken);
+      qc.setQueryData(qk.me, result.user);
+    },
+  });
+}
+
+/**
+ * Google/Apple sign-in (#263). Same response union and the same "challenge"
+ * narrowing as useLogin — a provider sign-in does not bypass a second factor
+ * the account owner turned on.
+ *
+ * `nonce` must be the exact value passed to the provider's SDK for this
+ * attempt (see GoogleButton) — it is how the API tells a fresh token from a
+ * replayed one.
+ */
+export function useOAuthSignIn() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: OAuthSignInInput) =>
+      request("/auth/oauth", LoginResult, { method: "POST", body, anonymous: true }),
     onSuccess: (result) => {
       if ("challenge" in result) return;
       tokens.set(result.accessToken, result.refreshToken);


### PR DESCRIPTION
Closes #263.

## What
`OAuthService` verified the algorithm, audience, issuer and JWKS signature on an ID token but never checked a `nonce` claim (confirmed: zero references to "nonce" anywhere in the codebase before this change). Audience pinning stops a token minted for a different application; it does not stop a token minted for this application from being replayed a second time within its validity window (~1 hour for Google).

## Why this shipped as a full feature, not a patch
The issue itself was filed rather than fixed because the fix is mostly client-side and no dashboard OAuth button existed yet, and it explicitly argues against a half-fix: accepting a nonce when present and warning when absent would ship a version that still accepts an unbound token from whoever forgot to send one. So this ships the nonce and the Google sign-in button together, as recommended.

## Changes

**Server**
- `packages/contract/src/auth.ts`: `OAuthSignInInput` gains a required `nonce` (16–256 chars).
- `apps/api/src/auth/oauth.service.ts`: `verify()` now takes an `expectedNonce`, compares it against the token's `nonce` claim via `constantTimeEqual` (new, exported, unit-tested), and refuses a missing or mismatched claim.
- `apps/api/src/auth/auth.service.ts` / `auth.controller.ts`: thread the nonce through `oauthSignIn`.
- `apps/api/.env.example`: documents `GOOGLE_OAUTH_CLIENT_ID` and `APPLE_OAUTH_CLIENT_ID` — both were real supported env vars with zero self-hoster-visible documentation before this change.

**Client**
- `web/src/components/auth/google-button.tsx` (new): loads Google Identity Services, generates a 32-byte nonce once per mount, passes it to the SDK, renders Google's own button, and posts `{ provider: "google", idToken, nonce }` to `/auth/oauth` on success. Renders nothing when `NEXT_PUBLIC_GOOGLE_CLIENT_ID` is unset, matching `OAuthService.enabled()` server-side.
- Wired into `/login` (`signin_with`) and `/register` (`signup_with`), each behind an `hasGoogleAuth`-gated "or" divider so nothing dangles when the feature is off.
- `web/src/lib/api/hooks/auth.ts`: new `useOAuthSignIn`, same `LoginResult` union and `"challenge" in result` narrowing as `useLogin` (a provider sign-in does not bypass an account's own 2FA).
- `web/src/lib/api/fixtures.ts`: `/auth/oauth` added to the fixture-mode regex alongside login/register.
- `web/.env.example`: documents `NEXT_PUBLIC_GOOGLE_CLIENT_ID`.

**Docs**
- `docs/DECISIONS.md`: new entry — why the nonce lives in browser memory rather than an httpOnly cookie, why Apple stays plumbed (its native flow needs the SHA-256 of the nonce, not the nonce itself) but not shipped, and why a half-fix was rejected.

## Testing
- `pnpm build` (full monorepo, `SNAPURL_ALLOW_UNCONFIGURED_BUILD=true` matching CI) — passes, including the Next.js production build.
- `pnpm --filter @snapurl/api test` — 153/153 passing, including 5 new `constantTimeEqual` cases (identical, mismatch same length, mismatch different lengths without throwing, empty-vs-nonempty both directions).
- Manual verification in-browser against a real local API + Postgres: confirmed the button renders on `/login` and `/register` with the correct label, confirmed it renders nothing (and the divider doesn't dangle) with `NEXT_PUBLIC_GOOGLE_CLIENT_ID` unset, confirmed a click correctly initiates Google's real OIDC flow with the generated nonce embedded in the authorize URL (verified via console/network inspection), and confirmed the existing email/password register → `/links` flow is unaffected (regression check).
- Full end-to-end sign-in (a real Google account completing consent) could not be exercised without a real registered Google Cloud OAuth client, which is outside what a sandboxed environment can provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
