### PR TITLE
fix(infra,worker): restore the redirect path — CloudFront function load + edge KVS signing

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-cloudfront-keyvaluestore": "^3.1121.0",
     "@aws-sdk/client-dynamodb": "^3.1121.0",
     "@aws-sdk/lib-dynamodb": "^3.1121.0",
+    "@aws-sdk/signature-v4a": "^3.1111.0",
     "@snapurl/contract": "workspace:*",
     "@snapurl/database": "workspace:*",
     "@snapurl/domain": "workspace:*",

--- a/infra/functions/redirect-viewer-request.js
+++ b/infra/functions/redirect-viewer-request.js
@@ -120,11 +120,20 @@ async function handler(event) {
 }
 
 /*
- * CloudFront Functions (JS_2_0) expect the module to export exactly the entry
- * point `handler`. `decide` and `edgeKey` are deliberately NOT exported here —
- * they are exercised through the byte-for-byte twin in
- * redirect-viewer-request.logic.mjs (the DRIFT-GUARDED REGION above is what the
- * test asserts is identical), so the deployed file stays a minimal, valid
- * CloudFront Function while the logic remains fully unit-tested.
+ * NO `export` STATEMENT. CloudFront Functions reject one outright:
+ *
+ *     SyntaxError: Illegal export statement
+ *
+ * and an invalid function makes the distribution answer every request with a
+ * 503 — it does NOT fall through to the origin, so this single line took the
+ * whole redirect path down. `import cf from "cloudfront"` above is a special
+ * case the runtime allows; that exception does not extend to exports. The
+ * runtime finds the entry point by looking for a global function named
+ * `handler`, which is exactly what is declared above.
+ *
+ * `decide` and `edgeKey` are deliberately not exported either — they are
+ * exercised through the byte-for-byte twin in redirect-viewer-request.logic.mjs
+ * (the DRIFT-GUARDED REGION above is what the test asserts is identical), so the
+ * deployed file stays a minimal, valid CloudFront Function while the logic
+ * remains fully unit-tested.
  */
-export { handler };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.1121.0
         version: 3.1121.0(@aws-sdk/client-dynamodb@3.1121.0)
+      '@aws-sdk/signature-v4a':
+        specifier: ^3.1111.0
+        version: 3.1111.0
       '@snapurl/contract':
         specifier: workspace:*
         version: link:../../packages/contract
@@ -551,6 +554,10 @@ packages:
 
   '@aws-sdk/signature-v4-multi-region@3.996.46':
     resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4a@3.1111.0':
+    resolution: {integrity: sha512-MA3xi/VD4dpaX2VBgUCZry4YU5FbzcGfXMtj3bXCOCBARySsVNN9hExRbpFTgW5CI8DojT8AZVYvJrDxlv2oXQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1116.0':
@@ -2012,6 +2019,10 @@ packages:
 
   '@smithy/signature-v4@5.7.3':
     resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4a@3.6.2':
+    resolution: {integrity: sha512-M5CXsK13/spy3QNudWMdcccGZFU4AKV4/7ixZ4heoowpSgJwOWcfvrHPFTekxaOmrpFA4is/of6B1OPdPz/9Yg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.17.2':
@@ -4361,6 +4372,11 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4a@3.1111.0':
+    dependencies:
+      '@smithy/signature-v4a': 3.6.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1116.0':
     dependencies:
       '@aws-sdk/core': 3.977.9
@@ -5345,6 +5361,13 @@ snapshots:
   '@smithy/signature-v4@5.7.3':
     dependencies:
       '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4a@3.6.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 


### PR DESCRIPTION
Two independent production bugs, both of which had been dormant because
`snapurl.in` had no DNS record until today. Adding the record made every request
reach the distribution for the first time, and both surfaced within minutes.

## 1. CloudFront function could not load

The viewer-request function ended with `export { handler };`. CloudFront
Functions reject that:

```
SyntaxError: Illegal export statement in 130
```

An invalid CloudFront Function does **not** fall through to the origin — the
distribution answers every request with a 503. So one line took the entire
redirect path down.

`import cf from "cloudfront"` is a special case the runtime allows; that
exception does not extend to exports. The entry point is found by looking for a
global `handler`, which was already declared.

Verified with `aws cloudfront test-function`: previously
`FunctionErrorMessage: "... Illegal export statement"`, now empty with 8%
compute utilisation.

## 2. Edge projection could never write a key

Every KVS write failed in production:

```
Neither CRT nor JS SigV4a implementation is available. Please load
either @aws-sdk/signature-v4-crt or @aws-sdk/signature-v4a
```

CloudFront KeyValueStore is a multi-region service, so its API is signed with
SigV4a. The AWS SDK v3 does not bundle a SigV4a implementation — it dynamically
requires one and throws when neither is installed. Nothing in the repo declared
either, so the #289 edge fast path has never worked in production.

Chose `@aws-sdk/signature-v4a` (pure JS) over `@aws-sdk/signature-v4-crt`
(native): the Lambda images build for arm64 under emulation, where a native
addon is an avoidable build and portability risk.

The DynamoDB-first ordering in `DynamoProjection` meant this lost nothing
authoritative — the projection table had the links, only the edge cache was
empty. That is exactly the failure isolation the ordering was chosen for, and it
held.

## Why tests did not catch either

- The CloudFront drift-guard test compares only the shared logic region against
  its `.logic.mjs` twin, never the module scaffolding around it. 14 tests passed
  while the deployed function could not load.
- `kvs-projection.test.ts` mocks the client, so no test ever exercises real
  request signing.

Both gaps are tracked in #357.

## Still outstanding

The CloudFront to Lambda Function URL origin returns 403 `AccessDeniedException`
even with correct `AWS_IAM` auth, a resource policy scoped to this distribution,
OAC `sigv4`/`always`/type `lambda`, and `Host` excluded from the origin request
policy. Filed separately. Once this PR is deployed, simple links are served from
the edge KVS and never reach that origin, so the 403 affects only the
fall-through paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
