### PR TITLE
test: coverage tooling + coverage-delta ratchet (#355)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,6 +37,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      non_e2e: ${{ steps.filter.outputs.non_e2e }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -45,8 +46,15 @@ jobs:
           # `code` is true when the PR changes any file that is NOT markdown.
           # A docs-only PR (every changed file is *.md) leaves it false and the
           # heavy jobs skip; ci-gate still reports (it tolerates skipped).
+          # `non_e2e` is true when the PR changes at least one file outside e2e/
+          # and outside markdown — the coverage-delta guard (issue #355) is
+          # meaningless for an e2e-only PR (Playwright has no vitest coverage).
           filters: |
             code:
+              - '!**/*.md'
+            non_e2e:
+              - '**'
+              - '!e2e/**'
               - '!**/*.md'
       # A push to main has no PR diff for paths-filter to read; force code=true
       # there so the default branch always runs the full suite.
@@ -819,6 +827,85 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Publish the coverage baseline (issue #355). Non-PR only (nightly cron / push
+  # to main): run the suite with coverage, merge the per-package summaries into
+  # one, and upload it as an artifact the PR coverage-delta job downloads. Stored
+  # as an artifact, not a committed file, so the test-only lane never has to
+  # update a committed baseline (which it is forbidden to touch).
+  coverage-baseline:
+    name: coverage-baseline
+    needs: changes
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Run coverage
+        run: pnpm test:coverage
+      - name: Merge coverage
+        run: pnpm coverage:merge
+      - name: Upload baseline artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-baseline
+          path: coverage/coverage-summary.json
+          retention-days: 14
+          if-no-files-found: error
+
+  # Coverage-delta guard (issue #355). On a PR that touches something other than
+  # e2e/ and docs, fail if a TEST-ONLY PR raises covered lines in no file (a
+  # tautological test). Downloads the latest nightly baseline from main; if none
+  # exists yet the delta script passes (no false red before the first baseline).
+  coverage-delta:
+    name: coverage-delta
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.non_e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Ensure origin/main is available
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
+      - name: Run coverage
+        run: pnpm test:coverage
+      - name: Merge coverage
+        run: pnpm coverage:merge
+      - name: Download latest nightly baseline from main
+        continue-on-error: true
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: verify.yml
+          branch: main
+          name: coverage-baseline
+          path: baseline
+          if_no_artifact_found: warn
+      - name: Coverage delta check
+        run: node scripts/coverage-delta.mjs --pr coverage/coverage-summary.json --baseline baseline/coverage-summary.json --base origin/main
+
   # Single required status for this workflow (issue #349). A required check that
   # gets SKIPPED by path filtering never reports a conclusion, which leaves a PR
   # pending forever — so the branch protection requires THIS job, not the heavy
@@ -828,7 +915,7 @@ jobs:
   # test failure is red here; nothing is left pending.
   ci-gate:
     name: CI gate
-    needs: [changes, verify, integration, dynamo-smoke, restore-test, e2e]
+    needs: [changes, verify, integration, dynamo-smoke, restore-test, e2e, coverage-delta]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ logs/
 # Internal agent task-state (planning artifacts, not product code)
 .tasks/
 .agents/
+
+# Coverage output (issue #355) — generated, never committed
+coverage/
+**/coverage/

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts"], coverage },
   // The source imports .js specifiers (NodeNext style) but the files are .ts.
   resolve: { extensions: [".ts", ".js", ".json"] },
 });

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "build.mjs", "vitest.config.ts"],
+  "include": ["src/**/*.ts", "build.mjs"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
   // happy-dom gives the pure lib tests a DOM (popup/options wiring lands in FEAT-004);
   // mirrors apps/api/vitest.config.ts which uses "node" for its server-only logic.
-  test: { environment: "happy-dom", include: ["src/**/*.test.ts"] },
+  test: { environment: "happy-dom", include: ["src/**/*.test.ts"], coverage },
   // The source imports .js specifiers (NodeNext style) but the files are .ts.
   resolve: { extensions: [".ts", ".js", ".json"] },
 });

--- a/apps/redirect/vitest.config.ts
+++ b/apps/redirect/vitest.config.ts
@@ -1,3 +1,4 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
-export default defineConfig({ test: { environment: "node", include: ["src/**/*.test.ts"] } });
+export default defineConfig({ test: { environment: "node", include: ["src/**/*.test.ts"], coverage } });

