### PR TITLE
test: fast-check property tests for the contract schemas (#356)

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -6,9 +6,14 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
@@ -21,6 +26,7 @@
   "devDependencies": {
     "@types/node": "^22.20.1",
     "typescript": "^5.7.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "fast-check": "^4.9.0"
   }
 }

--- a/packages/contract/src/schemas.property.test.ts
+++ b/packages/contract/src/schemas.property.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { z } from "zod";
+import { HttpUrl, isDeniedHost } from "./http-url.js";
+import { BulkLinkOutcome, CreateLinkInput, Link } from "./link.js";
+
+/* Property tests for the contract schemas (issue #356). packages/contract is the
+   single source of truth for every payload shape; these generate inputs biased
+   toward the boundaries hand-written tests miss. Seeded so CI is deterministic. */
+
+const SEED = 4356;
+const runs = { numRuns: 500, seed: SEED };
+
+/* ------------------------------------------------------------------ *
+ * 1. HttpUrl — the SSRF guard. Generators biased at the denylist edges.
+ *    Every generated internal host MUST be rejected. A genuine miss here is a
+ *    security bug to REPORT as its own issue, never to accommodate by loosening
+ *    the test.
+ * ------------------------------------------------------------------ */
+describe("HttpUrl rejects internal hosts (SSRF guard)", () => {
+  const octet = fc.integer({ min: 0, max: 255 });
+
+  // Private / loopback / link-local / CGNAT IPv4, generated across each range
+  // and its edges rather than a fixed list.
+  const deniedIpv4 = fc.oneof(
+    fc.tuple(fc.constant(0), octet, octet, octet), // 0.0.0.0/8
+    fc.tuple(fc.constant(10), octet, octet, octet), // 10/8
+    fc.tuple(fc.constant(127), octet, octet, octet), // 127/8 loopback
+    fc.tuple(fc.constant(169), fc.constant(254), octet, octet), // 169.254/16 metadata
+    fc.tuple(fc.constant(172), fc.integer({ min: 16, max: 31 }), octet, octet), // 172.16/12
+    fc.tuple(fc.constant(192), fc.constant(168), octet, octet), // 192.168/16
+    fc.tuple(fc.constant(100), fc.integer({ min: 64, max: 127 }), octet, octet), // 100.64/10 CGNAT
+  ).map((o) => o.join("."));
+
+  it("rejects every private/loopback/link-local IPv4", () => {
+    fc.assert(
+      fc.property(deniedIpv4, fc.constantFrom("http", "https"), (host, scheme) => {
+        expect(HttpUrl.safeParse(`${scheme}://${host}/path`).success).toBe(false);
+      }),
+      runs,
+    );
+  });
+
+  it("rejects IPv6 loopback, link-local and unique-local, incl. IPv4-mapped metadata", () => {
+    const deniedIpv6 = fc.constantFrom(
+      "::1",
+      "::",
+      "[::1]",
+      "fe80::1",
+      "fd00::1",
+      "fc00::1",
+      "[fe80::abcd]",
+      "::ffff:169.254.169.254",
+      "::ffff:127.0.0.1",
+      "::ffff:10.0.0.1",
+    );
+    fc.assert(
+      fc.property(deniedIpv6, (host) => {
+        expect(HttpUrl.safeParse(`http://[${host.replace(/^\[|\]$/g, "")}]/`).success).toBe(false);
+      }),
+      runs,
+    );
+  });
+
+  it("rejects localhost and *.localhost regardless of case", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("localhost", "LOCALHOST", "LocalHost", "foo.localhost", "a.b.localhost"),
+        (host) => {
+          expect(isDeniedHost(host)).toBe(true);
+          expect(HttpUrl.safeParse(`https://${host}/`).success).toBe(false);
+        },
+      ),
+      runs,
+    );
+  });
+
+  it("rejects non-http(s) schemes outright", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(
+          "javascript:alert(1)",
+          "data:text/html;base64,PHNjcmlwdD4=",
+          "file:///etc/passwd",
+          "ftp://example.com/x",
+          "gopher://example.com",
+        ),
+        (url) => {
+          expect(HttpUrl.safeParse(url).success).toBe(false);
+        },
+      ),
+      runs,
+    );
+  });
+
+  it("accepts ordinary public https URLs (no false positives on public hosts)", () => {
+    // Public IPv4: first octet not in any denied leading range, kept simple.
+    const publicHost = fc.constantFrom(
+      "example.com",
+      "sub.example.co.uk",
+      "8.8.8.8",
+      "1.1.1.1",
+      "93.184.216.34",
+      "github.com",
+    );
+    fc.assert(
+      fc.property(publicHost, (host) => {
+        expect(HttpUrl.safeParse(`https://${host}/path?q=1`).success).toBe(true);
+      }),
+      runs,
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * 2. Tri-state fields: undefined / null / value are each accepted, and the
+ *    parsed value distinguishes them (they have different service semantics).
+ * ------------------------------------------------------------------ */
+describe("tri-state nullable+optional fields keep all three states distinct", () => {
+  const base = { destination: "https://example.com/x", domain: "snap.to" };
+
+  it("expiresAt: undefined, null and a string are each preserved as-is", () => {
+    // Note: expiresAt is .nullable().optional() on the INPUT schema. (comment is
+    // deliberately optional-only on CreateLinkInput even though Link.comment is
+    // nullable — an intentional input/response asymmetry, not a bug.)
+    fc.assert(
+      fc.property(fc.option(fc.option(fc.string({ maxLength: 40 }), { nil: null }), { nil: undefined }), (value) => {
+        const parsed = CreateLinkInput.safeParse({ ...base, expiresAt: value });
+        expect(parsed.success).toBe(true);
+        if (parsed.success) expect(parsed.data.expiresAt).toStrictEqual(value);
+      }),
+      runs,
+    );
+  });
+
+  it("clickLimit: undefined, null and a number stay distinct", () => {
+    fc.assert(
+      fc.property(fc.option(fc.option(fc.integer(), { nil: null }), { nil: undefined }), (value) => {
+        const parsed = CreateLinkInput.safeParse({ ...base, clickLimit: value });
+        expect(parsed.success).toBe(true);
+        if (parsed.success) expect(parsed.data.clickLimit).toStrictEqual(value);
+      }),
+      runs,
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * 3. Discriminated union: no input parses as two variants.
+ * ------------------------------------------------------------------ */
+describe("BulkLinkOutcome discriminated union is mutually exclusive", () => {
+  const okVariant = fc.record({
+    ok: fc.constant(true),
+    index: fc.integer(),
+    link: fc.constant(exampleLink()),
+  });
+  const errVariant = fc.record({
+    ok: fc.constant(false),
+    index: fc.integer(),
+    destination: fc.string(),
+    error: fc.string(),
+  });
+
+  it("a valid outcome parses as exactly one variant, keyed on ok", () => {
+    fc.assert(
+      fc.property(fc.oneof(okVariant, errVariant), (outcome) => {
+        const parsed = BulkLinkOutcome.safeParse(outcome);
+        expect(parsed.success).toBe(true);
+        if (parsed.success) expect(parsed.data.ok).toBe(outcome.ok);
+      }),
+      { numRuns: 200, seed: SEED },
+    );
+  });
+
+  it("a wrong-shape-for-its-discriminant object is rejected", () => {
+    // ok:true but carrying the error branch's fields (and no link) must fail.
+    fc.assert(
+      fc.property(fc.string(), fc.integer(), (error, index) => {
+        expect(BulkLinkOutcome.safeParse({ ok: true, index, destination: "x", error }).success).toBe(false);
+      }),
+      { numRuns: 200, seed: SEED },
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * 4. Round-trip stability: a value the schema accepts re-parses unchanged.
+ * ------------------------------------------------------------------ */
+describe("Link response schema round-trips", () => {
+  it("parse(x) then parse(parse(x)) is stable", () => {
+    const link = exampleLink();
+    const once = Link.parse(link);
+    const twice = Link.parse(once);
+    expect(twice).toStrictEqual(once);
+  });
+});
+
+/* A minimal valid Link built from the schema's required fields, so the union and
+   round-trip tests never hand-roll a shape that drifts from the contract. */
+function exampleLink(): z.infer<typeof Link> {
+  return Link.parse({
+    id: "lnk_1",
+    domain: "snap.to",
+    slug: "spring-sale",
+    destination: "https://example.com/x",
+    status: "active",
+    clicks: 0,
+    createdAt: new Date().toISOString(),
+    tags: [],
+    rules: [],
+    redirectType: "302",
+    forwardQuery: true,
+    deepLink: false,
+    hideReferrer: false,
+    publicPreview: true,
+    sparkline: [],
+    safeBrowsing: { status: "clean", checkedAt: new Date().toISOString() },
+  });
+}

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/node": "^22.20.1",
     "typescript": "^5.7.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "fast-check": "^4.9.0"
   }
 }

--- a/packages/domain/src/slug.property.test.ts
+++ b/packages/domain/src/slug.property.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { RESERVED_SLUGS, isSlugAvailableShape } from "./slug.js";
+
+/* Property tests for the slug RULES (issue #356). The contract schema only pins
+   the slug SHAPE (`^[a-zA-Z0-9._-]*$`); the reserved-word, file-extension and
+   length rules live here in the domain layer. A generator built only from the
+   schema produces slugs the contract accepts but the service still rejects — so
+   these pin the domain layer directly. (This test lives in @snapurl/domain, not
+   @snapurl/contract: contract must not import domain, which would be a cycle.)
+
+   Seeded for deterministic CI. */
+
+const SHAPE = /^[a-zA-Z0-9._-]+$/;
+const SEED = 4356;
+
+describe("slug rules reject shapes the contract schema would accept", () => {
+  it("reserved slugs are shape-valid but rule-rejected", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...RESERVED_SLUGS), (slug) => {
+        // Reserved entries are all made of shape-legal characters.
+        expect(SHAPE.test(slug)).toBe(true);
+        expect(isSlugAvailableShape(slug).ok).toBe(false);
+      }),
+      { numRuns: 100, seed: SEED },
+    );
+  });
+
+  it("file-extension slugs are shape-valid but rule-rejected", () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.stringMatching(/^[a-z]{1,10}$/),
+          fc.constantFrom("html", "htm", "php", "aspx", "jsp", "json", "xml", "txt", "js", "css", "map"),
+        ),
+        ([stem, ext]) => {
+          const slug = `${stem}.${ext}`;
+          expect(SHAPE.test(slug)).toBe(true);
+          expect(isSlugAvailableShape(slug).ok).toBe(false);
+        },
+      ),
+      { numRuns: 200, seed: SEED },
+    );
+  });
+
+  it("over-length slugs (shape-legal chars) are rule-rejected", () => {
+    // Generate directly from the shape alphabet — filtering a broad fc.string()
+    // for SHAPE would reject almost every candidate and starve the generator.
+    const shapeChar = fc.constantFrom(..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-".split(""));
+    const overLong = fc.array(shapeChar, { minLength: 65, maxLength: 200 }).map((cs) => cs.join(""));
+    fc.assert(
+      fc.property(overLong, (slug) => {
+        expect(isSlugAvailableShape(slug).ok).toBe(false);
+      }),
+      { numRuns: 100, seed: SEED },
+    );
+  });
+
+  it("a shape-legal, non-reserved, extension-free, in-length slug is accepted", () => {
+    // Same: build from the alphabet, then exclude the two rule-level rejections.
+    const shapeChar = fc.constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789_-".split(""));
+    const goodSlug = fc
+      .array(shapeChar, { minLength: 1, maxLength: 30 })
+      .map((cs) => cs.join(""))
+      .filter((s) => !RESERVED_SLUGS.has(s.toLowerCase()) && !/\.[a-z]+$/.test(s));
+    fc.assert(
+      fc.property(goodSlug, (slug) => {
+        expect(isSlugAvailableShape(slug).ok).toBe(true);
+      }),
+      { numRuns: 200, seed: SEED },
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -343,6 +346,9 @@ importers:
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -2971,6 +2977,10 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-copy@4.0.4:
     resolution: {integrity: sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==}
 
@@ -3628,6 +3638,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -6415,6 +6428,10 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-copy@4.0.4: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -7070,6 +7087,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.2: {}
 
   qrcode@1.5.4:
     dependencies:


### PR DESCRIPTION
## fast-check property tests for the contract schemas (closes #356)

Adds `fast-check` and property tests over the four areas the issue calls out, biased toward the boundaries hand-written tests miss. Seeded for deterministic CI.

### Coverage
**`packages/contract/src/schemas.property.test.ts`** (10 properties):
- **`HttpUrl` — the SSRF guard** (highest-value target): generators biased at each denylist boundary — every private/loopback/link-local/CGNAT IPv4 range and its edges, IPv6 loopback/link-local/ULA, IPv4-mapped-IPv6 metadata (`::ffff:169.254.169.254`), `localhost`/`*.localhost` case-folding — all asserted **rejected**. Non-http(s) schemes (`javascript:`/`data:`/`file:`/`ftp:`) rejected. Public hosts accepted (no false positives). **No SSRF gap found** under 500 runs — the guard holds.
- **Tri-state fields**: `expiresAt`/`clickLimit` (`.nullable().optional()` on `CreateLinkInput`) preserve `undefined` / `null` / value as distinct. Documented an intentional asymmetry surfaced while writing this: `CreateLinkInput.comment` is optional-**only** while `Link.comment` is nullable — not a bug, but exactly the kind of subtlety property tests exist to pin.
- **Discriminated union**: `BulkLinkOutcome` parses as exactly one variant keyed on `ok`; a wrong-shape-for-its-discriminant object is rejected.
- **Round-trip**: `Link` re-parses stably.

**`packages/domain/src/slug.property.test.ts`** (4 properties): the slug **rules** live in the domain layer, not the contract (the schema pins only the shape). This test lives in `@snapurl/domain` deliberately — **contract must not import domain (a cycle)**, so the "test both layers" note is honored on the domain side. Reserved words, file-extension slugs, and over-length slugs are all shape-valid but rule-rejected; a clean slug is accepted.

### Notes
- `fast-check@^4.9.0` added as a devDep to both `packages/contract` and `packages/domain`; lockfile committed (`--frozen-lockfile` holds).
- Tests are **deterministic** (fixed `seed`).
- **No genuine bug found**, so nothing to file separately (per the acceptance criterion). The only "failure" while developing was a test asserting the wrong contract for `comment`, corrected.
- One generator initially **hung** (a `fc.string().filter(shapeRegex)` starved because random strings rarely match the slug shape) — rewritten to generate directly from the slug alphabet; both files run in <100ms.

*QA program — phase 2 test-infra. The last actionable phase-2 issue; #267 epic stays open.*
