### PR TITLE
test(web): set up vitest + first lib/utils tests (#351)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
 
 packages:
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,9 @@
     "vercel-build": "pnpm --filter @snapurl/contract build && pnpm --filter @snapurl/domain build && next build",
     "start": "next start --port 3000",
     "lint": "eslint .",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -37,6 +39,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4.1.13",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { compact, inr, pct, shortUrl, faviconFor, relativeDate, formatDate } from "./utils";
+
+/* First tests for web/ (issue #351). These are the pure formatting helpers the
+   dashboard renders numbers, money and links with — worth pinning because a
+   silent change to any of them is a wrong figure on every table. */
+
+describe("compact", () => {
+  it("keeps small numbers verbatim", () => {
+    expect(compact(0)).toBe("0");
+    expect(compact(999)).toBe("999");
+  });
+  it("abbreviates thousands and millions", () => {
+    expect(compact(84_392)).toBe("84.4k");
+    expect(compact(1_500_000)).toBe("1.5M");
+  });
+  it("handles negatives by magnitude", () => {
+    expect(compact(-2_000)).toBe("-2.0k");
+  });
+});
+
+describe("inr", () => {
+  it("formats lakh and crore thresholds", () => {
+    expect(inr(100_000)).toBe("₹1.0L");
+    expect(inr(10_000_000)).toBe("₹1.0Cr");
+  });
+  it("uses en-IN grouping below a lakh", () => {
+    expect(inr(1999)).toBe("₹1,999");
+  });
+});
+
+describe("pct", () => {
+  it("fixes to one digit by default and keeps the sign", () => {
+    expect(pct(28.9)).toBe("28.9%");
+    expect(pct(-3.25, 2)).toBe("-3.25%");
+  });
+});
+
+describe("shortUrl", () => {
+  it("joins domain and slug with a slash", () => {
+    expect(shortUrl("localhost:3002", "spring-sale")).toBe("localhost:3002/spring-sale");
+  });
+});
+
+describe("faviconFor", () => {
+  it("maps known hosts (ignoring www.) and falls back to a link glyph", () => {
+    expect(faviconFor("https://www.acme.com/x")).toBe("🛍");
+    expect(faviconFor("https://calendly.com/acme/demo")).toBe("🗓");
+    expect(faviconFor("https://unknown.example/x")).toBe("🔗");
+  });
+  it("never throws on a malformed URL", () => {
+    expect(faviconFor("not a url")).toBe("🔗");
+  });
+});
+
+describe("relativeDate / formatDate", () => {
+  afterEach(() => vi.useRealTimers());
+  it("returns 'just now' within a minute and hours/days beyond", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-09T12:00:00.000Z"));
+    expect(relativeDate("2026-09-09T11:59:40.000Z")).toBe("just now");
+    expect(relativeDate("2026-09-09T09:00:00.000Z")).toBe("3 hours ago");
+    expect(relativeDate("2026-09-07T12:00:00.000Z")).toBe("2 days ago");
+  });
+  it("echoes an unparseable input back unchanged", () => {
+    expect(relativeDate("not-a-date")).toBe("not-a-date");
+    expect(formatDate("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vitest/config";
+
+// web/ had zero tests (issue #351). Pure helpers (src/lib/utils.ts and future
+// lib logic) run under the node environment; component/DOM tests can add
+// jsdom/happy-dom later without changing this include.
+export default defineConfig({ test: { environment: "node", include: ["src/**/*.test.ts"] } });


### PR DESCRIPTION
## Set up vitest for web/ + first tests (closes #351)

`web/` had **zero tests** and no test tooling. This bootstraps it and adds a real first suite.

### Changes
- `web/vitest.config.ts` — node environment, `src/**/*.test.ts` (matches the monorepo's convention; DOM/component tests can add jsdom later without changing this).
- `web/package.json` — `test` (`vitest run`) + `test:watch` scripts, and `vitest ^3.2.4` devDep (matched to the rest of the monorepo). Lockfile updated.
- `web/src/lib/utils.test.ts` — **11 tests** covering the pure formatting helpers the dashboard renders every number/money/link with: `compact`, `inr` (lakh/crore), `pct`, `shortUrl`, `faviconFor` (incl. malformed-URL fallback), and `relativeDate`/`formatDate` (with faked time + the unparseable-input passthrough).

### Why this is enough to close it
The CI `verify` job runs `pnpm -r test`, which now recurses into `snapurl-web` automatically — verified locally (`utils.test.ts` runs under the root recursive command). So web tests now run on every PR, and the file gives a real, non-trivial baseline to grow (not a placeholder).

Local: web suite 11/11 pass; `pnpm install --frozen-lockfile` clean.

*QA program — phase 2 test-infra. First of the web-testing chain (#352/#353 build on this).*
