### PR TITLE
chore: add .kiro/steering rules for agent-assisted development

### DIFF
--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -1,0 +1,45 @@
+# SnapURL — Architecture rules (steering)
+
+These rules bind every agent turn and every subagent. They encode decisions
+already made in `docs/DECISIONS.md`; violating them is a bug, not a style choice.
+
+## Monorepo shape
+- pnpm workspace. Projects: `apps/{api,redirect,worker,extension}`, `web`,
+  `packages/{contract,domain,database,cache}`. Do not add a top-level project
+  without an ADR.
+- **`packages/contract` is the single source of truth for all request/response
+  payloads (zod).** API and web both import from it. Never redefine a payload
+  shape inline in a controller or a React component — import the zod schema.
+- **`packages/domain` is pure shared logic** (routing chains, geo/device rules).
+  It must not import from `apps/*` or from `packages/database`. Keep it
+  side-effect-free and framework-agnostic.
+- No cross-`apps` imports. `apps/api`, `apps/redirect`, `apps/worker` share code
+  only through `packages/*`, never by reaching into each other.
+
+## The redirect hot path is sacred
+- `apps/redirect` is latency-critical and deliberately has **no rate limiting**
+  and minimal dependencies. Do not add heavyweight middleware, ORM calls on the
+  request path, or synchronous external calls to it. Click accounting is done
+  via the outbox/worker, not inline.
+- Rate limiting (`@nestjs/throttler`, default 120/min) belongs on the dashboard
+  API only.
+
+## Database
+- Postgres 18, Drizzle ORM, schema in `packages/database`. Every schema change
+  is a Drizzle migration — never hand-edit a live table shape.
+- Uses native `uuidv7()`. New primary keys follow the same pattern unless an ADR
+  says otherwise.
+- Anything that touches the DB is tested against a **real Postgres via
+  Testcontainers**, not a mock.
+
+## Architectural changes require an ADR
+- A new external dependency, a new service, a change to the contract/domain
+  boundary, or a change to a deploy profile: add an entry to `docs/DECISIONS.md`
+  (with a "revisit if" clause) in the same PR. No silent architecture drift.
+
+## Deploy profiles
+- Three profiles exist: AWS-serverless (CDK), single-node (docker compose), and
+  Helm. **Single-node `docker compose up` is the flagship self-host story and
+  must keep working** — do not introduce a hard dependency on an external SaaS
+  (Tinybird/PlanetScale/Upstash-style) on the single-node path. Swappable ports
+  (e.g. `CacheStore`) are the mechanism; use them.

