### PR TITLE
QA hardening: health 503, analytics query validation, link-domain default, docs

### DIFF
--- a/apps/api/src/common/health.controller.ts
+++ b/apps/api/src/common/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Inject } from "@nestjs/common";
+import { Controller, Get, Inject, ServiceUnavailableException } from "@nestjs/common";
 import { sql, type Database } from "@snapurl/database";
 import { DB } from "../database/database.module.js";
 import { Public } from "../auth/auth.guard.js";
@@ -8,7 +8,9 @@ export class HealthController {
   constructor(@Inject(DB) private readonly db: Database) {}
 
   /** Checks the database too — a process that is up but cannot reach Postgres
-   *  is not healthy, and a load balancer should know that. */
+   *  is not healthy, and a load balancer should know that. The unhealthy path
+   *  therefore responds 503 (not a 200 body), so an LB / orchestrator that
+   *  keys on the HTTP status code stops routing traffic to this instance. */
   @Public()
   @Get()
   async check() {
@@ -17,7 +19,11 @@ export class HealthController {
       await this.db.execute(sql`select 1`);
       return { status: "ok", database: "ok", latencyMs: Date.now() - startedAt };
     } catch {
-      return { status: "degraded", database: "unreachable", latencyMs: Date.now() - startedAt };
+      throw new ServiceUnavailableException({
+        status: "degraded",
+        database: "unreachable",
+        latencyMs: Date.now() - startedAt,
+      });
     }
   }
 }

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -96,15 +96,16 @@ service verifies unlock tokens that the API signed.
 
 ## Frontend follow-ups
 
-The backend is written so the current frontend works unmodified. These unlock
-the rest — the full table is in [DECISIONS.md](./DECISIONS.md) Part 4.
+The backend is written so the current frontend works unmodified. The items that
+once "unlocked the rest" have all shipped — kept here as a record of what the
+frontend now does (the full table is in [DECISIONS.md](./DECISIONS.md) Part 4):
 
-| Change | Why | Blocking |
-| --- | --- | --- |
-| Call `POST /auth/logout` in `useLogout` | Refresh tokens currently survive sign-out | **Yes — security** |
-| Add `useUpdateLink` → `PATCH /links/:id` | Editing a destination is the core product promise | Yes |
-| Handle `{ challenge: "totp" }` on login | 2FA users cannot sign in otherwise | Only with 2FA on |
-| Unlock form on `/p/[slug]` | Password links are otherwise unreachable | Only for locked links |
+| Change | Status |
+| --- | --- |
+| Call `POST /auth/logout` in `useLogout` | ✅ Done — sign-out revokes the refresh token (`web/src/lib/api/hooks/auth.ts`) |
+| Add `useUpdateLink` → `PATCH /links/:id` | ✅ Done — editing a destination is wired into the link detail page |
+| Handle `{ challenge: "totp" }` on login | ✅ Done — the 2FA challenge flow is implemented |
+| Unlock form on `/p/[slug]` | ✅ Done — password links prompt and unlock via `?k=<token>` |
 
 ## Deploying
 

--- a/packages/contract/src/analytics.ts
+++ b/packages/contract/src/analytics.ts
@@ -51,10 +51,16 @@ export type Analytics = z.infer<typeof Analytics>;
 export const AnalyticsRange = z.enum(["24h", "7d", "30d", "90d", "12m"]);
 export type AnalyticsRange = z.infer<typeof AnalyticsRange>;
 
-export const AnalyticsQuery = z.object({
-  range: AnalyticsRange.default("30d"),
-  linkId: z.string().optional(),
-});
+// `.strict()` so an unsupported or misspelled query param (e.g. `from`/`to`,
+// or `rnge`) is rejected with a 400 naming the offending key, rather than
+// silently stripped — which previously returned the default 30d window with a
+// 200 and made a client typo look like real, empty data.
+export const AnalyticsQuery = z
+  .object({
+    range: AnalyticsRange.default("30d"),
+    linkId: z.string().optional(),
+  })
+  .strict();
 export type AnalyticsQuery = z.infer<typeof AnalyticsQuery>;
 
 export const ConversionEvent = z.object({

--- a/web/src/components/links/create-link-drawer.tsx
+++ b/web/src/components/links/create-link-drawer.tsx
@@ -29,7 +29,11 @@ export function CreateLinkDrawer({ open, onClose }: { open: boolean; onClose: ()
     resolver: zodResolver(CreateLinkInput),
     defaultValues: {
       destination: "",
-      domain: "snap.to",
+      // Left blank here and filled from the workspace's own domains once they
+      // load (see the effect below). Hardcoding a production domain like
+      // "snap.to" made the first create in any other workspace fail with
+      // "snap.to isn't a domain you can use" until the user changed it.
+      domain: "",
       slug: "",
       tags: [],
       redirectType: "302",
@@ -41,11 +45,20 @@ export function CreateLinkDrawer({ open, onClose }: { open: boolean; onClose: ()
     },
   });
 
-  const { register, handleSubmit, control, watch, reset, formState } = form;
+  const { register, handleSubmit, control, watch, reset, setValue, formState } = form;
   const destination = watch("destination");
   const domain = watch("domain");
   const slug = watch("slug");
   const utm = watch("utm");
+
+  // Default the back-half domain to the workspace's own first domain once the
+  // list loads, unless the user has already picked one. Avoids hardcoding a
+  // domain the workspace may not own.
+  useEffect(() => {
+    if (!domain && domains?.length) {
+      setValue("domain", domains[0].domain);
+    }
+  }, [domains, domain, setValue]);
 
   // Escape closes; body scroll locks while the drawer owns the screen.
   useEffect(() => {


### PR DESCRIPTION
End-to-end QA pass on SnapURL surfaced four fixes. All build clean; API+contract tests (128) pass; the two backend fixes are runtime-verified.

### 1. Health check returns 503 when the DB is unreachable  ·  *bug*
`apps/api/src/common/health.controller.ts` returned the `{status:"degraded"}` body on the DB-unreachable path, which ships as **HTTP 200**. A load balancer keys on the status code, so it marked the instance healthy and routed traffic to an API that couldn't reach Postgres — defeating the check's own stated purpose. Now throws `ServiceUnavailableException` (503). Verified: DB up → 200 `status:ok`; DB down → **503**.

### 2. Analytics query rejects unknown params
`AnalyticsQuery` is now `.strict()`. A misspelled or unsupported query key (e.g. `from`/`to`, or a typo'd `range`) returns **400** naming the key, instead of being silently stripped and returning the default 30d window with a 200. Verified the web client only sends `range`/`linkId`, so the frontend is unaffected.

### 3. New-link drawer defaults to the workspace's own domain
`web/src/components/links/create-link-drawer.tsx` hardcoded `domain:"snap.to"`, so the first create in any other workspace failed with *"snap.to isn't a domain you can use"*. Now defaults blank and fills from the workspace's first domain once the list loads.

### 4. docs: mark the "Frontend follow-ups" table as shipped
logout-revocation, `useUpdateLink`, the 2FA challenge, and the `/p/[slug]` unlock form are all implemented; the table listed them as pending.

*Generated from an autonomous QA pass.*