### PR TITLE
test(e2e): settings profile and appearance journey

### DIFF
--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test";
+import { seedSession } from "../support/session";
+
+/* E2E journey: Settings > Appearance. Appearance is a real product feature
+   (web/src/components/theme/theme-provider.tsx) wired to a per-device store
+   (localStorage "snapurl.appearance") and applied to <html> — both by the
+   pre-paint script in web/src/app/layout.tsx before React mounts, and by the
+   provider after. It is NOT an API call, so this asserts on the resulting DOM
+   effect (the data-theme attribute and the controls' aria-pressed state), never
+   a network round-trip.
+
+   Settings is an authenticated /(app) route, so we seedSession first.
+   Selectors use accessible names only: the accent swatches carry
+   aria-label={accent.name} + aria-pressed, and the Theme/segmented controls are
+   aria-pressed buttons labelled Light / Match system / Dark. No CSS, no
+   data-testid. */
+
+test.describe("settings appearance", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSession(page);
+  });
+
+  test("choosing an accent and dark theme applies and survives a reload", async ({ page }) => {
+    await page.goto("/settings");
+    // The page rendered (not bounced to login) — the workspace name is in the head.
+    await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+
+    const html = page.locator("html");
+    // Default appearance is "match system" (mode ""), so no data-theme is set.
+    await expect(html).not.toHaveAttribute("data-theme", /.+/);
+
+    // --- Pick an accent. The swatch's accessible name is the accent name. ---
+    // "Cobalt" is the default (already pressed), so choose a different one so the
+    // assertion proves the click did something rather than matching the default.
+    const magenta = page.getByRole("button", { name: "Magenta" });
+    await expect(magenta).toHaveAttribute("aria-pressed", "false");
+    await magenta.click();
+    await expect(magenta).toHaveAttribute("aria-pressed", "true");
+    // Selecting an accent is mutually exclusive — the previous default un-presses.
+    await expect(page.getByRole("button", { name: "Cobalt" })).toHaveAttribute("aria-pressed", "false");
+
+    // --- Switch the Theme to Dark and see it applied to the document. ---
+    const dark = page.getByRole("button", { name: "Dark" });
+    await dark.click();
+    await expect(dark).toHaveAttribute("aria-pressed", "true");
+    await expect(html).toHaveAttribute("data-theme", "dark");
+    // A CSS custom property is the token the whole UI reads; the provider sets it.
+    await expect
+      .poll(() => page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue("--accent").trim()))
+      .not.toEqual("");
+
+    // --- Persistence: a full reload re-runs the pre-paint script from the
+    // localStorage the click wrote, so the choice must survive it. ---
+    await page.reload();
+    await expect(html).toHaveAttribute("data-theme", "dark");
+    await expect(page.getByRole("button", { name: "Dark" })).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByRole("button", { name: "Magenta" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("Reset to defaults clears a dark theme back to the system default", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+
+    const html = page.locator("html");
+
+    // Put the appearance into a non-default state first.
+    await page.getByRole("button", { name: "Dark" }).click();
+    await expect(html).toHaveAttribute("data-theme", "dark");
+
+    // Reset must tear that state down: mode returns to "match system", so the
+    // data-theme attribute is removed and Dark is no longer pressed. This is the
+    // negative/teardown case — a reset that left a stale attribute behind would
+    // keep forcing dark on every page for this device.
+    await page.getByRole("button", { name: "Reset to defaults" }).click();
+    await expect(html).not.toHaveAttribute("data-theme", /.+/);
+    await expect(page.getByRole("button", { name: "Dark" })).toHaveAttribute("aria-pressed", "false");
+    // Accent is back to the built-in default (Cobalt) rather than whatever was set.
+    await expect(page.getByRole("button", { name: "Cobalt" })).toHaveAttribute("aria-pressed", "true");
+  });
+});


### PR DESCRIPTION
## What

Adds `e2e/tests/settings.spec.ts` — the missing E2E coverage for the **Settings** flow (`/(app)/settings`), part of the E2E-coverage goal. Two Playwright cases against the existing fixtures-mode harness:

1. **Primary journey** — an authenticated user picks a non-default accent (Magenta) and switches the Theme to Dark, sees both applied to the document (`aria-pressed` on the controls, `data-theme="dark"` on `<html>`, a non-empty `--accent` CSS custom property), then **reloads** and the choice survives (the pre-paint script in `web/src/app/layout.tsx` re-applies it from `localStorage`).
2. **Negative / teardown case** — after forcing Dark, **Reset to defaults** must clear the state: `data-theme` is removed (back to "match system"), Dark un-presses, and the accent returns to the built-in Cobalt. A reset that left a stale `data-theme` behind would keep forcing dark on every page for that device.

## Why appearance, not a profile network call

Appearance is a genuine product feature wired to a per-device store (`localStorage "snapurl.appearance"`) and applied client-side — there is no API round-trip to assert on, so the spec asserts the resulting **DOM effect** exactly as intended. The Workspace "Name" field's `<label>` is not programmatically associated with its `<Input>` (same limitation the existing create-link spec documents), so a name journey could not use accessible-name selectors without touching app code; appearance gives a fully accessible, non-trivial journey.

## Conventions followed

- Fixtures mode (`NEXT_PUBLIC_USE_FIXTURES=true`), chromium, `testDir ./tests` — no new config.
- `seedSession(page)` in `beforeEach` (authenticated `/(app)` route).
- **Accessible-name selectors only** — `getByRole` on the accent swatches (`aria-label={accent.name}`) and the Theme segmented buttons; no CSS, no `data-testid`.
- One flow per file; top-of-file intent comment.

## Test evidence

Ran locally (`cd e2e && pnpm exec playwright test tests/settings.spec.ts`): **2 passed**.