### PR TITLE
test(e2e): edit and delete a link journey

### DIFF
--- a/e2e/tests/edit-delete-link.spec.ts
+++ b/e2e/tests/edit-delete-link.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { seedSession } from "../support/session";
+
+/* E2E journey: edit a link's destination, then delete the link. Builds on the
+   #353 harness — fixtures mode (no API/DB), accessible-name selectors only, and
+   a seeded fixture link (spring-sale, id lnk_spring) as the subject. Fixture
+   state resets on a full page load, so each test starts from a clean goto. */
+
+test.describe("edit and delete a link", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSession(page);
+  });
+
+  test("an authenticated user can edit a link's destination", async ({ page }) => {
+    await page.goto("/links");
+    // Open the seeded link's detail page via its short-link in the row.
+    await page.getByRole("link", { name: /spring-sale/ }).first().click();
+    await expect(page).toHaveURL(/\/links\/lnk_spring$/);
+
+    // Toggle the edit form open and change the destination.
+    const newDestination = "https://example.com/e2e/edited-destination";
+    await page.getByRole("button", { name: "Edit" }).click();
+    const destination = page.getByPlaceholder("https://example.com/where-it-should-go");
+    await expect(destination).toBeVisible();
+    await destination.fill(newDestination);
+    await page.getByRole("button", { name: "Save destination" }).click();
+
+    // The edit card closes (Save gone) and the new destination is reflected in
+    // the page sub-heading ("→ <destination> · created ...").
+    await expect(page.getByRole("button", { name: "Save destination" })).toBeHidden();
+    await expect(page.getByText(newDestination, { exact: false })).toBeVisible();
+  });
+
+  test("an authenticated user can delete a link and it leaves the list", async ({ page }) => {
+    await page.goto("/links");
+    // Confirm the target is present in the list first.
+    await expect(page.getByRole("button", { name: /Copy short link .+\/spring-sale$/ })).toBeVisible();
+
+    await page.getByRole("link", { name: /spring-sale/ }).first().click();
+    await expect(page).toHaveURL(/\/links\/lnk_spring$/);
+
+    // Delete is a two-step confirm: "Delete" -> "Delete for good".
+    await page.getByRole("button", { name: "Delete this link" }).click();
+    await page.getByRole("button", { name: "Delete for good" }).click();
+
+    // The page navigates back to the list, and the deleted link is gone. (Fixture
+    // state persists across this client-side nav — no full reload — so the delete
+    // is visible in the list.)
+    await expect(page).toHaveURL(/\/links$/);
+    await expect(page.getByRole("button", { name: /Copy short link .+\/spring-sale$/ })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## E2E journey: edit / delete a link

Second Playwright journey (after the #353 create-link foundation), expanding browser coverage of the core link lifecycle. Fixtures mode, accessible-name selectors only, no app changes.

### Flow (`e2e/tests/edit-delete-link.spec.ts`)
- **Edit:** seed session → `/links` → click the seeded `spring-sale` row → land on `/links/lnk_spring` → "Edit" → fill a new destination → "Save destination" → assert the edit card closes and the new destination shows in the page sub-heading.
- **Delete:** `/links` → confirm the row is present → open the link → "Delete this link" → "Delete for good" → assert redirect to `/links` and the row is gone.

Both drive the UI end to end (no session-seed shortcut past the flow itself) and use `getByRole`/`getByPlaceholder` against the accessible names from #352. The seeded fixture link `spring-sale` (id `lnk_spring`) is the subject; fixture state resets per full page load.

### Verified locally
`pnpm --filter snapurl-e2e test:e2e` (this spec) — **2/2 passed**, ~3s each. e2e-only change, so the coverage-delta ratchet exempts it (non_e2e paths-filter).

*E2E journey expansion — 1 of 5 (edit/delete, routing rules, QR, analytics, login form).*
