### PR TITLE
feat(web): TOTP challenge step on login (#377)

### DIFF
--- a/e2e/tests/2fa-login.spec.ts
+++ b/e2e/tests/2fa-login.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+/* E2E journey: 2FA login (issue #377). The login page now branches on the
+   LoginResult union — a 2FA-enabled account gets a TOTP challenge step instead
+   of an immediate session. In fixtures mode the account 2fa@snapurl.local
+   returns a challenge, and code 123456 verifies. No session seed — this drives
+   the real two-step form. */
+
+test.describe("2FA login", () => {
+  test("a 2FA account is challenged for a code, then reaches the dashboard", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByPlaceholder("you@company.com").fill("2fa@snapurl.local");
+    await page.getByPlaceholder("••••••••").fill("whatever-password");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // The password step is accepted but does NOT sign in — a TOTP challenge step
+    // appears instead of navigating to the dashboard.
+    const codeInput = page.getByRole("textbox", { name: "Authentication code" });
+    await expect(codeInput).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+
+    // A wrong code is rejected and keeps us on the challenge step.
+    await codeInput.fill("000000");
+    await page.getByRole("button", { name: "Verify" }).click();
+    await expect(codeInput).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+
+    // The correct fixture code completes the login and lands on the dashboard.
+    await codeInput.fill("123456");
+    await page.getByRole("button", { name: "Verify" }).click();
+    await expect(page).toHaveURL(/\/links$/);
+    await expect(page.getByRole("button", { name: /New link|Create a link/ }).first()).toBeVisible();
+  });
+
+  test("a non-2FA account still signs in directly (no challenge)", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByPlaceholder("you@company.com").fill("demo@snapurl.local");
+    await page.getByPlaceholder("••••••••").fill("demo-password-1234");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // No challenge step — straight to the dashboard.
+    await expect(page).toHaveURL(/\/links$/);
+    await expect(page.getByRole("textbox", { name: "Authentication code" })).toHaveCount(0);
+  });
+});

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -3,12 +3,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { AuthShell } from "@/components/auth/auth-shell";
 import { GoogleButton, hasGoogleAuth } from "@/components/auth/google-button";
 import { Button, Field, Input } from "@/components/ui";
