### PR TITLE
fix(security): flagged links keep redirecting under dynamo projection (#346)

### DIFF
--- a/apps/api/src/reports/reports.service.integration.test.ts
+++ b/apps/api/src/reports/reports.service.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { abuseReports, createDatabase, domains, eq, links, workspaces, type Database } from "@snapurl/database";
+import { abuseReports, createDatabase, domains, eq, links, projectionOutbox, workspaces, type Database } from "@snapurl/database";
 import { ReportsService } from "./reports.service.js";
 
 /* ============================================================
@@ -216,6 +216,11 @@ describeDb("ReportsService.list / review", () => {
   });
 
   afterAll(async () => {
+    // projection_outbox.link_id has no FK cascade, so the row that flagging
+    // linkA enqueues (issue #346) would outlive the workspace and pollute the
+    // worker's global drainOutbox concurrency test. Delete it before the
+    // workspaces go.
+    if (linkA) await db.delete(projectionOutbox).where(eq(projectionOutbox.linkId, linkA));
     if (wsA) await db.delete(workspaces).where(eq(workspaces.id, wsA));
     if (wsB) await db.delete(workspaces).where(eq(workspaces.id, wsB));
     await db.delete(abuseReports).where(eq(abuseReports.id, reportNullWorkspace));
@@ -248,6 +253,15 @@ describeDb("ReportsService.list / review", () => {
       .limit(1);
     expect(row!.status).toBe("flagged");
     expect(row!.checkedAt).not.toBeNull();
+
+    // Issue #346: the flag must also enqueue a projection_outbox row in the same
+    // transaction, or under LINK_PROJECTION=dynamo the redirect keeps serving
+    // the stale (clean) projected copy. Without the enqueue, this is empty.
+    const outbox = await db
+      .select({ id: projectionOutbox.linkId, op: projectionOutbox.operation })
+      .from(projectionOutbox)
+      .where(eq(projectionOutbox.linkId, linkA));
+    expect(outbox.some((r) => r.op === "upsert")).toBe(true);
   });
 
   it("updates status without touching safeBrowsingStatus for a status-only review", async () => {

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
-import { abuseReports, and, desc, eq, links, sql, type Database } from "@snapurl/database";
+import { abuseReports, and, desc, eq, links, projectionOutbox, sql, type Database } from "@snapurl/database";
 import type { AbuseReport, SubmitReportInput, SubmitReportResult, UpdateAbuseReportInput } from "@snapurl/contract";
 import { DB } from "../database/database.module.js";
 import { recordActivity, type Actor } from "../common/activity.js";
@@ -128,6 +128,20 @@ export class ReportsService {
           .where(and(eq(links.id, report.linkId!), eq(links.workspaceId, workspaceId)))
           .returning({ id: links.id });
         didFlag = updated.length > 0;
+
+        // Issue #346: propagate the flag to the read projection in the SAME
+        // transaction, exactly as links.service does for every other link
+        // mutation. Without this, under LINK_PROJECTION=dynamo the redirect
+        // service reads a stale projected copy whose safeBrowsingStatus is still
+        // "clean", so a link an operator just flagged keeps redirecting until
+        // some unrelated write happens to re-project it.
+        if (didFlag) {
+          await tx.insert(projectionOutbox).values({
+            linkId: report.linkId!,
+            operation: "upsert",
+            payload: { linkId: report.linkId!, operation: "upsert" },
+          });
+        }
       }
 
       // Flagging a link is itself the action, so default to 'actioned' when the


### PR DESCRIPTION
## Security fix — flagged abuse links keep redirecting under DynamoDB projection (closes #346)

When an operator flags a link from an abuse report, `ReportsService.review()` wrote `safeBrowsingStatus = 'flagged'` straight to Postgres **without enqueueing a projection**. Every other link mutation in `links.service.ts` enqueues a `projection_outbox` row in the same transaction; this path did not.

**Impact:** under `LINK_PROJECTION=dynamo` (production), the redirect service reads the projected copy, not Postgres. The projected `safeBrowsingStatus` stayed `clean`, so the `flagged` gate in `apps/redirect/src/main.ts` never fired — **a link an operator just flagged kept redirecting**, indefinitely, until some unrelated write re-projected it. Under `LINK_PROJECTION=none` the behaviour was correct, which is why existing tests missed it.

### Fix
Enqueue a `projection_outbox` upsert **inside the same transaction**, only when the flag actually landed (`didFlag`), mirroring `LinksService.enqueueProjection`.

### Tests
Extended the flag integration test (`reports.service.integration.test.ts`) to assert a `projection_outbox` upsert row exists for the flagged link after `review({ flagLink: true })` — this is empty (and the test fails) without the enqueue. Runs in CI's DB-backed suite.

Build + full unit suite green (132 passed).

*QA program — phase 0 bug.*
