### PR TITLE
Wire GOOGLE_OAUTH_CLIENT_ID into the API Lambda

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -371,6 +371,33 @@ lives (Cloudflare, Route53, anywhere), and CloudFormation resumes once ACM
 sees it resolve. `RedirectDomain`'s output becomes the real domain once this
 is set, rather than "CNAME your short domain here."
 
+### Google OAuth
+
+Optional — unset means `OAuthService.enabled('google')` is `false` and
+`POST /auth/oauth` rejects every Google sign-in attempt. The frontend button
+does not know this: it only checks its own `NEXT_PUBLIC_GOOGLE_CLIENT_ID` and
+renders regardless, so an operator who sets the frontend var but not this flag
+gets a rendered "Continue with Google" button that fails on every click.
+
+```bash
+npx cdk deploy -c googleOAuthClientId=<id>.apps.googleusercontent.com
+```
+
+The value must be byte-identical to `NEXT_PUBLIC_GOOGLE_CLIENT_ID` on the
+frontend — Google signs the ID token's `aud` claim to whichever client id the
+frontend's SDK call initialized with, and `oauth.service.ts` checks that claim
+against this one. It also needs the deploy's Google Cloud OAuth client to list
+the frontend's origin (e.g. `https://app.snapurl.in`) under **Authorized
+JavaScript origins** — this flow uses Google Identity Services' JS callback,
+not a redirect, so no **Authorized redirect URI** is needed.
+
+Not SSM config like `mail-from` despite being just as stable across deploys:
+`config.get()` in `infra/lib/config.ts` has no default and fails the deploy on
+a missing parameter, which is correct for required stage config but would make
+this feature mandatory rather than optional. See the natStrategy section above
+— the JWKS fetch this depends on needs egress, so it stays non-functional
+under `natStrategy = 'none'` regardless of this flag.
+
 ### The redirect uses AWS SDK adapters and can leave the VPC
 
 The claim that "there is no AWS SDK anywhere in `apps/` or `packages/`" is no

--- a/infra/bin/snapurl.ts
+++ b/infra/bin/snapurl.ts
@@ -69,6 +69,15 @@ new SnapUrlStack(app, "SnapUrl", {
   budgetEmail: app.node.tryGetContext("budgetEmail"),
   domainName,
   certificate,
+  /* Optional, same shape as budgetEmail: unset means the Google sign-in
+     button on the frontend renders (it only checks its own
+     NEXT_PUBLIC_GOOGLE_CLIENT_ID) but every attempt fails server-side, since
+     OAuthService.enabled('google') has nothing to check the ID token's
+     audience against. Set with
+     `-c googleOAuthClientId=<id>.apps.googleusercontent.com`, matching the
+     Google Cloud Console client's id exactly, and matching
+     NEXT_PUBLIC_GOOGLE_CLIENT_ID on the frontend. */
+  googleOAuthClientId: app.node.tryGetContext("googleOAuthClientId"),
   description: "SnapURL: API, redirect service, worker, and the Postgres they share.",
   tags: {
     Project: "SnapURL",

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -123,6 +123,23 @@ export interface SnapUrlStackProps extends StackProps {
   /** See {@link domainName}. Must be issued in us-east-1 regardless of the
    *  stack's own region — a CloudFront/ACM requirement. */
   certificate?: acm.ICertificate;
+  /**
+   * Google's OAuth client id, for verifying the `aud` claim on ID tokens at
+   * `POST /auth/oauth` (see `apps/api/src/auth/oauth.service.ts`). Optional,
+   * like {@link budgetEmail}: `OAuthService.enabled('google')` treats an unset
+   * value as the provider being switched off, not misconfigured, so omitting
+   * this is a valid choice and the stack still deploys. Set it with
+   * `-c googleOAuthClientId=<id>.apps.googleusercontent.com`.
+   *
+   * Not SSM config despite being stable across deploys: `config.get()` has no
+   * default and fails the deploy on a missing parameter, which is right for
+   * required stage config but wrong for a feature that is meant to be
+   * optional. The same id must also be set as `NEXT_PUBLIC_GOOGLE_CLIENT_ID`
+   * on the frontend (Vercel) — the two are compared implicitly, because Google
+   * signs the ID token's `aud` claim to whichever client id the frontend
+   * initialized the SDK with.
+   */
+  googleOAuthClientId?: string;
 }
 
 export class SnapUrlStack extends Stack {
@@ -722,6 +739,11 @@ export class SnapUrlStack extends Stack {
            under the prefix — so without this the adapter waits out its
            readiness timeout on every cold start before serving anything. */
         AWS_LWA_READINESS_CHECK_PATH: `/${API_PREFIX}/health`,
+        /* Spread in only when set: the env var must be genuinely absent (not
+           an empty string) for OAuthService.enabled('google') to read this as
+           "off" rather than "misconfigured". Only the API verifies OAuth ID
+           tokens, so redirectFn and workerFn never get this key. */
+        ...(props.googleOAuthClientId ? { GOOGLE_OAUTH_CLIENT_ID: props.googleOAuthClientId } : {}),
       },
       ...vpcSettings,
     });


### PR DESCRIPTION
## Summary
- `GOOGLE_OAUTH_CLIENT_ID` was never passed to the deployed API Lambda, so `OAuthService.enabled('google')` was always `false` in production — every Google sign-in attempt failed server-side with `UnauthorizedException`, even though the frontend's "Continue with Google" button renders regardless (it only checks its own `NEXT_PUBLIC_GOOGLE_CLIENT_ID`).
- Wire it through as an optional `-c googleOAuthClientId=...` CLI context flag (same shape as `domainName`/`budgetEmail`), not as SSM config — `config.get()` has no default and fails the deploy on a missing parameter, which would make this intentionally-optional feature mandatory.
- Only `ApiFn` gets the env var, and only when the flag is set, so an unset value stays genuinely absent rather than an empty string.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` in `infra/`
- [x] `cdk synth` with `-c googleOAuthClientId=...` shows `GOOGLE_OAUTH_CLIENT_ID` on `ApiFn`
- [x] `cdk synth` without the flag shows zero occurrences of `GOOGLE_OAUTH_CLIENT_ID`
- [ ] Deploy with the real client id and confirm a live Google sign-in against `app.snapurl.in` succeeds (pending merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
