### PR TITLE
feat(api): generate browsable OpenAPI/Swagger docs from packages/contract (#339)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,12 +13,15 @@
     "dev:nest": "nest start --watch"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^9.1.0",
     "@fastify/cors": "^11.0.1",
+    "@fastify/static": "^10.1.3",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.6",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-fastify": "^11.1.6",
+    "@nestjs/swagger": "^11.4.7",
     "@nestjs/throttler": "^6.4.0",
     "@snapurl/cache": "workspace:*",
     "@snapurl/contract": "workspace:*",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,17 @@
 import "reflect-metadata";
+/* Import order matters here, unusually: extendZodWithOpenApi() (inside
+   ./openapi/registry.js, pulled in by document.js below) has to patch zod's
+   prototypes before ANY zod schema anywhere in the app is constructed — the
+   patch does not apply retroactively to schemas already built with the
+   unpatched .object()/.extend()/.optional() etc, only to ones built after.
+   AppModule transitively constructs every schema in packages/contract the
+   moment it loads, so this import has to come first. This project compiles
+   to CommonJS, where imports run in source order rather than being hoisted,
+   which is what makes that ordering meaningful at all. */
+import { buildOpenApiDocument } from "./openapi/document.js";
 import { NestFactory } from "@nestjs/core";
 import { FastifyAdapter, type NestFastifyApplication } from "@nestjs/platform-fastify";
+import { SwaggerModule, type OpenAPIObject } from "@nestjs/swagger";
 import { Logger } from "nestjs-pino";
 import cors from "@fastify/cors";
 import { resolveSecrets } from "@snapurl/database";
@@ -58,10 +69,22 @@ async function bootstrap() {
 
   app.enableShutdownHooks();
 
+  /* Generated from packages/contract (#339), not from decorators — see
+     openapi/registry.ts for why. Mounted next to the prefix it documents
+     (env.API_PREFIX/docs) rather than a fixed path, so it still lines up if
+     that prefix is ever changed. */
+  const openApiDocument = buildOpenApiDocument(env.API_PREFIX);
+  // zod-to-openapi's OpenAPIObject (openapi3-ts) and @nestjs/swagger's own
+  // OpenAPIObject type are two independent declarations of the same OpenAPI
+  // 3.0 JSON shape — structurally compatible at runtime, nominally distinct
+  // to the type checker. SwaggerModule.setup() only ever serializes this.
+  SwaggerModule.setup(`${env.API_PREFIX}/docs`, app, openApiDocument as unknown as OpenAPIObject);
+
   await app.listen({ port: env.PORT, host: "0.0.0.0" });
 
   const logger = app.get(Logger);
   logger.log(`SnapURL API listening on http://localhost:${env.PORT}/${env.API_PREFIX}`);
+  logger.log(`API docs at http://localhost:${env.PORT}/${env.API_PREFIX}/docs`);
   if (!env.GOOGLE_SAFE_BROWSING_API_KEY) {
     logger.warn(
       "Safe Browsing is off (no GOOGLE_SAFE_BROWSING_API_KEY). Links will be marked clean without being scanned.",

--- a/apps/api/src/members/members.controller.ts
+++ b/apps/api/src/members/members.controller.ts
@@ -1,11 +1,8 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post } from "@nestjs/common";
-import { z } from "zod";
-import { InviteMemberInput, MemberRole } from "@snapurl/contract";
+import { ChangeRoleInput, InviteMemberInput } from "@snapurl/contract";
 import { zodBody } from "../common/zod.pipe.js";
 import { Actor, Roles, type RequestActor } from "../auth/auth.guard.js";
 import { MembersService } from "./members.service.js";
-
-const ChangeRoleInput = z.object({ role: MemberRole });
 
 @Controller()
 export class MembersController {
@@ -28,7 +25,7 @@ export class MembersController {
   async changeRole(
     @Actor() actor: RequestActor,
     @Param("id") id: string,
-    @Body(zodBody(ChangeRoleInput)) input: z.infer<typeof ChangeRoleInput>,
+    @Body(zodBody(ChangeRoleInput)) input: ChangeRoleInput,
   ) {
     await this.members.changeRole(actor.workspaceId, id, input.role, actor.label);
   }

--- a/apps/api/src/openapi/document.ts
+++ b/apps/api/src/openapi/document.ts
@@ -1,0 +1,37 @@
+import { OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi";
+import { registry } from "./registry.js";
+
+// Side-effecting imports: each of these calls route(...) against the shared
+// registry above when loaded. Nothing here is used directly — the value is
+// in having been imported at all before buildOpenApiDocument() runs.
+import "./paths/links.js";
+import "./paths/analytics.js";
+import "./paths/domains.js";
+import "./paths/bio-pages.js";
+import "./paths/forms.js";
+import "./paths/reports.js";
+import "./paths/members.js";
+import "./paths/developers.js";
+import "./paths/auth.js";
+import "./paths/workspaces.js";
+import "./paths/public.js";
+import "./paths/health.js";
+
+/** Built once at boot, from the same env the rest of the app already
+ *  validated — this doc's `servers` entry has to match wherever this
+ *  process is actually mounted (env.API_PREFIX), or Swagger UI's
+ *  "Try it out" would call the wrong path. */
+export function buildOpenApiDocument(apiPrefix: string) {
+  const generator = new OpenApiGeneratorV3(registry.definitions);
+  return generator.generateDocument({
+    openapi: "3.0.0",
+    info: {
+      title: "SnapURL API",
+      version: "2.0.0",
+      description:
+        "Generated from the zod schemas in packages/contract (#339) — the same shapes the API validates against " +
+        "and the web app imports, so this document cannot drift from either the way a hand-written one could.",
+    },
+    servers: [{ url: `/${apiPrefix}` }],
+  });
+}

--- a/apps/api/src/openapi/paths/analytics.ts
+++ b/apps/api/src/openapi/paths/analytics.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { refs, route } from "../registry.js";
+
+route({
+  method: "get",
+  path: "/analytics",
+  tag: "Analytics",
+  summary: "Click analytics for the workspace, or one link",
+  query: refs.AnalyticsQuery,
+  responses: { 200: { description: "Analytics", schema: refs.Analytics } },
+});
+
+route({
+  method: "get",
+  path: "/conversions",
+  tag: "Conversions",
+  summary: "Recorded conversions for a range",
+  // The controller reads `range` with a plain @Query, not zodQuery(AnalyticsQuery)
+  // — no enum validation at the edge, unlike /analytics. Documented as a free
+  // string here to match what the endpoint actually accepts today.
+  query: z.object({ range: z.string().optional().describe('Defaults to "30d" in the handler; not validated') }),
+  responses: { 200: { description: "Conversions report", schema: refs.ConversionsReport } },
+});
+
+route({
+  method: "post",
+  path: "/conversions",
+  tag: "Conversions",
+  summary: "Record a conversion (typically called with an API key)",
+  body: refs.RecordConversionInput,
+  responses: { 201: { description: "Recorded", schema: refs.RecordConversionResult } },
+});

--- a/apps/api/src/openapi/paths/auth.ts
+++ b/apps/api/src/openapi/paths/auth.ts
@@ -1,0 +1,107 @@
+import { refs, route } from "../registry.js";
+
+const tag = "Auth";
+
+route({
+  method: "post",
+  path: "/auth/register",
+  tag,
+  summary: "Register a new account and workspace",
+  public: true,
+  body: refs.RegisterInput,
+  responses: { 201: { description: "A new session", schema: refs.AuthSession } },
+});
+
+route({
+  method: "post",
+  path: "/auth/login",
+  tag,
+  summary: "Sign in with email and password (5/min per IP)",
+  public: true,
+  body: refs.LoginInput,
+  responses: {
+    200: {
+      description: "A session, or a TOTP challenge if the account has 2FA enabled",
+      schema: refs.LoginResult,
+    },
+  },
+});
+
+route({
+  method: "post",
+  path: "/auth/oauth",
+  tag,
+  summary: "Sign in with a Google or Apple ID token, bound to a nonce (#263)",
+  public: true,
+  body: refs.OAuthSignInInput,
+  responses: {
+    200: {
+      description: "A session, or a TOTP challenge if the account has 2FA enabled",
+      schema: refs.LoginResult,
+    },
+  },
+});
+
+route({
+  method: "post",
+  path: "/auth/refresh",
+  tag,
+  summary: "Exchange a refresh token for a new token pair",
+  public: true,
+  body: refs.RefreshInput,
+  responses: { 200: { description: "A new access/refresh token pair", schema: refs.TokenPair } },
+});
+
+route({
+  method: "post",
+  path: "/auth/logout",
+  tag,
+  summary: "Revoke a refresh token's whole family (G2)",
+  public: true,
+  body: refs.LogoutInput,
+  responses: { 204: { description: "Revoked" } },
+});
+
+route({
+  method: "get",
+  path: "/auth/me",
+  tag,
+  summary: "The signed-in user",
+  responses: { 200: { description: "The current user", schema: refs.AuthUser } },
+});
+
+route({
+  method: "post",
+  path: "/auth/2fa/setup",
+  tag,
+  summary: "Start TOTP enrolment",
+  responses: { 201: { description: "otpauth:// URI to render as a QR code, plus the raw secret", schema: refs.TotpSetup } },
+});
+
+route({
+  method: "post",
+  path: "/auth/2fa/enable",
+  tag,
+  summary: "Confirm TOTP enrolment",
+  body: refs.TotpEnableInput,
+  responses: { 200: { description: "Ten single-use recovery codes, shown once", schema: refs.TotpRecoveryCodes } },
+});
+
+route({
+  method: "post",
+  path: "/auth/2fa/verify",
+  tag,
+  summary: "Complete a login that returned a TOTP challenge (5/min per IP)",
+  public: true,
+  body: refs.TotpVerifyInput,
+  responses: { 200: { description: "A session", schema: refs.AuthSession } },
+});
+
+route({
+  method: "post",
+  path: "/auth/2fa/disable",
+  tag,
+  summary: "Turn off TOTP",
+  body: refs.TotpDisableInput,
+  responses: { 204: { description: "Disabled" } },
+});

--- a/apps/api/src/openapi/paths/bio-pages.ts
+++ b/apps/api/src/openapi/paths/bio-pages.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+const tag = "Bio pages";
+
+route({
+  method: "get",
+  path: "/bio-pages",
+  tag,
+  summary: "List bio pages",
+  responses: { 200: { description: "Bio pages", schema: z.array(refs.BioPage) } },
+});
+
+route({
+  method: "put",
+  path: "/bio-pages",
+  tag,
+  summary: "Create or update the bio page for a (domain, slug)",
+  body: refs.UpsertBioPageInput,
+  responses: { 200: { description: "The bio page", schema: refs.BioPage } },
+});
+
+route({
+  method: "delete",
+  path: "/bio-pages/{id}",
+  tag,
+  summary: "Delete a bio page",
+  params: IdParam,
+  responses: { 204: { description: "Deleted" } },
+});

--- a/apps/api/src/openapi/paths/developers.ts
+++ b/apps/api/src/openapi/paths/developers.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+route({
+  method: "get",
+  path: "/api-keys",
+  tag: "API keys",
+  summary: "List API keys",
+  responses: { 200: { description: "API keys (never the raw key again)", schema: z.array(refs.ApiKey) } },
+});
+
+route({
+  method: "post",
+  path: "/api-keys",
+  tag: "API keys",
+  summary: "Create an API key",
+  body: refs.CreateApiKeyInput,
+  responses: {
+    201: { description: "The only response that ever includes the raw key", schema: refs.CreatedApiKey },
+  },
+});
+
+route({
+  method: "delete",
+  path: "/api-keys/{id}",
+  tag: "API keys",
+  summary: "Revoke an API key",
+  params: IdParam,
+  responses: { 204: { description: "Revoked" } },
+});
+
+route({
+  method: "get",
+  path: "/webhooks",
+  tag: "Webhooks",
+  summary: "List webhooks",
+  responses: { 200: { description: "Webhooks (never the signing secret again)", schema: z.array(refs.Webhook) } },
+});
+
+route({
+  method: "post",
+  path: "/webhooks",
+  tag: "Webhooks",
+  summary: "Create a webhook",
+  body: refs.CreateWebhookInput,
+  responses: {
+    201: { description: "The only response that ever includes the signing secret", schema: refs.CreatedWebhook },
+  },
+});
+
+route({
+  method: "delete",
+  path: "/webhooks/{id}",
+  tag: "Webhooks",
+  summary: "Delete a webhook",
+  params: IdParam,
+  responses: { 204: { description: "Deleted" } },
+});

--- a/apps/api/src/openapi/paths/domains.ts
+++ b/apps/api/src/openapi/paths/domains.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+const tag = "Domains";
+
+route({
+  method: "get",
+  path: "/domains",
+  tag,
+  summary: "List domains",
+  responses: { 200: { description: "Domains", schema: z.array(refs.Domain) } },
+});
+
+route({
+  method: "post",
+  path: "/domains",
+  tag,
+  summary: "Add a domain",
+  body: refs.AddDomainInput,
+  responses: { 201: { description: "The added domain", schema: refs.Domain } },
+});
+
+route({
+  method: "post",
+  path: "/domains/{id}/verify",
+  tag,
+  summary: "Re-check a domain's DNS/TLS verification",
+  params: IdParam,
+  responses: { 200: { description: "The updated domain", schema: refs.Domain } },
+});
+
+route({
+  method: "delete",
+  path: "/domains/{id}",
+  tag,
+  summary: "Remove a domain",
+  params: IdParam,
+  responses: { 204: { description: "Deleted" } },
+});

--- a/apps/api/src/openapi/paths/forms.ts
+++ b/apps/api/src/openapi/paths/forms.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+const tag = "Forms";
+
+route({
+  method: "get",
+  path: "/forms",
+  tag,
+  summary: "List forms",
+  responses: { 200: { description: "Forms", schema: z.array(refs.Form) } },
+});
+
+route({
+  method: "get",
+  path: "/forms/{id}",
+  tag,
+  summary: "Get a form",
+  params: IdParam,
+  responses: { 200: { description: "The form", schema: refs.Form } },
+});
+
+route({
+  method: "get",
+  path: "/forms/{id}/responses",
+  tag,
+  summary: "List a form's responses",
+  params: IdParam,
+  responses: { 200: { description: "Responses", schema: refs.FormResponseList } },
+});
+
+route({
+  method: "get",
+  path: "/forms/{id}/responses.csv",
+  tag,
+  summary: "Export a form's responses as CSV",
+  params: IdParam,
+  responses: { 200: { description: "CSV file, streamed", schema: z.string(), contentType: "text/csv" } },
+});
+
+route({
+  method: "post",
+  path: "/forms",
+  tag,
+  summary: "Create a form",
+  body: refs.CreateFormInput,
+  responses: { 201: { description: "The created form", schema: refs.Form } },
+});
+
+route({
+  method: "patch",
+  path: "/forms/{id}",
+  tag,
+  summary: "Update a form",
+  params: IdParam,
+  body: refs.UpdateFormInput,
+  responses: { 200: { description: "The updated form", schema: refs.Form } },
+});
+
+route({
+  method: "delete",
+  path: "/forms/{id}",
+  tag,
+  summary: "Delete a form",
+  params: IdParam,
+  responses: { 204: { description: "Deleted" } },
+});

--- a/apps/api/src/openapi/paths/health.ts
+++ b/apps/api/src/openapi/paths/health.ts
@@ -1,0 +1,10 @@
+import { HealthStatus, route } from "../registry.js";
+
+route({
+  method: "get",
+  path: "/health",
+  tag: "Health",
+  summary: "Liveness/readiness probe for a load balancer",
+  public: true,
+  responses: { 200: { description: "Health status", schema: HealthStatus } },
+});

--- a/apps/api/src/openapi/paths/links.ts
+++ b/apps/api/src/openapi/paths/links.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+const tag = "Links";
+
+route({
+  method: "get",
+  path: "/links",
+  tag,
+  summary: "List links in the workspace",
+  query: refs.ListLinksQuery,
+  responses: { 200: { description: "A page of matching links", schema: refs.LinkList } },
+});
+
+// Declared before /links/:id in the actual controller so "export" is never
+// swallowed as an :id — this doc mirrors that path ordering for the same
+// reason, though the generated spec itself has no ordering hazard.
+route({
+  method: "get",
+  path: "/links/export",
+  tag,
+  summary: "Export matching links as CSV",
+  query: refs.ListLinksQuery,
+  responses: { 200: { description: "CSV file, streamed", schema: z.string(), contentType: "text/csv" } },
+});
+
+route({
+  method: "get",
+  path: "/links/{id}",
+  tag,
+  summary: "Get a single link",
+  params: IdParam,
+  responses: { 200: { description: "The link", schema: refs.Link } },
+});
+
+route({
+  method: "post",
+  path: "/links",
+  tag,
+  summary: "Create a link",
+  body: refs.CreateLinkInput,
+  responses: { 201: { description: "The created link", schema: refs.Link } },
+});
+
+route({
+  method: "post",
+  path: "/links/bulk",
+  tag,
+  summary: "Create up to 100 links in one call",
+  body: refs.BulkCreateLinksInput,
+  responses: {
+    200: {
+      description: "Always 200 — per-row success/failure is reported in the body, not the status",
+      schema: refs.BulkCreateLinksResult,
+    },
+  },
+});
+
+route({
+  method: "post",
+  path: "/links/{id}/clone",
+  tag,
+  summary: "Clone a link",
+  params: IdParam,
+  body: refs.CloneLinkInput,
+  responses: { 201: { description: "The cloned link", schema: refs.Link } },
+});
+
+route({
+  method: "patch",
+  path: "/links/{id}",
+  tag,
+  summary: "Update a link (not its domain or slug)",
+  params: IdParam,
+  body: refs.UpdateLinkInput,
+  responses: { 200: { description: "The updated link", schema: refs.Link } },
+});
+
+route({
+  method: "delete",
+  path: "/links/{id}",
+  tag,
+  summary: "Delete a link",
+  params: IdParam,
+  responses: { 204: { description: "Deleted" } },
+});

--- a/apps/api/src/openapi/paths/members.ts
+++ b/apps/api/src/openapi/paths/members.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+route({
+  method: "get",
+  path: "/members",
+  tag: "Members",
+  summary: "List workspace members",
+  responses: { 200: { description: "Members", schema: z.array(refs.Member) } },
+});
+
+route({
+  method: "post",
+  path: "/members",
+  tag: "Members",
+  summary: "Invite a member",
+  body: refs.InviteMemberInput,
+  responses: { 201: { description: "The invited member", schema: refs.Member } },
+});
+
+route({
+  method: "patch",
+  path: "/members/{id}",
+  tag: "Members",
+  summary: "Change a member's role",
+  params: IdParam,
+  body: refs.ChangeRoleInput,
+  responses: { 204: { description: "Changed" } },
+});
+
+route({
+  method: "delete",
+  path: "/members/{id}",
+  tag: "Members",
+  summary: "Remove a member",
+  params: IdParam,
+  responses: { 204: { description: "Removed" } },
+});
+
+route({
+  method: "get",
+  path: "/audit",
+  tag: "Audit",
+  summary: "The workspace's audit log",
+  responses: { 200: { description: "Audit entries", schema: z.array(refs.AuditEntry) } },
+});

--- a/apps/api/src/openapi/paths/public.ts
+++ b/apps/api/src/openapi/paths/public.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { refs, route, SlugParam } from "../registry.js";
+
+const tag = "Public";
+
+route({
+  method: "get",
+  path: "/public/links/{slug}/preview",
+  tag,
+  summary: "Preview a link's destination before following it",
+  public: true,
+  params: SlugParam,
+  query: z.object({ host: z.string().optional().describe("The domain the slug was resolved on") }),
+  responses: { 200: { description: "Preview", schema: refs.PublicLinkPreview } },
+});
+
+route({
+  method: "post",
+  path: "/public/links/{slug}/unlock",
+  tag,
+  summary: "Submit a password for a password-protected link (5/min per IP)",
+  public: true,
+  params: SlugParam,
+  query: z.object({ host: z.string().optional() }),
+  body: refs.UnlockLinkInput,
+  responses: {
+    200: { description: "A short-lived unlock token, scoped to this one link", schema: refs.UnlockLinkResult },
+  },
+});
+
+route({
+  method: "get",
+  path: "/public/forms/{slug}",
+  tag,
+  summary: "Get a published form (404 for draft/closed — existence is not public)",
+  public: true,
+  params: SlugParam,
+  responses: { 200: { description: "The public form definition", schema: refs.PublicForm } },
+});
+
+route({
+  method: "post",
+  path: "/public/forms/{slug}",
+  tag,
+  summary: "Submit a form response (10/min per IP)",
+  public: true,
+  params: SlugParam,
+  body: refs.SubmitFormInput,
+  responses: {
+    200: {
+      description: "Always 200 — validation failures are per-field errors in the body, not a 400",
+      schema: refs.SubmitFormResult,
+    },
+  },
+});
+
+route({
+  method: "post",
+  path: "/public/links/{slug}/report",
+  tag,
+  summary: "Report a link for abuse (10/min per IP)",
+  public: true,
+  params: SlugParam,
+  body: refs.SubmitReportInput,
+  responses: {
+    200: {
+      description: "Always {ok:true} regardless of whether the slug resolves — cannot be used to enumerate slugs (#291)",
+      schema: refs.SubmitReportResult,
+    },
+  },
+});

--- a/apps/api/src/openapi/paths/reports.ts
+++ b/apps/api/src/openapi/paths/reports.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { IdParam, refs, route } from "../registry.js";
+
+const tag = "Abuse reports";
+
+route({
+  method: "get",
+  path: "/reports",
+  tag,
+  summary: "List abuse reports (operator-side review queue)",
+  responses: { 200: { description: "Reports", schema: z.array(refs.AbuseReport) } },
+});
+
+route({
+  method: "patch",
+  path: "/reports/{id}",
+  tag,
+  summary: "Review an abuse report",
+  params: IdParam,
+  body: refs.UpdateAbuseReportInput,
+  responses: { 200: { description: "The updated report", schema: refs.AbuseReport } },
+});

--- a/apps/api/src/openapi/paths/workspaces.ts
+++ b/apps/api/src/openapi/paths/workspaces.ts
@@ -1,0 +1,18 @@
+import { refs, route } from "../registry.js";
+
+route({
+  method: "get",
+  path: "/workspaces/current",
+  tag: "Workspace",
+  summary: "Get the caller's workspace",
+  responses: { 200: { description: "The workspace", schema: refs.Workspace } },
+});
+
+route({
+  method: "patch",
+  path: "/workspaces/current",
+  tag: "Workspace",
+  summary: "Update workspace settings",
+  body: refs.UpdateWorkspaceInput,
+  responses: { 200: { description: "The updated workspace", schema: refs.Workspace } },
+});

--- a/apps/api/src/openapi/registry.ts
+++ b/apps/api/src/openapi/registry.ts
@@ -1,0 +1,133 @@
+import { extendZodWithOpenApi, OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { z, type ZodTypeAny } from "zod";
+
+/* Patches zod's schema-construction methods (.object(), .extend(), .optional(),
+   etc.) so that whatever they build carries a working .openapi(). This is NOT
+   a plain prototype patch that applies retroactively — it has to run before a
+   single schema anywhere in the process is constructed, packages/contract
+   included, or the schemas already built by then keep the unpatched methods.
+   That is why this sits between the two imports rather than above both:
+   `import * as Contract from "@snapurl/contract"` below is what constructs
+   every schema in the contract package, so it has to come after this call,
+   not before it — an ordinary top-of-file import block would run Contract's
+   construction first and this patch second, silently too late. */
+extendZodWithOpenApi(z);
+
+import * as Contract from "@snapurl/contract";
+
+/* ============================================================
+   The OpenAPI registry, generated from packages/contract rather
+   than from decorators.
+
+   The API deliberately has no class-validator DTOs to hang
+   @nestjs/swagger's usual @ApiProperty() introspection off of —
+   see docs/DECISIONS.md's stack-choices table ("I dropped
+   nestjs-zod mid-build"). Decorating every controller method by
+   hand instead would just grow a second description of each shape
+   that can drift from packages/contract the same way
+   web/README.md's endpoint table already had (#339) — two sources
+   of truth for the same schema, silently disagreeing.
+
+   So every request/response body here is the SAME zod schema the
+   API validates against and the frontend imports, fed through
+   @asteasolutions/zod-to-openapi. Registering a schema is a plain
+   object walk over every named export of @snapurl/contract that is
+   actually a ZodType — the two exported `as const` string tuples
+   (API_SCOPES, WEBHOOK_EVENTS) and the isDeniedHost() helper fail
+   that check and are skipped without needing to name them.
+   ============================================================ */
+
+export const registry = new OpenAPIRegistry();
+
+registry.registerComponent("securitySchemes", "bearerAuth", {
+  type: "http",
+  scheme: "bearer",
+  bearerFormat: "JWT",
+  description:
+    "A session access token (from /auth/login, /auth/oauth or /auth/register) or an API key prefixed snap_live_.",
+});
+
+/** Every contract export, registered under its own name so route definitions
+ *  below can reference `refs.Link` etc. and get a `$ref` in the generated
+ *  document instead of the schema inlined again at every use site — the
+ *  library links a schema to its ref by the identity of what register()
+ *  RETURNS, not the original import, which is why every route file imports
+ *  from here rather than from @snapurl/contract directly. */
+export const refs: Record<string, ZodTypeAny> = {};
+for (const [name, value] of Object.entries(Contract)) {
+  if (value instanceof z.ZodType) {
+    refs[name] = registry.register(name, value);
+  }
+}
+
+/** Two shapes with no equivalent in packages/contract: /health has no
+ *  request/response contract (it's an infra probe, not part of the app's
+ *  data contract), and path/query params are validated at the NestJS layer
+ *  (ParseUUIDPipe, etc.) rather than by a named zod schema, so there is
+ *  nothing in the contract package to point at for them either. */
+export const IdParam = z.object({ id: z.string().describe("Resource id (UUID)") });
+export const SlugParam = z.object({ slug: z.string().describe("The link, form or bio page's back-half") });
+export const HealthStatus = registry.register(
+  "HealthStatus",
+  z.object({
+    status: z.enum(["ok", "degraded"]),
+    database: z.enum(["ok", "unreachable"]),
+    latencyMs: z.number(),
+  }),
+);
+
+type Method = "get" | "post" | "patch" | "put" | "delete";
+
+interface ResponseDef {
+  description: string;
+  schema?: ZodTypeAny;
+  contentType?: string;
+}
+
+interface RouteDef {
+  method: Method;
+  path: string;
+  tag: string;
+  summary: string;
+  /** Defaults to requiring the bearer scheme; set true for an @Public() route. */
+  public?: boolean;
+  params?: ZodTypeAny;
+  query?: ZodTypeAny;
+  body?: ZodTypeAny;
+  bodyContentType?: string;
+  responses: Record<number, ResponseDef>;
+}
+
+/** One call per endpoint, matching the #339 inventory of every controller.
+ *  Kept as a single helper (rather than repeating registerPath's shape at
+ *  every call site) purely to fold the security/content-type boilerplate
+ *  that is identical across ~60 routes into one place. */
+export function route(def: RouteDef): void {
+  registry.registerPath({
+    method: def.method,
+    path: def.path,
+    tags: [def.tag],
+    summary: def.summary,
+    security: def.public ? [] : [{ bearerAuth: [] }],
+    request: {
+      // params/query are always registered as z.object({...}) at every call
+      // site (IdParam, SlugParam, or an inline z.object(...)) — the cast is
+      // only here because `refs` erases that to the base ZodType so every
+      // export of @snapurl/contract fits in one map.
+      ...(def.params ? { params: def.params as z.ZodObject } : {}),
+      ...(def.query ? { query: def.query as z.ZodObject } : {}),
+      ...(def.body
+        ? { body: { content: { [def.bodyContentType ?? "application/json"]: { schema: def.body } } } }
+        : {}),
+    },
+    responses: Object.fromEntries(
+      Object.entries(def.responses).map(([status, r]) => [
+        status,
+        {
+          description: r.description,
+          ...(r.schema ? { content: { [r.contentType ?? "application/json"]: { schema: r.schema } } } : {}),
+        },
+      ]),
+    ),
+  });
+}

--- a/packages/contract/src/workspace.ts
+++ b/packages/contract/src/workspace.ts
@@ -94,6 +94,9 @@ export const InviteMemberInput = z.object({
 });
 export type InviteMemberInput = z.infer<typeof InviteMemberInput>;
 
+export const ChangeRoleInput = z.object({ role: MemberRole });
+export type ChangeRoleInput = z.infer<typeof ChangeRoleInput>;
+
 export const AuditEntry = z.object({
   id: z.string(),
   at: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,15 @@ importers:
 
   apps/api:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^9.1.0
+        version: 9.1.0(zod@4.4.3)
       '@fastify/cors':
         specifier: ^11.0.1
         version: 11.3.0
+      '@fastify/static':
+        specifier: ^10.1.3
+        version: 10.1.3
       '@nestjs/common':
         specifier: ^11.1.6
         version: 11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
@@ -31,7 +37,10 @@ importers:
         version: 11.0.2(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))
       '@nestjs/platform-fastify':
         specifier: ^11.1.6
-        version: 11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+        version: 11.2.3(@fastify/static@10.1.3)(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/swagger':
+        specifier: ^11.4.7
+        version: 11.4.7(@fastify/static@10.1.3)(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
       '@nestjs/throttler':
         specifier: ^6.4.0
         version: 6.5.0(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
@@ -92,7 +101,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/extension:
     dependencies:
@@ -117,7 +126,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/redirect:
     dependencies:
@@ -163,7 +172,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/worker:
     dependencies:
@@ -197,7 +206,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   infra:
     devDependencies:
@@ -224,7 +233,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/cache:
     dependencies:
@@ -249,7 +258,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/contract:
     dependencies:
@@ -265,7 +274,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/database:
     dependencies:
@@ -302,7 +311,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/domain:
     dependencies:
@@ -318,7 +327,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   web:
     dependencies:
@@ -432,6 +441,11 @@ packages:
   '@angular-devkit/schematics@19.2.27':
     resolution: {integrity: sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@asteasolutions/zod-to-openapi@9.1.0':
+    resolution: {integrity: sha512-pLMeRgRYS7/vZIgAAkOe2P6+XGTifR1MT9pqDoxZ11EmcJJ+DPmdPqLN8ZZF4U8R9KHCCQCS9c2wtuE8wSrfkw==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@aws-cdk/asset-awscli-v1@2.2.292':
     resolution: {integrity: sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==}
@@ -1176,6 +1190,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/accept-negotiator@2.1.0':
+    resolution: {integrity: sha512-F3EVbzWt+xcnVaOHmWyIlpuFtbxOln7HDZQsh09MtMmMm/CipMayNt8hnIL8VQi54u2ZociDbf+iluGYkf7B1A==}
+
   '@fastify/ajv-compiler@4.0.6':
     resolution: {integrity: sha512-NtuzM0SfaMJbGlnjr9LWQUN5LzgSrbB8tf/wRZNas+4E1O/Nmzl53e7ruT61HDZyRCJGC6FxIogmNZO1c5ETBA==}
 
@@ -1199,6 +1216,12 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.1':
+    resolution: {integrity: sha512-BYo+EiaKwlxH+WetGk6hAs1d39iP0y1gqB8lGF/qwkJ9ZZ/cBY1vx5NvExb9Sc3yRMFjD5X4Eyh4e4+TzRkzdw==}
+
+  '@fastify/static@10.1.3':
+    resolution: {integrity: sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==}
 
   '@hookform/resolvers@5.9.1':
     resolution: {integrity: sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==}
@@ -1600,6 +1623,13 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -1662,6 +1692,19 @@ packages:
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
 
+  '@nestjs/mapped-types@2.1.1':
+    resolution: {integrity: sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0 || ^0.15.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/platform-fastify@11.2.3':
     resolution: {integrity: sha512-SxUH+4+KnloYV0RD/fjuCl7UkQx9paMkxyHQLO1mHTTdX8CCBToWIZ6PXrBvXVNEHlVmxGnR0ob4zGVKWdD9EA==}
     peerDependencies:
@@ -1682,6 +1725,23 @@ packages:
       typescript: '>=4.8.2'
     peerDependenciesMeta:
       prettier:
+        optional: true
+
+  '@nestjs/swagger@11.4.7':
+    resolution: {integrity: sha512-QyDYnmfP4IRucgmtQxMqzgRBdWtjFoDp8eFvvgf92+3wdLCL+Q0xOFO1948j/ntW/Wi7qT2dyck6ka8ADzPWQQ==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0 || ^9.0.0 || ^10.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
         optional: true
 
   '@nestjs/throttler@6.5.0':
@@ -1919,6 +1979,9 @@ packages:
     resolution: {integrity: sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==}
     cpu: [x64]
     os: [win32]
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@smithy/core@3.33.3':
     resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
@@ -2474,6 +2537,10 @@ packages:
   constructs@10.8.1:
     resolution: {integrity: sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==}
 
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
+    engines: {node: '>=18'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -2579,6 +2646,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2755,6 +2826,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -2897,6 +2971,10 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
@@ -2968,6 +3046,10 @@ packages:
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -3152,6 +3234,11 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -3249,6 +3336,9 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openapi3-ts@4.6.1:
+    resolution: {integrity: sha512-XW9MOldkhoICNeXVzzmXzmOW5G73ppOEGmh7fLCqHjgfdEYCGGN+00MlVCeUZgovjjfC56j9tvtDt1zGabNjjA==}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -3526,6 +3616,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3576,6 +3669,10 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -3625,6 +3722,9 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  swagger-ui-dist@5.32.13:
+    resolution: {integrity: sha512-qQobzb3DeC2LeK0j3E8812Ef4aIq1y9flJxvZkimkqUC/w4u7wS+yCc+VakqGJLweUUBrI24effhwo8OsAvNAw==}
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -3723,6 +3823,10 @@ packages:
   toad-cache@3.7.4:
     resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
     engines: {node: '>=20'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -3913,6 +4017,11 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -4007,6 +4116,11 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@asteasolutions/zod-to-openapi@9.1.0(zod@4.4.3)':
+    dependencies:
+      openapi3-ts: 4.6.1
+      zod: 4.4.3
 
   '@aws-cdk/asset-awscli-v1@2.2.292': {}
 
@@ -4566,6 +4680,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@fastify/accept-negotiator@2.1.0': {}
+
   '@fastify/ajv-compiler@4.0.6':
     dependencies:
       ajv: 8.20.0
@@ -4598,6 +4714,24 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.2
       ipaddr.js: 2.5.0
+
+  '@fastify/send@4.1.1':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@10.1.3':
+    dependencies:
+      '@fastify/accept-negotiator': 2.1.0
+      '@fastify/error': 4.2.0
+      '@fastify/send': 4.1.1
+      content-disposition: 2.0.1
+      fastify-plugin: 6.0.0
+      fastq: 1.20.1
+      glob: 13.0.6
 
   '@hookform/resolvers@5.9.1(@standard-schema/spec@1.1.0)(ajv-formats@2.1.1(ajv@8.20.0))(ajv@8.20.0)(react-hook-form@7.86.0(react@19.1.0))(zod@4.4.3)':
     dependencies:
@@ -4874,6 +5008,10 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@lukeed/ms@2.0.2': {}
+
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -4950,7 +5088,12 @@ snapshots:
       '@types/jsonwebtoken': 9.0.10
       jsonwebtoken: 9.0.3
 
-  '@nestjs/platform-fastify@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
+      reflect-metadata: 0.2.2
+
+  '@nestjs/platform-fastify@11.2.3(@fastify/static@10.1.3)(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
       '@fastify/cors': 11.3.0
       '@fastify/formbody': 8.0.2
@@ -4964,6 +5107,8 @@ snapshots:
       path-to-regexp: 8.4.2
       reusify: 1.1.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@fastify/static': 10.1.3
 
   '@nestjs/schematics@11.1.0(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -4975,6 +5120,20 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - chokidar
+
+  '@nestjs/swagger@11.4.7(@fastify/static@10.1.3)(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@nestjs/common': 11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
+      '@nestjs/core': 11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)
+      js-yaml: 5.3.0
+      lodash: 4.18.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.32.13
+    optionalDependencies:
+      '@fastify/static': 10.1.3
 
   '@nestjs/throttler@6.5.0(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.2.3(@nestjs/common@11.2.3(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
     dependencies:
@@ -5121,6 +5280,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.63.0':
     optional: true
+
+  '@scarf/scarf@1.4.0': {}
 
   '@smithy/core@3.33.3':
     dependencies:
@@ -5339,13 +5500,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12))':
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -5668,6 +5829,8 @@ snapshots:
 
   constructs@10.8.1: {}
 
+  content-disposition@2.0.1: {}
+
   cookie@1.1.1: {}
 
   cosmiconfig@8.3.6(typescript@5.9.3):
@@ -5753,6 +5916,8 @@ snapshots:
       clone: 1.0.4
 
   denque@2.1.0: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -5921,6 +6086,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -6077,6 +6244,14 @@ snapshots:
 
   help-me@5.0.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -6134,6 +6309,10 @@ snapshots:
   js-tokens@9.0.1: {}
 
   js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6291,6 +6470,8 @@ snapshots:
 
   mime-db@1.54.0: {}
 
+  mime@3.0.0: {}
+
   mimic-fn@2.1.0: {}
 
   minimatch@10.2.6:
@@ -6370,6 +6551,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openapi3-ts@4.6.1:
+    dependencies:
+      yaml: 2.9.0
 
   ora@5.4.1:
     dependencies:
@@ -6675,6 +6860,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  setprototypeof@1.2.0: {}
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -6740,6 +6927,8 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   string-width@4.2.3:
@@ -6780,6 +6969,10 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  swagger-ui-dist@5.32.13:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   symbol-observable@4.0.0: {}
 
@@ -6832,6 +7025,8 @@ snapshots:
   tinyspy@4.0.4: {}
 
   toad-cache@3.7.4: {}
+
+  toidentifier@1.0.1: {}
 
   token-types@6.1.2:
     dependencies:
@@ -6905,13 +7100,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12):
+  vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6926,7 +7121,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12):
+  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.7)
@@ -6941,12 +7136,13 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.51.0
       tsx: 4.23.12
+      yaml: 2.9.0
 
-  vitest@3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12):
+  vitest@3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12))
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -6964,8 +7160,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)
-      vite-node: 3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
@@ -7060,6 +7256,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   y18n@4.0.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ allowBuilds:
   esbuild: true
   sharp: true
   argon2: true
+  '@scarf/scarf': true


### PR DESCRIPTION
Closes #339.

## What
There was no browsable API documentation. The closest thing — an endpoint table in `web/README.md` — was already stale, missing `PATCH /links/:id`, `/auth/oauth`, `/auth/logout`, `/auth/2fa/*`, `/forms`, `/reports`, `/developers/*`, and more.

## Why generated from packages/contract, not decorators
`@nestjs/swagger`'s usual `@ApiProperty()` introspection needs class-validator DTOs, which this API deliberately doesn't have (`docs/DECISIONS.md`: "I dropped nestjs-zod mid-build"). Decorating every controller method by hand instead would just grow a second description of each shape that can drift from `packages/contract` the same way the README table already had — two sources of truth for the same schema, silently disagreeing.

So the document is generated directly from the zod schemas in `packages/contract` via `@asteasolutions/zod-to-openapi`, then served through `@nestjs/swagger`'s `SwaggerModule.setup()` (which accepts any OpenAPI document object, not only one built via its own `DocumentBuilder`). It's the same schema the API validates against and the frontend imports — there's exactly one source of truth.

## Scope
All 56 routes across all 12 controllers, registered against their actual request/response contract types (`apps/api/src/openapi/paths/*.ts`, one file per controller). Verified against a fresh inventory of every controller (method, path, auth requirement, body/response schema) rather than documenting a partial subset — a half-covered doc would just be a new version of the staleness problem this closes.

## Two things worth flagging
- `ChangeRoleInput` (`PATCH /members/:id`) was previously defined inline in `members.controller.ts` rather than exported from `packages/contract` — moved it so there's one source of truth for it too, matching every other schema.
- `extendZodWithOpenApi()` has to run before a single zod schema anywhere in the process is constructed, not just before registration — it patches the schema-construction methods themselves (`.object()`, `.extend()`, etc.), not something retroactive on already-built schemas. `registry.ts` calls it between its two zod-related imports, before importing `@snapurl/contract` (which is what constructs every schema); `main.ts` also imports `openapi/document.js` before `AppModule` for the same reason, as defense in depth. Took a while to track down — worth knowing if this ever needs touching again.

## Where it lives
Swagger UI at `/api/v1/docs`, raw spec at `/api/v1/docs-json` — mounted next to whatever `API_PREFIX` is configured, so it stays correct if that's ever changed.

## Testing
- `pnpm --filter @snapurl/api type-check` / `build` — clean.
- `pnpm --filter @snapurl/api test` — 153/153 passing.
- `pnpm --filter @snapurl/contract test` (48/48) and `pnpm --filter @snapurl/database test` (65/65) — passing, covers the `ChangeRoleInput` move.
- `pnpm build` (full monorepo, matching CI) — clean.
- Manual verification against a real running instance: Swagger UI renders all 56 routes with correct tags/methods; expanding `POST /links` shows the real `CreateLinkInput` field list; confirmed `/auth/oauth` has no security requirement while `/auth/me` requires the bearer scheme; confirmed CSV-returning routes (`/links/export`, `/forms/:id/responses.csv`) declare `text/csv` content type instead of JSON; confirmed `PATCH /members/:id` correctly `$ref`s the newly-exported `ChangeRoleInput`; fetched the raw JSON spec directly and counted 56 path+method entries and 79 component schemas (78 contract exports + a hand-written `HealthStatus` for the one endpoint with no contract equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
