### PR TITLE
fix(security): block admin->owner privilege escalation (#345)

### DIFF
--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -50,7 +50,7 @@ export const Actor = createParamDecorator((_data: unknown, ctx: ExecutionContext
 });
 
 /** owner ⊃ admin ⊃ editor ⊃ viewer. Higher rank satisfies a lower requirement. */
-const RANK: Record<string, number> = { viewer: 0, editor: 1, admin: 2, owner: 3 };
+export const RANK: Record<string, number> = { viewer: 0, editor: 1, admin: 2, owner: 3 };
 
 /**
  * Does the caller's role clear the bar for this route?

--- a/apps/api/src/members/members.controller.ts
+++ b/apps/api/src/members/members.controller.ts
@@ -27,7 +27,7 @@ export class MembersController {
     @Param("id") id: string,
     @Body(zodBody(ChangeRoleInput)) input: ChangeRoleInput,
   ) {
-    await this.members.changeRole(actor.workspaceId, id, input.role, actor.label);
+    await this.members.changeRole(actor.workspaceId, id, input.role, actor.label, actor.role);
   }
 
   @Delete("members/:id")

--- a/apps/api/src/members/members.service.spec.test.ts
+++ b/apps/api/src/members/members.service.spec.test.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata";
+import { ForbiddenException } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import { MembersService } from "./members.service.js";
+
+/* ============================================================
+   Issue #345 — privilege escalation.
+
+   PATCH /members/:id is gated @Roles("admin"), but "admin" is not "owner".
+   Without a rank check in changeRole, any admin could PATCH their own
+   membership to { role: "owner" }, then demote the real owner and take the
+   workspace. changeRole now enforces two rank rules against the caller's role:
+     1. cannot grant a role higher than your own;
+     2. cannot change the role of someone who currently outranks you.
+
+   These are pure guard assertions: the db is stubbed to return the target
+   membership, and we assert the method throws BEFORE any update runs. No real
+   database, so this runs in the normal unit suite (not the DB-gated one).
+   ============================================================ */
+
+function serviceWithTarget(targetRole: string) {
+  const update = vi.fn(() => ({ set: () => ({ where: async () => undefined }) }));
+  const insert = vi.fn(() => ({ values: async () => undefined }));
+  // this.db.select()...limit() -> [target]; this.db.update() should NEVER be
+  // reached on the escalation paths.
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [{ id: "m1", workspaceId: "w1", role: targetRole }] }),
+      }),
+    }),
+    update,
+    insert,
+  } as unknown as ConstructorParameters<typeof MembersService>[0];
+  // READ_DB + MailService are unused on this path.
+  const svc = new MembersService(db, db as never, { send: vi.fn() } as never);
+  return { svc, update };
+}
+
+describe("MembersService.changeRole — #345 privilege-escalation guards", () => {
+  it("an admin cannot grant a role higher than their own (admin -> owner is refused)", async () => {
+    const { svc, update } = serviceWithTarget("admin");
+    await expect(
+      svc.changeRole("w1", "m1", "owner" as never, "Admin User", "admin"),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("an admin cannot change the role of an owner (target outranks caller)", async () => {
+    const { svc, update } = serviceWithTarget("owner");
+    await expect(
+      svc.changeRole("w1", "m1", "editor" as never, "Admin User", "admin"),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("an unknown caller role fails closed (cannot grant anything)", async () => {
+    const { svc, update } = serviceWithTarget("editor");
+    await expect(
+      svc.changeRole("w1", "m1", "editor" as never, "Nobody", "banana"),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("an owner may still grant owner (rank permits it)", async () => {
+    const { svc, update } = serviceWithTarget("editor");
+    await svc.changeRole("w1", "m1", "owner" as never, "Owner User", "owner");
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/members/members.service.ts
+++ b/apps/api/src/members/members.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import { randomBytes, createHash } from "node:crypto";
 import { and, auditLog, desc, eq, links, memberships, sql, users, type Database } from "@snapurl/database";
 import type { AuditEntry, InviteMemberInput, Member } from "@snapurl/contract";
 import { DB, READ_DB } from "../database/database.module.js";
 import { initialsOf } from "../auth/auth.service.js";
+import { RANK } from "../auth/auth.guard.js";
 import { MailService } from "../mail/mail.service.js";
 
 @Injectable()
@@ -109,13 +110,33 @@ export class MembersService {
     };
   }
 
-  async changeRole(workspaceId: string, membershipId: string, role: Member["role"], actorLabel: string) {
+  async changeRole(
+    workspaceId: string,
+    membershipId: string,
+    role: Member["role"],
+    actorLabel: string,
+    actorRole: string,
+  ) {
     const [target] = await this.db
       .select()
       .from(memberships)
       .where(and(eq(memberships.id, membershipId), eq(memberships.workspaceId, workspaceId)))
       .limit(1);
     if (!target) throw new NotFoundException("That person isn't on this team.");
+
+    /* Privilege-escalation guards (issue #345). The route is gated @Roles("admin"),
+       but "admin" is not "owner": rank must be enforced here or any admin could
+       PATCH their own membership to owner and then demote the real owner.
+       - You cannot grant a role higher than your own.
+       - You cannot change the role of someone who currently outranks you.
+       Fails closed via the shared RANK map (an unknown role ranks below all). */
+    const callerRank = RANK[actorRole] ?? -1;
+    if ((RANK[role] ?? 99) > callerRank) {
+      throw new ForbiddenException("You cannot grant a role higher than your own.");
+    }
+    if ((RANK[target.role] ?? 99) > callerRank) {
+      throw new ForbiddenException("You cannot change the role of someone who outranks you.");
+    }
 
     /* A workspace with no owner cannot be administered by anyone, and there is
        no support desk to undo it. */


### PR DESCRIPTION
## Security fix — privilege escalation (closes #345)

`PATCH /members/:id` is gated `@Roles("admin")`, but **admin is not owner**. `MembersService.changeRole` had no rank check, so any **admin could PATCH their own membership to `{ "role": "owner" }`**, and — with a second owner now present, defeating the last-owner guard — then demote the original owner and seize sole control of the workspace.

### Fix
Two rank rules enforced in `changeRole` against the **caller's** role, reusing the shared `RANK` map (now `export`ed from `apps/api/src/auth/auth.guard.ts`):

1. You cannot grant a role **higher than your own** → an admin granting `owner` is refused (403).
2. You cannot change the role of someone who **currently outranks you** → an admin touching an owner is refused (403).

Both fail **closed** via `RANK` (an unknown role ranks below everything), matching the guard's existing fail-closed contract.

### Tests
New no-DB unit tests in `apps/api/src/members/members.service.spec.test.ts`:
- admin → owner is refused, and `update` is never called
- admin changing an owner is refused
- an unknown caller role fails closed
- an owner granting owner still succeeds (rank permits it)

Full API + contract suite: **132 passed** (was 128; +4 here). Build + type-check clean.

*From the QA program — phase 0 bug.*
