### PR TITLE
ci: move heavy jobs off per-PR path (#350)

### DIFF
--- a/.github/workflows/deploy-helm.yml
+++ b/.github/workflows/deploy-helm.yml
@@ -27,6 +27,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # Heavy (three image builds + a kind cluster + a rollout). Off the ordinary-PR
+  # path (issue #350): nightly on main + push to main + manual, and on a PR only
+  # when labelled `deep-check` (gated on the job's `if` below).
+  schedule:
+    - cron: "42 4 * * *"
 
 # A new push to the same branch makes the previous run irrelevant.
 concurrency:
@@ -72,6 +77,11 @@ env:
 jobs:
   helm-kind:
     name: kind deploy + multi-replica rate-limit proof
+    # Off the ordinary-PR path (issue #350): runs on schedule/push/dispatch, and
+    # on a PR only when it carries the `deep-check` label. Not a required check.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'deep-check')
     runs-on: ubuntu-latest
     # Heavy: three image builds, a kind cluster, a full rollout and two smoke
     # suites. 40 minutes is generous headroom over the observed ~15-20m.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # Nightly full run on main so the heavy jobs that are off the per-PR path
+  # (restore-test here, and the Helm/kind deploy workflow) still run daily
+  # against the default branch. 04:17 UTC — off the top of the hour to avoid
+  # the scheduler's peak. (Issue #350.)
+  schedule:
+    - cron: "17 4 * * *"
 
 # A new push to the same branch makes the previous run irrelevant.
 concurrency:
@@ -586,7 +592,13 @@ jobs:
   restore-test:
     name: Backup and restore round-trip
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Heavy (backup/restore round-trip). Off the ordinary-PR path (issue #350):
+    # runs nightly on main (schedule), on a push to main, and on a PR only when
+    # it carries the `deep-check` label. ci-gate tolerates it being skipped.
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      (github.event_name != 'pull_request' ||
+       contains(github.event.pull_request.labels.*.name, 'deep-check'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Move the heaviest CI jobs off the per-PR path (closes #350)

`restore-test` (backup/restore round-trip, in `verify.yml`) and the whole `deploy-helm.yml` workflow (kind cluster + three image builds — the "kind deploy" check) each ran on every PR: ~30–40 min of wall clock and a big share of the concurrent-job allowance, and neither can be affected by an ordinary code/test change. Now that `ci-gate` (#349) is the single required check and tolerates skipped jobs, these can come off the per-PR path without leaving anything pending.

### Changes (`.github/workflows/`, authorized by this issue)
- **`restore-test`** (`verify.yml`): `if` now also requires `github.event_name != 'pull_request' || <PR has label 'deep-check'>`. Added a nightly `schedule` (04:17 UTC) to `verify.yml`.
- **`deploy-helm.yml`**: nightly `schedule` (04:42 UTC) added; the `helm-kind` job gated on the same non-PR-or-`deep-check` condition.

### Acceptance criteria
- [x] Neither runs on an ordinary PR (skipped via the `if`; this PR itself demonstrates it — `CI gate` stays green with both skipped)
- [x] Both run nightly on `main` (schedule triggers)
- [x] Both run on a PR labelled `deep-check` (`contains(...labels.*.name, 'deep-check')`)
- [x] Neither is a required status check (only `CI gate` is required, per #349)

YAML validated (`yaml.safe_load`) and gating asserted. Depends on #349 (ci-gate), which is merged.

*QA program — phase 1 guardrails.*