--- a/apps/worker/src/jobs/lease.test.ts
+++ b/apps/worker/src/jobs/lease.test.ts
@@ -137,7 +137,7 @@ describeDb("withLease", () => {
     expect(next.acquired).toBe(true);
   });
 
-  it("derives the expiry from ttlSeconds, so the lease frees itself on time", async () => {
+  it("derives the expiry from ttlSeconds, so the lease frees itself on time", { retry: 2, timeout: 20_000 }, async () => {
     /* Every other test writes `locked_until` by hand, which means none of them
        touch the TTL — reading the argument as minutes instead of seconds, or
        ignoring it entirely, would pass the whole suite. This is the only case

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+    coverage,
     /* One database, so one file at a time.
      *
      * These suites run against a real Postgres rather than a fake, and they are

--- a/infra/vitest.config.ts
+++ b/infra/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../vitest.coverage.base";
 
 export default defineConfig({
   test: {
@@ -7,5 +8,6 @@ export default defineConfig({
     // CDK stack itself is validated by `cdk synth`, not vitest). Keep the glob
     // scoped to functions/ so it never tries to import a construct file.
     include: ["functions/**/*.test.ts"],
+    coverage,
   },
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "build:packages": "pnpm --filter \"./packages/*\" build",
     "type-check": "pnpm build:packages && pnpm -r type-check",
     "test": "pnpm build:packages && pnpm -r --workspace-concurrency=1 test",
+    "test:coverage": "COVERAGE=1 pnpm build:packages && COVERAGE=1 pnpm -r --workspace-concurrency=1 test",
+    "coverage:merge": "node scripts/merge-coverage.mjs",
     "lint": "pnpm -r lint",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
@@ -32,6 +34,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@vitest/coverage-v8": "^3.2.7",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/cache/vitest.config.ts
+++ b/packages/cache/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts"], coverage },
 });

--- a/packages/contract/vitest.config.ts
+++ b/packages/contract/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts"], coverage },
 });

--- a/packages/database/vitest.config.ts
+++ b/packages/database/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts"], coverage },
 });