-import { useLogin } from "@/lib/api/hooks";
+import { useLogin, useVerifyTotp } from "@/lib/api/hooks";
 
 const Schema = z.object({
   email: z.string().min(1, "Enter your email address").email("That doesn't look like an email address"),
@@ -19,16 +20,71 @@ type Values = z.infer<typeof Schema>;
 export default function LoginPage() {
   const router = useRouter();
   const login = useLogin();
+  const verify = useVerifyTotp();
   const { register, handleSubmit, formState } = useForm<Values>({ resolver: zodResolver(Schema) });
+
+  /* Login can come back as a session OR a TOTP challenge (LoginResult union). We
+     hold the challenge token here and swap the form for a code-entry step; only a
+     verified session navigates. Without this, a 2FA-enabled account could not
+     finish signing in (issue #377). */
+  const [challengeToken, setChallengeToken] = useState<string | null>(null);
+  const [code, setCode] = useState("");
+  const [codeError, setCodeError] = useState<string | null>(null);
 
   const onSubmit = handleSubmit(async (values) => {
     try {
-      await login.mutateAsync(values);
+      const result = await login.mutateAsync(values);
+      if ("challenge" in result) {
+        setChallengeToken(result.challengeToken);
+        return;
+      }
       router.push("/links");
     } catch {
       /* surfaced from login.error */
     }
   });
+
+  async function submitCode(e: React.FormEvent) {
+    e.preventDefault();
+    if (!challengeToken) return;
+    setCodeError(null);
+    try {
+      await verify.mutateAsync({ challengeToken, code });
+      router.push("/links");
+    } catch (err) {
+      setCodeError((err as Error).message || "That code isn't right.");
+    }
+  }
+
+  if (challengeToken) {
+    return (
+      <AuthShell title="Two-factor authentication" sub="Enter the 6-digit code from your authenticator app.">
+        <form onSubmit={submitCode} className="flex flex-col gap-3.5">
+          <Field label="Authentication code" error={codeError ?? undefined}>
+            <Input
+              value={code}
+              onChange={(e) => { setCode(e.target.value); setCodeError(null); }}
+              autoComplete="one-time-code"
+              inputMode="numeric"
+              placeholder="123456"
+              aria-label="Authentication code"
+              autoFocus
+            />
+          </Field>
+          <Button type="submit" variant="primary" size="lg" className="justify-center" disabled={verify.isPending || code.length < 6}>
+            {verify.isPending ? "Verifying…" : "Verify"}
+          </Button>
+          <button
+            type="button"
+            onClick={() => { setChallengeToken(null); setCode(""); setCodeError(null); }}
+            className="text-[12.5px] text-ink-3 text-center bg-transparent border-0 cursor-pointer"
+          >
+            Back to sign in
+          </button>
+        </form>
+      </AuthShell>
+    );
+  }
 
   return (
     <AuthShell title="Welcome back" sub="Sign in to your SnapURL workspace.">

--- a/web/src/lib/api/fixtures.ts
+++ b/web/src/lib/api/fixtures.ts
@@ -20,6 +20,7 @@ import type {
   SubmitReportResult,
   TotpRecoveryCodes,
   TotpSetup,
+  TotpChallenge,
   UnlockLinkResult,
   UpdateLinkInput,
   UpdateWorkspaceInput,
@@ -662,7 +663,17 @@ export async function fixtureRequest<T>(
   let data: unknown;
 
   /* ---- auth ---- */
-  if (m(/^\/auth\/(login|register|oauth)$/)) data = SESSION;
+  if (m(/^\/auth\/login$/) && method === "POST") {
+    // A designated fixture account has 2FA on, so login returns a CHALLENGE
+    // rather than a session — this is what lets the TOTP login flow (issue #377)
+    // be exercised in fixtures mode. Everyone else signs in directly, as before.
+    const email = (opts.body as { email?: string })?.email ?? "";
+    if (email.toLowerCase() === "2fa@snapurl.local") {
+      data = { challenge: "totp", challengeToken: "fixture.totp.challenge" } satisfies TotpChallenge;
+    } else {
+      data = SESSION;
+    }
+  } else if (m(/^\/auth\/(register|oauth)$/)) data = SESSION;
   else if (m(/^\/auth\/me$/)) data = SESSION.user;
   else if (m(/^\/auth\/logout$/)) data = undefined;
   else if (m(/^\/auth\/2fa\/setup$/)) {
@@ -675,8 +686,13 @@ export async function fixtureRequest<T>(
     data = {
       recoveryCodes: Array.from({ length: 10 }, (_, i) => `${1000 + i * 137}-${7300 - i * 91}`),
     } satisfies TotpRecoveryCodes;
-  } else if (m(/^\/auth\/2fa\/verify$/)) data = SESSION;
-  else if (m(/^\/auth\/2fa\/disable$/)) data = undefined;
+  } else if (m(/^\/auth\/2fa\/verify$/)) {
+    // The fixture "correct" code is 123456; anything else is rejected, so the
+    // wrong-code path is exercisable too. The real server checks the TOTP.
+    const code = (opts.body as { code?: string })?.code ?? "";
+    if (code !== "123456") throw new Error("That code isn't right. Try again.");
+    data = SESSION;
+  } else if (m(/^\/auth\/2fa\/disable$/)) data = undefined;
   /* ---- workspace ---- */
   else if (m(/^\/workspaces\/current$/) && method === "PATCH") {
     Object.assign(WORKSPACE, opts.body as UpdateWorkspaceInput);


### PR DESCRIPTION
## Implement the TOTP challenge step on login (closes #377)

The login page had no second-factor step, so a 2FA-enabled account could not finish signing in — `onSubmit` navigated to `/links` unconditionally, ignoring that `login` returns a `LoginResult` union (`AuthSession | TotpChallenge`). The hooks layer already modelled this correctly (`useLogin` deliberately stores no tokens on a challenge; `useVerifyTotp()` already exists) — the only missing piece was the UI.

### Changes
- **`web/src/app/(auth)/login/page.tsx`** — branch on the login result: on a `TotpChallenge`, hold the `challengeToken` and render a **6-digit code step** (labelled "Authentication code") that completes via `useVerifyTotp`. Only a verified `AuthSession` navigates to `/links`. A wrong code surfaces an error and stays on the step; "Back to sign in" returns to the password form. The non-2FA path is unchanged.
- **`web/src/lib/api/fixtures.ts`** — `/auth/login` now returns a `TotpChallenge` for the designated account `2fa@snapurl.local` (everyone else still gets a session, unchanged), and `/auth/2fa/verify` accepts `123456` and rejects anything else — so the whole flow is exercisable in fixtures mode.
- **`e2e/tests/2fa-login.spec.ts`** — new Playwright journey: 2FA account → challenge step appears (no premature nav) → wrong code rejected → correct code → dashboard; plus a non-2FA account still signs in directly with no challenge.

### Verified locally
- `pnpm --filter snapurl-web type-check` clean; full web suite **168/168** (fixture-parity intact — the login/register dispatch split still satisfies the route patterns).
- Full e2e suite **8/8** green on this branch (login-form journey lands separately via #381).

### Notes
This is a real auth-path change, so it runs the full CI gate (not the e2e-exempt lane). Recovery-code entry is supported by the same `TotpVerifyInput` (code up to 40 chars); the UI accepts it. No security invariant touched — a challenge still stores no tokens until `/auth/2fa/verify` returns a session.
