### PR TITLE
fix(worker): drain the projection outbox on its own timer

### DIFF
--- a/apps/worker/src/lambda.test.ts
+++ b/apps/worker/src/lambda.test.ts
@@ -21,10 +21,12 @@ vi.mock("@snapurl/database", async (importOriginal) => {
 const fakeDb = { __fake: true };
 const runFrequent = vi.fn(async () => ({ rolled: { events: 0 } }));
 const runMaintenance = vi.fn(async () => ({ ok: true }));
+const runProjection = vi.fn(async () => ({ processed: 0, failed: 0 }));
 vi.mock("./main.js", () => ({
   initDb: vi.fn(async () => ({ db: fakeDb, close: async () => {} })),
   runFrequent: (...args: unknown[]) => runFrequent(...args),
   runMaintenance: (...args: unknown[]) => runMaintenance(...args),
+  runProjection: (...args: unknown[]) => runProjection(...args),
   log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
@@ -137,6 +139,8 @@ describe("worker task dispatch", () => {
     runMaintenance.mockResolvedValue({ ok: true } as never);
     runFrequent.mockReset();
     runFrequent.mockResolvedValue({ rolled: { events: 0 } } as never);
+    runProjection.mockReset();
+    runProjection.mockResolvedValue({ processed: 0, failed: 0 } as never);
   });
 
   it("dispatches the backfill task to backfillClickPartitions and returns its result", async () => {
@@ -168,8 +172,14 @@ describe("worker task dispatch", () => {
 
   it("does not treat a frequent invocation as a backfill", async () => {
     runFrequent.mockResolvedValue({ rolled: { events: 0 } } as never);
+    runProjection.mockResolvedValue({ processed: 3, failed: 0 } as never);
     const result = await handler({ task: "frequent" });
-    expect(result).toEqual({ task: "frequent", frequent: { rolled: { events: 0 } } });
+    // runProjection's result is folded in as `outbox`, exactly the field name
+    // runFrequent used to return when it drained the outbox itself.
+    expect(result).toEqual({
+      task: "frequent",
+      frequent: { rolled: { events: 0 }, outbox: { processed: 3, failed: 0 } },
+    });
     expect(backfillClickPartitions).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -1,5 +1,5 @@
 import { deserializeClickEvent, insertClickEvents, resolveDatabaseUrl, runMigrations, type Database } from "@snapurl/database";
-import { initDb, log, runFrequent, runMaintenance } from "./main.js";
+import { initDb, log, runFrequent, runMaintenance, runProjection } from "./main.js";
 import { backfillClickPartitions } from "./jobs/rollup.js";
 
 /* The worker as a Lambda, dispatched by a `task` discriminator.
@@ -20,12 +20,12 @@ import { backfillClickPartitions } from "./jobs/rollup.js";
  *                               (see below). A one-time adoption/repair op an
  *                               operator triggers manually, on no schedule.
  *   - `"maintenance"`        -> runMaintenance only.
- *   - `"frequent"`           -> runFrequent only.
- *   - `"rollup"`             -> runFrequent only (back-compat alias for the
- *                               old payload; the previous handler treated a
- *                               no-payload/rollup invocation as the recurring
- *                               job).
- *   - default / no payload   -> runFrequent only.
+ *   - `"frequent"`           -> runProjection + runFrequent.
+ *   - `"rollup"`             -> runProjection + runFrequent (back-compat alias
+ *                               for the old payload; the previous handler
+ *                               treated a no-payload/rollup invocation as the
+ *                               recurring job).
+ *   - default / no payload   -> runProjection + runFrequent.
  *
  * The DEFAULT partition still guarantees inserts never fail between the hourly
  * ensureClickPartitions runs, so moving maintenance off the 1-minute cadence
@@ -168,7 +168,13 @@ export const handler = async (event: WorkerEvent | SqsEvent = {}) => {
   }
 
   /* Everything else — the 1-minute frequent schedule, the "rollup" back-compat
-     alias, and a bare no-payload invocation — runs the frequent job only. */
+     alias, and a bare no-payload invocation — runs the frequent job. Outbox
+     draining (runProjection) is a separate function from runFrequent (see
+     main.ts) so the long-running worker loop can put it on its own faster
+     timer; a scheduled Lambda invocation has no such loop; it just runs both
+     back to back and folds the result into the same `frequent` shape this
+     handler has always returned. */
+  const outbox = await runProjection(db);
   const frequent = await runFrequent(db);
-  return { task: "frequent", frequent };
+  return { task: "frequent", frequent: { ...frequent, outbox } };
 };

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -22,6 +22,12 @@ import { deliverWebhooks, pruneDeliveries } from "./jobs/webhooks.js";
    creating a second pino with its own level and destination. */
 export const log = pino({ level: process.env.LOG_LEVEL ?? "info" });
 const ROLLUP_SECONDS = Number(process.env.ROLLUP_INTERVAL_SECONDS ?? 30);
+/* Defaults to ROLLUP_SECONDS so nothing needs to change to keep today's
+   cadence — the dynamo-smoke CI job's ROLLUP_INTERVAL_SECONDS=0.25 already
+   governs this too, unless PROJECTION_INTERVAL_SECONDS overrides it
+   separately. See runProjection's header for why this runs on its own timer
+   rather than as a step inside runFrequent's. */
+const PROJECTION_SECONDS = Number(process.env.PROJECTION_INTERVAL_SECONDS ?? ROLLUP_SECONDS);
 const MAINTENANCE_SECONDS = Number(process.env.MAINTENANCE_INTERVAL_SECONDS ?? 3600);
 
 /* Four for the long-running process; the scheduled Lambda sets this to 1,
@@ -176,26 +182,54 @@ function projectionFor(database: Database): ProjectionTarget {
   return projectionTarget;
 }
 
-/** Runs often: this is the loop that makes the dashboards current. */
+/** Drains the projection outbox — the ONLY thing standing between a link
+ *  write and that link being resolvable from the DynamoDB projection (see
+ *  @snapurl/database's link-projection module and DynamoLinkResolver).
+ *
+ *  Kept on its OWN timer (main()'s loop below), independent of runFrequent's
+ *  rollupClicks + deliverWebhooks. It used to run as the middle step of
+ *  runFrequent, so its effective cadence was hostage to however long the
+ *  other two took on a given pass: rollupClicks runs a multi-statement
+ *  transaction over click_events whose cost grows with click volume, and
+ *  everyN's anti-overlap guard (see below) means a slow pass doesn't just
+ *  delay that tick's drain — it pushes the NEXT tick's start out too, so the
+ *  gap between a link's outbox insert and its projection could stretch well
+ *  past the nominal interval under load. That is exactly the gap the
+ *  LINK_PROJECTION=dynamo CI job's create-then-immediately-redirect smoke
+ *  assertions race against (see verify.yml's dynamo-smoke job): a link
+ *  created late in the smoke script's setup burst, then resolved moments
+ *  later, could still 404 because its outbox row was still waiting on a slow
+ *  rollup pass to finish. Running this alone keeps its cadence close to the
+ *  configured interval regardless of what rollupClicks or deliverWebhooks are
+ *  doing. */
+export async function runProjection(database: Database) {
+  const outbox = await drainOutbox(database, projectionFor(database));
+  if (outbox.processed || outbox.failed) {
+    log.info({ projected: outbox.processed, projectionFailures: outbox.failed }, "projection drain");
+  }
+  return outbox;
+}
+
+/** Runs often: this is the loop that makes the dashboards current. Outbox
+ *  draining lives in the separate runProjection() (see its header) so its
+ *  cadence is never hostage to how long rollupClicks or deliverWebhooks take
+ *  here. */
 export async function runFrequent(database: Database) {
   const rolled = await rollupClicks(database);
-  const outbox = await drainOutbox(database, projectionFor(database));
   const webhooks = await deliverWebhooks(database);
 
-  if (rolled.events || outbox.processed || outbox.failed || webhooks.sent || webhooks.failed) {
+  if (rolled.events || webhooks.sent || webhooks.failed) {
     log.info(
       {
         clicks: rolled.events,
         days: rolled.days,
-        projected: outbox.processed,
-        projectionFailures: outbox.failed,
         webhooksSent: webhooks.sent,
         webhookFailures: webhooks.failed,
       },
       "frequent pass",
     );
   }
-  return { rolled, outbox, webhooks };
+  return { rolled, webhooks };
 }
 
 /** Runs hourly: housekeeping, and the jobs that keep the privacy promise. */
@@ -357,15 +391,20 @@ async function main() {
   const { db } = await initDb();
 
   if (process.argv.includes("--once")) {
+    const projection = await runProjection(db);
     const frequent = await runFrequent(db);
     const maintenance = await runMaintenance(db);
-    log.info({ frequent, maintenance }, "single pass complete");
+    log.info({ projection, frequent, maintenance }, "single pass complete");
     await close();
     return;
   }
 
-  log.info({ rollupSeconds: ROLLUP_SECONDS, maintenanceSeconds: MAINTENANCE_SECONDS }, "worker started");
+  log.info(
+    { projectionSeconds: PROJECTION_SECONDS, rollupSeconds: ROLLUP_SECONDS, maintenanceSeconds: MAINTENANCE_SECONDS },
+    "worker started",
+  );
   const timers = [
+    everyN(PROJECTION_SECONDS, () => runProjection(db)),
     everyN(ROLLUP_SECONDS, () => runFrequent(db)),
     everyN(MAINTENANCE_SECONDS, () => runMaintenance(db)),
   ];
@@ -381,7 +420,8 @@ async function main() {
 
 /* Only start the loop when this file is the process entrypoint.
  *
- * dist/lambda.js imports runFrequent and runMaintenance from here, and an
+ * dist/lambda.js imports runProjection, runFrequent and runMaintenance from
+ * here, and an
  * unguarded main() would start a 30-second interval inside a Lambda that is
  * about to be frozen — burning the invocation's time budget on work nobody
  * asked for, then being suspended mid-flight. */


### PR DESCRIPTION
## Summary

The `LINK_PROJECTION=dynamo smoke (dynamodb-local)` CI job has failed three times across #338 and #340 (#340 twice: its original run and a re-run) on `scripts/smoke-redirect.sh`'s "routing chain" section, always on the `$RUN-geo` fixture (the link with country/device routing rules).

The three failures had different shapes (all 3 routing-chain assertions failing, vs. just 2 of 3), which raised a real question: was this the same DynamoDB-projection timing race the job's own comments describe (already mitigated once via a 0.25s worker tick), or a genuine gap in how routing `rules` round-trip through the DynamoDB projection?

I pulled the full logs for all three failed jobs (101250979642, 101263885183, 101266278007) via the GitHub API. The redirect service's own request logs settle it: for the third failure, the first two GETs to the just-created `$RUN-geo` slug got a bare **404** (link not found at all — not "found with empty rules"), and the third GET, ~40ms later, got a **302** to the correct base destination. That is a "not projected into DynamoDB yet" race, not a rules-serialization bug — `packages/database/src/link-projection.ts`'s `toLinkItem`/`fromLinkItem` write and read the whole `LinkItem` (rules included) as one atomic `PutRequest`, so there is no window where a link exists in the projection without its rules.

The worker's own "frequent pass" log lines showed why: its tick period (nominally `ROLLUP_INTERVAL_SECONDS=0.25` = 250ms) was actually landing every 202–311ms. `runFrequent` ran `rollupClicks` (a multi-statement transaction over `click_events`, whose cost grows with click volume), *then* `drainOutbox`, *then* `deliverWebhooks`, all sequentially inside one `everyN`-guarded tick — and `everyN` skips a whole tick outright if the previous one is still running. So a slow rollup pass didn't just delay that tick's drain, it push the *next* tick's start out too, stretching the real gap between a link's outbox insert and its DynamoDB projection past the nominal 250ms under load. `$RUN-geo` is created near the end of the smoke script's fixture-creation burst and asserted against only ~9 fast round trips later (much less margin than `$RUN-plain`, which the job's original 0.25s-tick reasoning was based on) — so it's the fixture most exposed to this jitter.

## Fix

Split the projection-outbox drain out of `runFrequent` into its own `runProjection()`, run on an independent timer in the worker's long-running loop (`main.ts`). Its cadence is no longer hostage to how long `rollupClicks` or `deliverWebhooks` take on a given pass.

- `PROJECTION_INTERVAL_SECONDS` defaults to `ROLLUP_INTERVAL_SECONDS`, so the CI job's existing `ROLLUP_INTERVAL_SECONDS=0.25` now governs a drain timer that actually fires every ~250ms, independent of rollup load — no workflow changes needed.
- `lambda.ts`'s scheduled-Lambda path (`frequent`/`rollup`/default tasks) now calls `runProjection` + `runFrequent` back to back and folds the result into the same response shape as before (`{ task: "frequent", frequent: { rolled, outbox, webhooks } }`), so the production AWS profile's behavior and the Lambda handler's external contract are unchanged.
- Updated `lambda.test.ts` for the new composition.

## Test plan

- [x] `apps/worker`: `vitest run` — 48 passed, 54 skipped (DB-gated tests need a live Postgres), 0 failed.
- [x] `apps/worker`: `tsc --noEmit` — clean.
- [ ] CI: `LINK_PROJECTION=dynamo smoke (dynamodb-local)` job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