--- a/packages/domain/vitest.config.ts
+++ b/packages/domain/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../../vitest.coverage.base";
 
 export default defineConfig({
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts"], coverage },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^3.2.7
+        version: 3.2.7(supports-color@8.1.1)(vitest@3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -432,6 +435,10 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@angular-devkit/core@19.2.24':
     resolution: {integrity: sha512-Kd49warf6U/EyWe5BszF/eebN3zQ3bk7tgfEljAw8q/rX95UUtriJubWvp6pgzHfzBA4jwq8f+QiNZB8eBEXPA==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -601,9 +608,26 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -1633,6 +1657,14 @@ packages:
   '@ioredis/commands@2.0.0':
     resolution: {integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1863,6 +1895,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.63.0':
     resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
@@ -2245,6 +2281,15 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
@@ -2382,9 +2427,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
@@ -2403,6 +2456,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -2458,6 +2514,9 @@ packages:
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -2812,6 +2871,9 @@ packages:
       sqlite3:
         optional: true
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -2820,6 +2882,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2966,6 +3031,10 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fork-ts-checker-webpack-plugin@9.1.0:
     resolution: {integrity: sha512-mpafl89VFPJmhnJ1ssH+8wmM2b50n+Rew5x42NeI2U78aRWgtkEtGmctp7iT16UjquJTjorEmIfESj3DxdW84Q==}
     engines: {node: '>=14.21.3'}
@@ -2995,6 +3064,11 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -3012,6 +3086,9 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3064,9 +3141,28 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -3079,6 +3175,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3250,6 +3349,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -3264,6 +3366,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
@@ -3291,6 +3400,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3401,6 +3514,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3416,6 +3532,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -3732,12 +3852,20 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3839,6 +3967,10 @@ packages:
     resolution: {integrity: sha512-myiQ6aFnxDOjdiXdTlC8ngVccQD88uHXTx5RUQOSEnarDYgJMjDagwAQszcOusjvmf4YqWsxoD1+MY+oAJRmpw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   thirty-two@1.0.2:
     resolution: {integrity: sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==}
@@ -4063,6 +4195,14 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4114,6 +4254,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@angular-devkit/core@19.2.24(chokidar@4.0.3)':
     dependencies:
@@ -4439,7 +4584,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -5064,6 +5222,17 @@ snapshots:
 
   '@ioredis/commands@2.0.0': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5275,6 +5444,9 @@ snapshots:
   '@phc/format@1.0.0': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@playwright/test@1.63.0':
     dependencies:
@@ -5585,6 +5757,25 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@vitest/coverage-v8@3.2.7(supports-color@8.1.1)(vitest@3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6(supports-color@8.1.1)
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@22.20.1)(happy-dom@15.11.7)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@8.1.1)(terser@5.51.0)(tsx@4.23.12)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -5761,9 +5952,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.3.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
 
@@ -5779,6 +5974,12 @@ snapshots:
   array-timsort@1.0.3: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   atomic-sleep@1.0.0: {}
 
@@ -5816,6 +6017,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -6037,6 +6242,8 @@ snapshots:
     optionalDependencies:
       postgres: 3.4.9
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -6044,6 +6251,8 @@ snapshots:
   electron-to-chromium@1.5.415: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -6283,6 +6492,11 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.2(esbuild@0.28.2)(lightningcss@1.32.0)(postcss@8.5.26)):
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -6319,6 +6533,15 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.6
@@ -6336,6 +6559,8 @@ snapshots:
   has-flag@4.0.0: {}
 
   help-me@5.0.0: {}
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -6385,7 +6610,34 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6(supports-color@8.1.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterare@1.2.1: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jest-worker@27.5.1:
     dependencies:
@@ -6396,6 +6648,8 @@ snapshots:
   jiti@2.7.0: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -6541,6 +6795,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.5.2: {}
 
   lucide-react@0.469.0(react@19.1.0):
@@ -6554,6 +6810,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   memfs@3.5.3:
     dependencies:
@@ -6574,6 +6840,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.18
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -6678,6 +6948,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6692,6 +6964,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -7037,6 +7314,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -7044,6 +7327,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
 
   strip-bom@3.0.0: {}
 
@@ -7100,6 +7387,12 @@ snapshots:
       acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
 
   thirty-two@1.0.2: {}
 
@@ -7352,6 +7645,18 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/scripts/coverage-delta.mjs
+++ b/scripts/coverage-delta.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/*
+ * Coverage-delta guard (issue #355). Fails a TEST-ONLY PR that increases covered
+ * lines in NO file — i.e. a tautological test that asserts nothing real. Passes:
+ * non-test-only PRs (out of scope), a missing baseline (first run), or a test-only
+ * PR that raises covered lines in >=1 file.
+ *
+ * Usage: node scripts/coverage-delta.mjs --pr <summary> --baseline <summary> --base <ref>
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const arg = (name, def) => {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : def;
+};
+const prPath = arg("--pr", "coverage/coverage-summary.json");
+const basePath = arg("--baseline", "baseline/coverage-summary.json");
+const base = arg("--base", "origin/main");
+
+const pass = (m) => {
+  console.log(`PASS coverage-delta: ${m}`);
+  process.exit(0);
+};
+const fail = (m) => {
+  console.error(`FAIL coverage-delta: ${m}`);
+  process.exit(1);
+};
+
+// 1. No baseline (first PR before any nightly, or download failed) -> PASS.
+if (!existsSync(basePath)) pass(`no baseline artifact at ${basePath}; cannot compute a delta`);
+
+// 2. Classify the PR. Only PURE test-only PRs are in scope for the guard.
+const changed = execSync(`git diff --name-only ${base}...HEAD`, { encoding: "utf8" })
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean);
+if (changed.length === 0) pass("no changed files detected");
+
+const isTestOrSupport = (f) =>
+  /\.test\.ts$/.test(f) ||
+  /(^|\/)__(tests|fixtures|mocks)__\//.test(f) ||
+  /\.md$/.test(f) ||
+  /(^|\/)vitest\.config\.ts$/.test(f) ||
+  f === "vitest.coverage.base.ts";
+
+const nonTest = changed.filter((f) => !isTestOrSupport(f));
+if (nonTest.length > 0) {
+  pass(`PR changes ${nonTest.length} non-test file(s); the guard only applies to test-only PRs`);
+}
+
+// 3. Test-only PR: require a covered-lines increase in at least one file.
+const pr = JSON.parse(readFileSync(prPath, "utf8"));
+const baseline = JSON.parse(readFileSync(basePath, "utf8"));
+const coveredLines = (summary, file) => summary[file]?.lines?.covered ?? 0;
+
+const allFiles = new Set([
+  ...Object.keys(pr).filter((k) => k !== "total"),
+  ...Object.keys(baseline).filter((k) => k !== "total"),
+]);
+
+const improved = [];
+for (const file of allFiles) {
+  if (coveredLines(pr, file) > coveredLines(baseline, file)) {
+    improved.push({ file, before: coveredLines(baseline, file), after: coveredLines(pr, file) });
+  }
+}
+
+if (improved.length === 0) {
+  fail(
+    "test-only PR did not raise covered lines in ANY file (tautological test?). " +
+      "Compared the PR coverage against the nightly baseline; no file's lines.covered increased.",
+  );
+}
+
+console.log("Files with increased covered lines:");
+for (const i of improved) console.log(`  ${i.file}: ${i.before} -> ${i.after}`);
+pass(`test-only PR raised covered lines in ${improved.length} file(s)`);

--- a/scripts/merge-coverage.mjs
+++ b/scripts/merge-coverage.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/*
+ * Merge every package's coverage/coverage-summary.json (pnpm -r runs each package
+ * separately, so there are N of them) into one repo-wide coverage/coverage-summary.json
+ * keyed by REPO-RELATIVE file path. Re-keying to repo-relative is what lets the
+ * nightly baseline (built in one checkout dir) and a PR run (a different checkout
+ * dir) be compared file-by-file. Run from the repo root. Issue #355.
+ */
+import { readFileSync, writeFileSync, mkdirSync, globSync } from "node:fs";
+import { relative, resolve, join } from "node:path";
+
+const ROOT = process.cwd();
+
+const files = globSync("**/coverage/coverage-summary.json", { cwd: ROOT }).filter(
+  (f) => !f.includes("node_modules") && f.replace(/\\/g, "/") !== "coverage/coverage-summary.json",
+);
+
+const merged = {}; // repoRelPath -> metrics
+
+for (const f of files) {
+  const json = JSON.parse(readFileSync(resolve(ROOT, f), "utf8"));
+  for (const [key, metrics] of Object.entries(json)) {
+    if (key === "total") continue; // recomputed below
+    // v8 summary keys are absolute paths; re-key to repo-relative, POSIX slashes.
+    const repoRel = relative(ROOT, key).split("\\").join("/");
+    merged[repoRel] = metrics;
+  }
+}
+
+const total = {};
+for (const cat of ["lines", "statements", "functions", "branches"]) {
+  let covered = 0;
+  let totalN = 0;
+  for (const m of Object.values(merged)) {
+    covered += m[cat]?.covered ?? 0;
+    totalN += m[cat]?.total ?? 0;
+  }
+  total[cat] = { covered, total: totalN, skipped: 0, pct: totalN ? +((covered / totalN) * 100).toFixed(2) : 100 };
+}
+
+mkdirSync(join(ROOT, "coverage"), { recursive: true });
+writeFileSync(join(ROOT, "coverage", "coverage-summary.json"), JSON.stringify({ total, ...merged }, null, 2) + "\n");
+console.log(`Merged ${files.length} package summaries -> coverage/coverage-summary.json (${Object.keys(merged).length} files)`);

--- a/vitest.coverage.base.ts
+++ b/vitest.coverage.base.ts
@@ -1,0 +1,29 @@
+/*
+ * Shared coverage config (issue #355), imported by every package's
+ * vitest.config.ts. Coverage activates only when COVERAGE=1 is in the env
+ * (the `test:coverage` root script sets it), so the normal `pnpm test` inner
+ * loop stays uninstrumented and fast.
+ *
+ * Why an env var, not `--coverage`: `pnpm -r test -- --coverage` does NOT forward
+ * the flag to vitest (pnpm consumes args after `--` before the package script),
+ * so `enabled` keyed on an env var is the reliable cross-workspace switch.
+ *
+ * Reporters: json-summary (the machine-readable coverage/coverage-summary.json
+ * the delta check consumes) + text (a human summary in the run log).
+ *
+ * No `vitest` type import here: this file is imported by web/ too, whose tsconfig
+ * does not resolve `vitest/config` for a file outside its own root. Each package's
+ * defineConfig({ test: { coverage } }) type-checks the shape at its use site.
+ */
+export const coverage = {
+  enabled: process.env.COVERAGE === "1",
+  provider: "v8" as const,
+  reporter: ["json-summary", "text"] as string[],
+  reportsDirectory: "./coverage",
+  // Only count first-party source; never count tests or fixtures as covered.
+  include: ["src/**/*.ts"],
+  exclude: ["src/**/*.test.ts", "src/**/*.d.ts", "src/**/__fixtures__/**", "src/**/__mocks__/**"],
+  // Emit a summary even for packages with zero tests, so the merge step never
+  // silently drops a package.
+  all: true,
+};

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitest/config";
+import { coverage } from "../vitest.coverage.base";
 
 // web/ had zero tests (issue #351). Pure helpers (src/lib/utils.ts and future
 // lib logic) run under the node environment; component/DOM tests can add
 // jsdom/happy-dom later without changing this include.
-export default defineConfig({ test: { environment: "node", include: ["src/**/*.test.ts"] } });
+export default defineConfig({ test: { environment: "node", include: ["src/**/*.test.ts"], coverage } });


### PR DESCRIPTION
## Coverage tooling + coverage-delta check (closes #355)

Adds coverage measurement and a CI ratchet that fails a **test-only PR which raises covered lines in no file** (a tautological test) — the guard that lets agent-authored tests be merged with limited human review.

### Coverage tooling
- `@vitest/coverage-v8@^3.2.7` (root devDep); a shared `vitest.coverage.base.ts` imported by all 10 vitest configs (json-summary + text reporters, `src/**/*.ts` only, tests/fixtures excluded, `all: true`).
- Coverage is **opt-in via `COVERAGE=1`** (the `test:coverage` script sets it), so the normal `pnpm test` inner loop stays uninstrumented and fast. Why an env var and not `--coverage`: `pnpm -r test -- --coverage` does **not** forward the flag through the package script (pnpm consumes it) — verified.
- `scripts/merge-coverage.mjs` combines the per-package `coverage-summary.json` files (pnpm runs each package separately) into one repo-wide summary **re-keyed to repo-relative paths**, so the nightly baseline (one checkout dir) and a PR run (another) compare file-by-file.

### CI (this issue authorizes .github / package.json / config edits)
- **`coverage-baseline`** job (nightly cron / push-main only): runs coverage, merges, uploads `coverage-summary.json` as an artifact (14-day retention). Baseline is an artifact, **not** a committed file — a committed baseline would be a config the test-only lane can't update, deadlocking it.
- **`coverage-delta`** job (PR, non-e2e-only): downloads the latest nightly baseline from main (`dawidd6/action-download-artifact`, fallback-PASS if none yet), runs coverage, and runs `scripts/coverage-delta.mjs`. Added to the **`CI gate`** needs so it's gated, not skippable.
- New `non_e2e` paths-filter output exempts **e2e-only PRs** (Playwright has no vitest coverage).

### The delta logic (`scripts/coverage-delta.mjs`)
Classifies the PR via `git diff --name-only origin/main...HEAD`. Only a **pure test-only** PR is in scope; if it changes any non-test source, the guard passes (source changes legitimately move coverage either way). For a test-only PR it fails when **no file's `lines.covered` increased** vs baseline. Missing baseline → PASS.

### Verified locally (all acceptance criteria proven)
- ✅ `pnpm test:coverage` emits per-package summaries; merge → one repo-wide summary (149 files, 47.4% lines).
- ✅ **Tautological test** (`expect(true).toBe(true)`) → 0 files improved → delta **FAILS**.
- ✅ **Real test** (exercising `contract/src/form.ts`) → `form.ts: 0→60` covered → delta **PASSES**.
- ✅ Normal `pnpm test` stays uninstrumented (no coverage dir); root type-check clean; full suite green.

### One fix flagged (not weakening — a pre-existing flake coverage exposed)
`apps/worker/src/jobs/lease.test.ts` "derives the expiry from ttlSeconds" is a DB timing test; under v8 instrumentation its round-trips occasionally exceed the 3s TTL and the "still held" assertion raced (~1/4 runs). Fixed with `{ retry: 2, timeout: 20_000 }` on that one test — **no assertion changed** (a passing attempt must still satisfy every assertion); this also hardens the existing `verify` job against the same latent flake. Author's own comment already notes they bumped 1s→3s for load; coverage is simply more load.

*QA program — phase 2 test-infra. Design assisted by an Opus reasoning pass; validated + corrected against the real code before shipping.*
