### PR TITLE
test(web): fixture-parity test — fail when fixtures drift from the API (#354)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "start": "node --env-file-if-exists=.env dist/main.js",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "emit:openapi": "pnpm build && node scripts/emit-openapi.mjs",
     "dev:nest": "nest start --watch"
   },
   "dependencies": {

--- a/apps/api/scripts/emit-openapi.mjs
+++ b/apps/api/scripts/emit-openapi.mjs
@@ -1,0 +1,33 @@
+/*
+ * Emit the API's route surface (OpenAPI paths) as a committed JSON artifact that
+ * web's fixture-parity test consumes as DATA (issue #354). The route list crosses
+ * the web<->apps boundary as serialized JSON, never as a source import, so the web
+ * bundle still depends only on @snapurl/contract and @snapurl/domain.
+ *
+ * Runs on the COMPILED output (dist/), so it needs `pnpm --filter @snapurl/api build`
+ * first and then plain node — no extra TS runner dependency. buildOpenApiDocument()
+ * is static (no running server): it reads the registry populated by the path imports.
+ *
+ * Usage:  pnpm --filter @snapurl/api build && node apps/api/scripts/emit-openapi.mjs
+ */
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { buildOpenApiDocument } from "../dist/openapi/document.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(here, "../../../web/src/lib/api/openapi.generated.json");
+
+const doc = buildOpenApiDocument("api");
+
+const paths = {};
+for (const [p, ops] of Object.entries(doc.paths ?? {})) {
+  paths[p] = Object.keys(ops)
+    .filter((k) => ["get", "post", "put", "patch", "delete"].includes(k.toLowerCase()))
+    .map((m) => m.toUpperCase())
+    .sort();
+}
+
+const sorted = Object.fromEntries(Object.entries(paths).sort(([a], [b]) => a.localeCompare(b)));
+writeFileSync(OUT, JSON.stringify(sorted, null, 2) + "\n");
+console.log(`Wrote ${Object.keys(sorted).length} paths to ${OUT}`);

--- a/web/src/lib/api/fixture-parity.allowlist.ts
+++ b/web/src/lib/api/fixture-parity.allowlist.ts
@@ -1,0 +1,34 @@
+/*
+ * Intentional gaps for the fixture-parity test (issue #354). An API route listed
+ * here is deliberately NOT backed by a fixture branch — because no dashboard hook
+ * in fixtures mode calls it. Every entry MUST carry a non-empty `reason`; the test
+ * rejects a reason-less entry, so a gap cannot be waved through silently.
+ *
+ * An entry suppresses BOTH directions for that method+path: a missing fixture
+ * branch (direction 1) and a stale branch (direction 2).
+ */
+export type AllowlistEntry = { method: string; path: string; reason: string };
+
+export const FIXTURE_PARITY_ALLOWLIST: ReadonlyArray<AllowlistEntry> = [
+  {
+    method: "POST",
+    path: "/auth/refresh",
+    reason:
+      "Token refresh is handled entirely inside the API client (client.ts rotates tokens); no hook calls it, so fixtures mode never exercises it.",
+  },
+  {
+    method: "GET",
+    path: "/links/export",
+    reason: "CSV export is a direct browser download (anchor href), not a hook request routed through fixtureRequest.",
+  },
+  {
+    method: "GET",
+    path: "/forms/{id}/responses.csv",
+    reason: "Form-responses CSV is a direct browser download, not a hook request routed through fixtureRequest.",
+  },
+  {
+    method: "GET",
+    path: "/health",
+    reason: "Liveness endpoint for the load balancer; no dashboard hook calls it.",
+  },
+];

--- a/web/src/lib/api/fixture-parity.test.ts
+++ b/web/src/lib/api/fixture-parity.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { fixtureRequest, FIXTURE_ROUTE_PATTERNS } from "./fixtures";
+import { FIXTURE_PARITY_ALLOWLIST } from "./fixture-parity.allowlist";
+
+/*
+ * Fixture-parity guard (issue #354). web/src/lib/api/fixtures.ts is a hand-kept
+ * fake backend; when the real API grows a route with no fixture branch, the UI
+ * looks like it works but is entirely fake. This test fails the build on drift in
+ * BOTH directions, against the API's own route surface serialized as data in
+ * openapi.generated.json (emitted by apps/api/scripts/emit-openapi.mjs — the route
+ * list crosses the web<->apps boundary as JSON, never as a source import).
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const doc = JSON.parse(readFileSync(resolve(here, "./openapi.generated.json"), "utf8")) as Record<string, string[]>;
+
+// Flatten the OpenAPI paths into {method, path} pairs — the live API surface.
+const apiRoutes = Object.entries(doc).flatMap(([path, methods]) =>
+  methods.map((method) => ({ method: method.toUpperCase(), path })),
+);
+
+const DUMMY = "sample-id";
+const concrete = (path: string) => path.replace(/\{[^}]+\}/g, DUMMY);
+
+const isAllowed = (method: string, path: string) =>
+  FIXTURE_PARITY_ALLOWLIST.some((e) => e.method.toUpperCase() === method && e.path === path);
+
+/** Ask the REAL dispatcher whether a branch handles (method, concrete path).
+ *  The dispatcher throws "No fixture for ..." only when nothing matched; any
+ *  other throw means a branch DID match but choked on our dummy body/schema —
+ *  which still counts as "a branch exists". */
+async function hasFixtureBranch(method: string, path: string): Promise<boolean> {
+  try {
+    await fixtureRequest(concrete(path), z.any(), { method, body: {} });
+    return true;
+  } catch (err) {
+    // The dispatcher's no-branch sentinel is exactly "No fixture for <METHOD> <path>.".
+    // Match that precisely — a branch's own not-found error ("No fixture form ...",
+    // "No fixture link ...", "No fixture domain ...") means a branch DID match.
+    return !/^No fixture for [A-Z]+ /.test(String((err as Error).message));
+  }
+}
+
+describe("fixture parity: every API route has a fixture branch (direction 1)", () => {
+  for (const { method, path } of apiRoutes) {
+    const testName = `${method} ${path}`;
+    it(testName, async () => {
+      if (isAllowed(method, path)) return; // intentional gap, documented in the allowlist
+      const covered = await hasFixtureBranch(method, path);
+      expect(
+        covered,
+        `${testName} is a live API route with no branch in fixtures.ts. Add a fixture branch, or add an explicit, reasoned entry to fixture-parity.allowlist.ts.`,
+      ).toBe(true);
+    });
+  }
+});
+
+describe("fixture parity: every fixture branch maps to a live API route (direction 2)", () => {
+  for (const branch of FIXTURE_ROUTE_PATTERNS) {
+    for (const method of branch.methods) {
+      const label = `${method} ${branch.pattern}`;
+      it(label, () => {
+        const matchesLiveRoute = apiRoutes.some(
+          (r) => r.method === method && branch.pattern.test(concrete(r.path)),
+        );
+        const matchesAllowlisted = FIXTURE_PARITY_ALLOWLIST.some(
+          (e) => e.method.toUpperCase() === method && branch.pattern.test(concrete(e.path)),
+        );
+        expect(
+          matchesLiveRoute || matchesAllowlisted,
+          `${label} is a fixture branch that matches no live API route. The route was likely removed/renamed — delete the stale branch, or allowlist it.`,
+        ).toBe(true);
+      });
+    }
+  }
+});
+
+describe("fixture parity: the declared pattern list stays in sync with the dispatcher", () => {
+  // Each declared (method, pattern) must actually resolve in the real dispatcher,
+  // so FIXTURE_ROUTE_PATTERNS cannot claim a branch the chain does not have. We
+  // build a concrete sample path from the pattern and probe the real dispatcher.
+  const sampleFor = (pattern: RegExp) =>
+    pattern.source
+      .replace(/^\^/, "")
+      .replace(/\$$/, "")
+      .replace(/\\\//g, "/")
+      .replace(/\(\[\^\/\]\+\)/g, DUMMY)
+      .replace(/\(([a-z|]+)\)/g, (_m, alts: string) => alts.split("|")[0]);
+
+  for (const branch of FIXTURE_ROUTE_PATTERNS) {
+    for (const method of branch.methods) {
+      const samplePath = sampleFor(branch.pattern);
+      it(`${method} ${samplePath} resolves in the dispatcher`, async () => {
+        const resolved = await hasFixtureBranch(method, samplePath);
+        expect(
+          resolved,
+          `FIXTURE_ROUTE_PATTERNS declares ${method} ${branch.pattern} but the dispatcher does not recognize ${method} ${samplePath} — the list drifted from the if/else chain.`,
+        ).toBe(true);
+      });
+    }
+  }
+
+  it("the allowlist has a reason for every entry", () => {
+    for (const e of FIXTURE_PARITY_ALLOWLIST) {
+      expect(e.reason.trim().length, `Allowlist entry ${e.method} ${e.path} needs a non-empty reason`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -598,6 +598,57 @@ function match(path: string) {
   return (pattern: RegExp) => pattern.exec(clean);
 }
 
+/*
+ * The set of (method, path-pattern) pairs this fake backend recognizes. It is the
+ * SAME list the dispatch chain in fixtureRequest() branches on, declared here as
+ * data so the fixture-parity test (issue #354) can check both directions:
+ *   - every real API route has a branch here (missing branch => test fails)
+ *   - every branch here still maps to a live API route (stale branch => test fails)
+ * A `methods` array lists exactly which HTTP methods that branch serves (mirroring
+ * the dispatch chain's `&& method === ...` guards; a branch with no guard serves
+ * GET). Keep this in lockstep with the chain below; the parity test's direction-1
+ * probe independently re-derives coverage from the real dispatcher, so a route
+ * this list forgets is still caught.
+ */
+export const FIXTURE_ROUTE_PATTERNS: ReadonlyArray<{ methods: string[]; pattern: RegExp }> = [
+  { methods: ["POST"], pattern: /^\/auth\/(login|register|oauth)$/ },
+  { methods: ["GET"], pattern: /^\/auth\/me$/ },
+  { methods: ["POST"], pattern: /^\/auth\/logout$/ },
+  { methods: ["POST"], pattern: /^\/auth\/2fa\/setup$/ },
+  { methods: ["POST"], pattern: /^\/auth\/2fa\/enable$/ },
+  { methods: ["POST"], pattern: /^\/auth\/2fa\/verify$/ },
+  { methods: ["POST"], pattern: /^\/auth\/2fa\/disable$/ },
+  { methods: ["GET", "PATCH"], pattern: /^\/workspaces\/current$/ },
+  { methods: ["GET", "POST"], pattern: /^\/links$/ },
+  { methods: ["POST"], pattern: /^\/links\/bulk$/ },
+  { methods: ["POST"], pattern: /^\/links\/([^/]+)\/clone$/ },
+  { methods: ["GET", "PATCH", "DELETE"], pattern: /^\/links\/([^/]+)$/ },
+  { methods: ["GET"], pattern: /^\/analytics$/ },
+  { methods: ["GET", "POST"], pattern: /^\/conversions$/ },
+  { methods: ["GET", "POST"], pattern: /^\/domains$/ },
+  { methods: ["POST"], pattern: /^\/domains\/([^/]+)\/verify$/ },
+  { methods: ["DELETE"], pattern: /^\/domains\/([^/]+)$/ },
+  { methods: ["GET", "POST"], pattern: /^\/members$/ },
+  { methods: ["PATCH", "DELETE"], pattern: /^\/members\/([^/]+)$/ },
+  { methods: ["GET"], pattern: /^\/audit$/ },
+  { methods: ["GET", "POST"], pattern: /^\/api-keys$/ },
+  { methods: ["DELETE"], pattern: /^\/api-keys\/([^/]+)$/ },
+  { methods: ["GET", "POST"], pattern: /^\/webhooks$/ },
+  { methods: ["DELETE"], pattern: /^\/webhooks\/([^/]+)$/ },
+  { methods: ["GET", "PUT"], pattern: /^\/bio-pages$/ },
+  { methods: ["DELETE"], pattern: /^\/bio-pages\/([^/]+)$/ },
+  { methods: ["GET"], pattern: /^\/forms\/([^/]+)\/responses$/ },
+  { methods: ["GET", "PATCH", "DELETE"], pattern: /^\/forms\/([^/]+)$/ },
+  { methods: ["GET", "POST"], pattern: /^\/forms$/ },
+  { methods: ["PATCH"], pattern: /^\/reports\/([^/]+)$/ },
+  { methods: ["GET"], pattern: /^\/reports$/ },
+  { methods: ["GET", "POST"], pattern: /^\/public\/forms\/([^/]+)$/ },
+  { methods: ["POST"], pattern: /^\/public\/links\/([^/]+)\/unlock$/ },
+  { methods: ["POST"], pattern: /^\/public\/links\/([^/]+)\/report$/ },
+  { methods: ["GET"], pattern: /^\/public\/links\/([^/]+)\/preview$/ },
+];
+
+
 export async function fixtureRequest<T>(
   path: string,
   schema: z.ZodType<T>,

--- a/web/src/lib/api/openapi.generated.json
+++ b/web/src/lib/api/openapi.generated.json
@@ -1,0 +1,140 @@
+{
+  "/analytics": [
+    "GET"
+  ],
+  "/api-keys": [
+    "GET",
+    "POST"
+  ],
+  "/api-keys/{id}": [
+    "DELETE"
+  ],
+  "/audit": [
+    "GET"
+  ],
+  "/auth/2fa/disable": [
+    "POST"
+  ],
+  "/auth/2fa/enable": [
+    "POST"
+  ],
+  "/auth/2fa/setup": [
+    "POST"
+  ],
+  "/auth/2fa/verify": [
+    "POST"
+  ],
+  "/auth/login": [
+    "POST"
+  ],
+  "/auth/logout": [
+    "POST"
+  ],
+  "/auth/me": [
+    "GET"
+  ],
+  "/auth/oauth": [
+    "POST"
+  ],
+  "/auth/refresh": [
+    "POST"
+  ],
+  "/auth/register": [
+    "POST"
+  ],
+  "/bio-pages": [
+    "GET",
+    "PUT"
+  ],
+  "/bio-pages/{id}": [
+    "DELETE"
+  ],
+  "/conversions": [
+    "GET",
+    "POST"
+  ],
+  "/domains": [
+    "GET",
+    "POST"
+  ],
+  "/domains/{id}": [
+    "DELETE"
+  ],
+  "/domains/{id}/verify": [
+    "POST"
+  ],
+  "/forms": [
+    "GET",
+    "POST"
+  ],
+  "/forms/{id}": [
+    "DELETE",
+    "GET",
+    "PATCH"
+  ],
+  "/forms/{id}/responses": [
+    "GET"
+  ],
+  "/forms/{id}/responses.csv": [
+    "GET"
+  ],
+  "/health": [
+    "GET"
+  ],
+  "/links": [
+    "GET",
+    "POST"
+  ],
+  "/links/{id}": [
+    "DELETE",
+    "GET",
+    "PATCH"
+  ],
+  "/links/{id}/clone": [
+    "POST"
+  ],
+  "/links/bulk": [
+    "POST"
+  ],
+  "/links/export": [
+    "GET"
+  ],
+  "/members": [
+    "GET",
+    "POST"
+  ],
+  "/members/{id}": [
+    "DELETE",
+    "PATCH"
+  ],
+  "/public/forms/{slug}": [
+    "GET",
+    "POST"
+  ],
+  "/public/links/{slug}/preview": [
+    "GET"
+  ],
+  "/public/links/{slug}/report": [
+    "POST"
+  ],
+  "/public/links/{slug}/unlock": [
+    "POST"
+  ],
+  "/reports": [
+    "GET"
+  ],
+  "/reports/{id}": [
+    "PATCH"
+  ],
+  "/webhooks": [
+    "GET",
+    "POST"
+  ],
+  "/webhooks/{id}": [
+    "DELETE"
+  ],
+  "/workspaces/current": [
+    "GET",
+    "PATCH"
+  ]
+}


### PR DESCRIPTION
## Fixture-parity test: fail the build when web fixtures drift from the API (closes #354)

`web/src/lib/api/fixtures.ts` is a hand-maintained fake backend. When a route is added to the API with no fixture branch, the UI appears to work and is entirely fake. This adds a test that fails on drift in **both** directions, running inside the existing `pnpm test` — no new CI job.

### How the two halves connect (without breaking the boundary)
The route list lives in `apps/api` and the fixtures live in `web`, and the steering rules forbid `web` importing from `apps/*`. So the API's route surface crosses the boundary as **serialized data, not a source import**:
- `apps/api/scripts/emit-openapi.mjs` calls the existing static `buildOpenApiDocument()` and writes the `{path → methods}` map to a committed `web/src/lib/api/openapi.generated.json` (41 paths / 56 method+path pairs). Convenience: `pnpm --filter @snapurl/api emit:openapi`.
- The web test reads that JSON as data. The web bundle still depends only on `@snapurl/contract` and `@snapurl/domain`.

### The test — `web/src/lib/api/fixture-parity.test.ts`
- **Direction 1 (route with no branch):** for each live API route, probe the **real** `fixtureRequest` dispatcher with a concrete path; the dispatcher's `No fixture for <METHOD> <path>` sentinel means no branch. Exact, and derived from the actual dispatcher (not source-scraping).
- **Direction 2 (stale branch for a dead route):** `fixtures.ts` now exports `FIXTURE_ROUTE_PATTERNS` (the recognizer `{methods, pattern}` list); the test asserts each declared branch still matches a live API route. A third block re-probes each declared pattern against the real dispatcher so the list can't drift from the if/else chain.
- **Allowlist (`fixture-parity.allowlist.ts`):** intentional API-only routes (`/auth/refresh`, `/links/export`, `/forms/{id}/responses.csv`, `/health`) each require a non-empty `reason` — the test rejects a reason-less entry, so a gap can't be waved through silently. Suppresses both directions.

### Verified locally
- 157 parity assertions pass; full web suite 168, api suite 172, all green.
- **Proved it catches drift:** injecting a fake API route fails direction 1; the sentinel match is tightened so a branch's own not-found error (`No fixture form …`) isn't misread as a missing branch.
- No new dependency (lockfile unchanged); no `.github` change; no existing assertion weakened.

### Judgment calls (flagging per the issue's constraints)
- Added an `emit:openapi` script to `apps/api/package.json` (a convenience wrapper for the raw node command). Minor, non-behavioral; happy to drop it if you'd rather keep `package.json` untouched.
- The staleness risk (committed JSON going out of date) is mitigated by CI building the API before `pnpm test`; a hard freshness gate could be a follow-up.

*QA program — phase 2 test-infra.*
