### PR TITLE
test(e2e): QR studio journey

### DIFF
--- a/e2e/tests/qr-code.spec.ts
+++ b/e2e/tests/qr-code.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { seedSession } from "../support/session";
+
+/* E2E journey: the QR studio. QR generation and download are entirely client-side
+   (the `qrcode` lib) — no server round-trip — so this asserts the preview renders,
+   a style control changes it, and the PNG/SVG downloads actually fire. Fixtures
+   mode (a seeded link supplies the value), accessible-name selectors. */
+
+test.describe("QR studio", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSession(page);
+  });
+
+  test("renders a QR preview, restyles it, and downloads PNG and SVG", async ({ page }) => {
+    await page.goto("/qr");
+
+    // The preview is an inline SVG generated from the selected link's short URL.
+    const preview = page.locator("svg").first();
+    await expect(preview).toBeVisible();
+
+    // Restyle: pick a non-default foreground colour swatch; the preview must stay
+    // rendered (it re-generates locally from the new colour).
+    await page.getByRole("button", { name: "Foreground colour #1F5FD4" }).click();
+    await expect(preview).toBeVisible();
+
+    // The header "Download" button produces a PNG entirely client-side.
+    const pngDownload = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Download", exact: true }).click();
+    const png = await pngDownload;
+    expect(png.suggestedFilename()).toMatch(/\.png$/);
+
+    // The export card's SVG button produces an SVG. Its label is "SVG …" — match
+    // the button whose accessible name contains SVG.
+    const svgDownload = page.waitForEvent("download");
+    await page.getByRole("button", { name: /SVG/ }).click();
+    const svg = await svgDownload;
+    expect(svg.suggestedFilename()).toMatch(/\.svg$/);
+  });
+});


### PR DESCRIPTION
## E2E journey: QR studio

Fourth Playwright journey. Covers the QR studio — preview render, restyle, and the client-side PNG/SVG downloads. Fixtures mode (a seeded link supplies the QR value), accessible-name selectors, no app changes.

### Flow (`e2e/tests/qr-code.spec.ts`)
- `/qr` → assert the inline QR preview SVG renders.
- Click a non-default foreground swatch ("Foreground colour #1F5FD4") → assert the preview stays rendered (re-generates locally).
- Click header **Download** → capture `page.waitForEvent("download")` → assert filename ends `.png`.
- Click the export card's **SVG** button → capture download → assert filename ends `.svg`.

QR generation/download is entirely client-side (`qrcode` lib, no server round-trip), so this genuinely exercises the download path via Playwright's download events.

### Verified locally
`pnpm --filter snapurl-e2e test:e2e` (this spec) — **1/1 passed**, ~1.3s. e2e-only change → coverage-delta exempt.

*E2E journey expansion — 3 of 5.*