--- a/.kiro/steering/security-and-context.md
+++ b/.kiro/steering/security-and-context.md
@@ -1,0 +1,41 @@
+# SnapURL — Security invariants & product context (steering)
+
+## Security invariants — do not regress these
+- Passwords: **argon2id** only. Never introduce a weaker hash or store a
+  plaintext/reversible secret.
+- Auth: 15-min access JWT + rotating refresh token with reuse detection and
+  server-side logout. Do not lengthen access-token TTL or remove reuse
+  detection without an ADR.
+- OAuth ID tokens are **nonce-bound** — keep the nonce check.
+- URL input passes the contract-layer SSRF guard (rejects dangerous schemes and
+  internal hosts). Any new URL-accepting endpoint reuses that guard; never
+  bypass it.
+- Secrets come from SSM / Secrets Manager, never the repo. Do not commit a
+  `.env` with real values, a key, or a token. Flag any file that looks like it
+  carries one.
+- The redirect Function URL is locked behind CloudFront OAC — do not expose it
+  directly.
+
+## Known operational gaps (context, so agents don't "discover" them as new)
+- **P0 — no account recovery.** Password reset and email verification are
+  absent (not stubbed). A locked-out user has no automated path. This is the
+  top-priority product gap.
+- **Mail is a stub** (`MAIL_TRANSPORT=outbox`, SES unwired). Any flow needing
+  email does not actually send yet.
+- Safe Browsing is off without a key. Several AWS-egress features (webhooks,
+  OAuth JWKS, mail, Safe Browsing) are non-functional under
+  `natStrategy='none'` and are synth-proven only — never run against real AWS.
+- Global form-slug namespace is squattable + a cross-tenant existence leak —
+  a knowingly-deferred trade-off, documented in DECISIONS. Don't "fix" it
+  ad hoc without reading the ADR first.
+
+## Privacy is a feature, protect it
+- Click analytics are cookieless: daily-salt visitor hashing with a
+  k-anonymity floor. Do not add a persistent visitor cookie, store a raw IP, or
+  drop the k-anonymity floor — the privacy-first analytics story is a
+  competitive differentiator, not incidental.
+
+## Multi-tenancy
+- Workspaces with role-based membership + 2FA. Every data query is
+  workspace-scoped. A new query that can read across workspace boundaries is a
+  security bug — scope it.

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -1,0 +1,34 @@
+# SnapURL — Testing & quality gates (steering)
+
+## Before you claim a change works
+- Run `pnpm type-check`, `pnpm build`, and the relevant package's `pnpm test`.
+  If your change touches the DB or redirect path, that means Vitest **with
+  Testcontainers** (real Postgres), not unit mocks.
+- Never present a change as done on the strength of "it should work". State what
+  you actually ran.
+
+## What CI enforces (`.github/workflows/verify.yml`)
+- `verify`: type-check → build → migrate → unit tests → smoke
+  (`scripts/smoke.sh`, `scripts/smoke-redirect.sh` against live processes).
+- `integration`: full `docker compose` stack + click-rollup assertions + a
+  pino error-level log gate (an error-level log fails the job).
+- `dynamo-smoke`: `LINK_PROJECTION=dynamo` against dynamodb-local.
+- `restore-test`: real backup/restore round-trip.
+Your PR must pass all of these. Do not weaken a gate to make a PR green —
+fix the code.
+
+## Lint (known-broken, being fixed)
+- `web` currently declares `eslint .` with no config and no eslint dependency,
+  so `pnpm lint` fails. Once lint is wired (eslint + prettier + commitlint,
+  see the contributor-readiness work), treat a lint failure as a hard gate.
+- Match existing formatting in the file you edit. Do not reformat unrelated
+  lines in the same commit — it buries the real diff.
+
+## Tests are part of the change
+- New feature → tests for it in the same PR. Bug fix → a regression test that
+  fails before the fix and passes after. A PR that adds behavior with no test is
+  incomplete.
+
+## Logs
+- Structured pino/nestjs-pino JSON only. No `console.log` in committed code.
+  An error-level log in the integration path fails CI — log at the right level.


### PR DESCRIPTION
## Summary
Adds three steering files under `.kiro/steering/` that bind every agent turn (and contributors' agent-assisted work) to SnapURL's existing invariants — sourced from `docs/DECISIONS.md`, `CONTRIBUTING.md`, and the current codebase.

- **architecture.md** — monorepo shape, `packages/contract` as the single zod source of truth, no cross-package/cross-app imports, the redirect hot path stays dependency-light, Postgres+Drizzle migration discipline, ADR-required-for-architectural-change, single-node `docker compose` must keep working.
- **testing.md** — type-check/build/test before claiming done, Vitest + Testcontainers for anything touching the DB or redirect path, what CI enforces, don't weaken a gate to go green, tests ship with the change.
- **security-and-context.md** — argon2id / rotating-refresh / nonce-bound-OAuth / SSRF-guard non-regression rules, secrets never in-repo, the known operational gaps (P0 account recovery, mail stub) recorded as context, and privacy-first cookieless analytics as a protected feature.

## Why
Docs-only. No runtime code changes. This is the maintainability foundation for autonomous + contributor agent work — it makes the project's rules machine-visible on every turn rather than tribal knowledge.

## Testing
N/A — documentation/config only. No build or test surface affected.