### PR TITLE
a11y(web): accessible names for ambiguous & icon-only controls (#352)

### DIFF
--- a/web/src/app/(app)/bio/page.tsx
+++ b/web/src/app/(app)/bio/page.tsx
@@ -151,7 +151,7 @@ export default function BioPagesPage() {
               <Button variant="primary" onClick={create} disabled={upsert.isPending}>
                 {upsert.isPending ? "Creating…" : "Create as draft"}
               </Button>
-              <Button onClick={() => { setCreating(false); setProblem(null); }}>Cancel</Button>
+              <Button aria-label="Cancel creating a bio page" onClick={() => { setCreating(false); setProblem(null); }}>Cancel</Button>
             </div>
           </CardBody>
         </Card>

--- a/web/src/app/(app)/developers/page.tsx
+++ b/web/src/app/(app)/developers/page.tsx
@@ -202,6 +202,7 @@ export default function DevelopersPage() {
                   <button
                     key={scope}
                     type="button"
+                    aria-pressed={keyScopes.includes(scope)}
                     onClick={() => setKeyScopes((cur) => toggle(cur, scope))}
                     className={`px-[9px] py-[4px] rounded-[var(--radius-sm)] border text-[12px] font-mono ${
                       keyScopes.includes(scope) ? "border-accent text-accent bg-accent-wash" : "border-line text-ink-3"
@@ -216,7 +217,7 @@ export default function DevelopersPage() {
               <Button variant="primary" onClick={mintKey} disabled={createKey.isPending}>
                 {createKey.isPending ? "Creating…" : "Create key"}
               </Button>
-              <Button onClick={() => { setNamingKey(false); setProblem(null); }}>Cancel</Button>
+              <Button aria-label="Cancel creating an API key" onClick={() => { setNamingKey(false); setProblem(null); }}>Cancel</Button>
             </div>
           </CardBody>
         </Card>
@@ -241,6 +242,7 @@ export default function DevelopersPage() {
                   <button
                     key={event}
                     type="button"
+                    aria-pressed={hookEvents.includes(event)}
                     onClick={() => setHookEvents((cur) => toggle(cur, event))}
                     className={`px-[9px] py-[4px] rounded-[var(--radius-sm)] border text-[12px] font-mono ${
                       hookEvents.includes(event) ? "border-accent text-accent bg-accent-wash" : "border-line text-ink-3"
@@ -255,7 +257,7 @@ export default function DevelopersPage() {
               <Button variant="primary" onClick={addWebhook} disabled={createWebhook.isPending || !endpoint.trim()}>
                 {createWebhook.isPending ? "Adding…" : "Add endpoint"}
               </Button>
-              <Button onClick={() => { setAddingHook(false); setProblem(null); }}>Cancel</Button>
+              <Button aria-label="Cancel adding a webhook endpoint" onClick={() => { setAddingHook(false); setProblem(null); }}>Cancel</Button>
             </div>
           </CardBody>
         </Card>

--- a/web/src/app/(app)/domains/page.tsx
+++ b/web/src/app/(app)/domains/page.tsx
@@ -93,7 +93,7 @@ export default function DomainsPage() {
               <Button variant="primary" onClick={add} disabled={addDomain.isPending || !name.trim()}>
                 {addDomain.isPending ? "Adding…" : "Add domain"}
               </Button>
-              <Button onClick={() => { setAdding(false); setProblem(null); }}>Cancel</Button>
+              <Button aria-label="Cancel adding a domain" onClick={() => { setAdding(false); setProblem(null); }}>Cancel</Button>
             </div>
           </CardBody>
         </Card>

--- a/web/src/app/(app)/links/[id]/page.tsx
+++ b/web/src/app/(app)/links/[id]/page.tsx
@@ -121,7 +121,7 @@ export default function LinkDetailPage() {
                 </Button>
               </>
             ) : (
-              <Button onClick={() => setConfirmingDelete(true)}>Delete</Button>
+              <Button aria-label="Delete this link" onClick={() => setConfirmingDelete(true)}>Delete</Button>
             )}
             <Button>Share report</Button>
             <Button variant="primary">Copy link</Button>
@@ -159,7 +159,7 @@ export default function LinkDetailPage() {
               <Button variant="primary" onClick={save} disabled={updateLink.isPending || draft === l.destination}>
                 {updateLink.isPending ? "Saving…" : "Save destination"}
               </Button>
-              <Button onClick={() => { setDraft(null); setProblem(null); }}>Cancel</Button>
+              <Button aria-label="Cancel editing the destination" onClick={() => { setDraft(null); setProblem(null); }}>Cancel</Button>
             </div>
           </CardBody>
         </Card>

--- a/web/src/app/(app)/qr/page.tsx
+++ b/web/src/app/(app)/qr/page.tsx
@@ -117,6 +117,7 @@ export default function QrStudioPage() {
                     <button
                       key={c}
                       aria-pressed={fg === c}
+                      aria-label={`Foreground colour ${c}`}
                       onClick={() => setFg(c)}
                       style={{ background: c }}
                       className={cn(

--- a/web/src/app/(app)/reports/page.tsx
+++ b/web/src/app/(app)/reports/page.tsx
@@ -82,6 +82,7 @@ export default function ReportsPage() {
                           size="sm"
                           variant="ghost"
                           disabled={review.isPending}
+                          aria-label={`Mark report on /${r.slug} reviewed`}
                           onClick={() => review.mutate({ id: r.id, status: "reviewed" })}
                         >
                           Reviewed
@@ -90,6 +91,7 @@ export default function ReportsPage() {
                           size="sm"
                           variant="ghost"
                           disabled={review.isPending}
+                          aria-label={`Dismiss report on /${r.slug}`}
                           onClick={() => review.mutate({ id: r.id, status: "dismissed" })}
                         >
                           Dismiss
@@ -97,6 +99,7 @@ export default function ReportsPage() {
                         <Button
                           size="sm"
                           disabled={review.isPending || r.linkId === null}
+                          aria-label={`Flag the link for report on /${r.slug}`}
                           title={r.linkId === null ? "This report's slug did not resolve to a link" : undefined}
                           onClick={() => review.mutate({ id: r.id, flagLink: true })}
                         >

--- a/web/src/app/(app)/team/page.tsx
+++ b/web/src/app/(app)/team/page.tsx
@@ -123,7 +123,7 @@ export default function TeamPage() {
               <Button variant="primary" onClick={sendInvite} disabled={invite.isPending || !email.trim()}>
                 {invite.isPending ? "Sending…" : "Send invitation"}
               </Button>
-              <Button onClick={() => { setInviting(false); setProblem(null); }}>Cancel</Button>
+              <Button aria-label="Cancel inviting a member" onClick={() => { setInviting(false); setProblem(null); }}>Cancel</Button>
             </div>
           </CardBody>
         </Card>

--- a/web/src/components/links/link-row.tsx
+++ b/web/src/components/links/link-row.tsx
@@ -65,6 +65,7 @@ export function LinkRow({ link, defaultOpen = false }: { link: Link; defaultOpen
             </NextLink>
             <button
               onClick={onCopy}
+              aria-label={`Copy short link ${link.domain}/${link.slug}`}
               className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-ink-3 text-[12px] px-[6px] py-[2px] rounded-[4px] hover:bg-surface-3 hover:text-ink transition-opacity"
             >
               {copied ? "✓ copied" : "⧉ copy"}
@@ -74,6 +75,7 @@ export function LinkRow({ link, defaultOpen = false }: { link: Link; defaultOpen
             <button
               onClick={() => cloneLink.mutate({ id: link.id })}
               disabled={cloneLink.isPending}
+              aria-label={`Duplicate link ${link.domain}/${link.slug}`}
               title="Create a copy of this link with a new back-half"
               className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-ink-3 text-[12px] px-[6px] py-[2px] rounded-[4px] hover:bg-surface-3 hover:text-ink transition-opacity disabled:opacity-50"
             >


### PR DESCRIPTION
## Accessible names for ambiguous & icon-only controls (closes #352)

Adds accessible names so every interactive control is reachable by a **unique** name within its section — a real a11y improvement **and** the prerequisite for stable Playwright selectors (#353). No `data-testid`, no visual change. Follows the existing pattern (search input, drawer close button, routing-rule move buttons, settings accent swatches).

### Changes (8 files, `web/src` only)
**Repeated per-row / per-card actions — scoped to their subject:**
- `link-row.tsx` — copy & duplicate buttons now `aria-label={`Copy/Duplicate … ${link.domain}/${link.slug}`}` (were identical across every row).
- `reports/page.tsx` — the per-report **Reviewed / Dismiss / Flag link** buttons scoped by `/${r.slug}` (repeated down the table).

**Repeated generic "Cancel"/"Delete" in inline forms — scoped to their form:**
- `team` → "Cancel inviting a member"; `bio` → "Cancel creating a bio page"; `domains` → "Cancel adding a domain"; `developers` → "Cancel creating an API key" / "Cancel adding a webhook endpoint"; `links/[id]` → "Cancel editing the destination" + "Delete this link".

**Icon-only / toggle controls — exposed state:**
- `qr/page.tsx` — foreground colour swatches get `aria-label={`Foreground colour ${c}`}`.
- `developers/page.tsx` — API-scope and webhook-event toggle buttons get `aria-pressed` (they had a visible label but no toggle state — needed for a11y and stable state assertions).

### Acceptance criteria
- ✅ Every interactive control reachable by a unique accessible name within its section (the ambiguous/repeated/icon-only cases).
- ✅ No visual change — only `aria-*` attributes added; no class/markup/layout changes.
- ✅ No `data-testid` introduced (grep-verified).

### Verified locally
`pnpm --filter snapurl-web type-check` clean; web vitest suite 11/11 green; grep confirms zero `data-testid`. Controls that were already correctly labeled (search, filters, drawer close, routing-rule buttons, account menu, accent swatches) were left untouched.

*QA program — phase 2 test-infra. Unblocks #353 (Playwright E2E).*
