### PR TITLE
test(e2e): custom domains journey

### DIFF
--- a/e2e/tests/domains.spec.ts
+++ b/e2e/tests/domains.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { seedSession } from "../support/session";
+
+/* E2E journey: an authenticated user brings their own custom domain. They add a
+   new domain, see it appear in the table as "Verifying DNS" with the DNS record
+   the app asks them to create, then run the DNS check and watch it go "Live".
+   A second case covers client-side validation rejecting a malformed domain.
+
+   Builds on the #353 harness — fixtures mode (no API/DB), accessible-name
+   selectors only (getByRole / getByPlaceholder — the Field label is not
+   programmatically associated so getByLabel is avoided), seeded auth session,
+   and a full-load fixture reset per test. Domains is an authenticated /(app)
+   route, so seedSession runs before the first navigation. */
+
+test.describe("custom domains", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSession(page);
+  });
+
+  test("an authenticated user can add a domain and verify it live", async ({ page }) => {
+    // A unique domain per run so the assertions cannot match a seeded fixture
+    // domain (snap.to / go.acme.com / acme.link).
+    const domain = `e2e-${Date.now().toString(36)}.example.com`;
+
+    // Full load (also the fixture reset) lands on the domains page.
+    await page.goto("/domains");
+    await expect(page).toHaveURL(/\/domains$/);
+
+    // Open the add-domain form. The primary action toggles between "＋ Add
+    // domain" and "Cancel"; match the add label specifically.
+    await page.getByRole("button", { name: /Add domain/ }).click();
+
+    // The domain input is addressed by its placeholder (the Field label is not
+    // associated). Typing a valid name enables the "Add domain" submit button.
+    await page.getByPlaceholder("go.example.com").fill(domain);
+    await page.getByRole("button", { name: "Add domain" }).click();
+
+    // The new domain appears in the status table. In fixtures a fresh domain
+    // starts as status "verifying" -> the row shows a "Verifying DNS" chip.
+    // The domain string also appears in the DNS setup card's record row (its
+    // Name cell), so the status row is anchored by its "Verifying DNS" chip +
+    // trailing "Check DNS" action to keep the locator unambiguous.
+    const row = page.getByRole("row", { name: new RegExp(`${domain}.*Verifying DNS.*Check DNS`) });
+    await expect(row).toBeVisible();
+
+    // The "Finish setting up <domain>" DNS card renders with the CNAME record.
+    await expect(page.getByText(`Finish setting up ${domain}`)).toBeVisible();
+    await expect(page.getByRole("cell", { name: "edge.snapurl.in" })).toBeVisible();
+
+    // Run the DNS check from the row. Fixtures flips the domain to live + SSL
+    // active, so its status chip becomes "Live" and the setup card disappears.
+    await row.getByRole("button", { name: "Check DNS" }).click();
+    await expect(
+      page.getByRole("row", { name: new RegExp(`${domain}.*Live`) }),
+    ).toBeVisible();
+    await expect(page.getByText(`Finish setting up ${domain}`)).toBeHidden();
+  });
+
+  test("a malformed domain is rejected client-side and not added", async ({ page }) => {
+    await page.goto("/domains");
+    await expect(page).toHaveURL(/\/domains$/);
+
+    // Wait for the table to finish loading (a seeded domain is present) so the
+    // "no new row" assertion is not racing the initial skeleton.
+    await expect(page.getByRole("cell", { name: "snap.to" }).first()).toBeVisible();
+
+    await page.getByRole("button", { name: /Add domain/ }).click();
+
+    // A non-empty but malformed value: the submit button is only disabled while
+    // the field is empty, so this string is submittable and must be rejected by
+    // the client-side AddDomainInput schema (regex requires a real TLD).
+    await page.getByPlaceholder("go.example.com").fill("notadomain");
+    await page.getByRole("button", { name: "Add domain" }).click();
+
+    // The validation message surfaces in the Field error and the form stays
+    // open; no row for the rejected value is added to the table.
+    await expect(page.getByText("That doesn't look like a domain name")).toBeVisible();
+    await expect(page.getByPlaceholder("go.example.com")).toBeVisible();
+    await expect(page.getByRole("cell", { name: "notadomain", exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What

Adds one new Playwright E2E spec `e2e/tests/domains.spec.ts` covering the **custom domains** flow (`/(app)/domains`), which had no E2E coverage.

## Cases (both pass locally, 2/2, stable across 2 runs)

1. **Add + verify a domain (primary journey)** — an authenticated user adds a unique-per-run domain, sees it appear in the status table as **Verifying DNS** with the **Finish setting up …** DNS card (CNAME → `edge.snapurl.in`), runs **Check DNS**, and the row flips to **Live** while the setup card disappears.
2. **Malformed domain rejected (negative/validation)** — a non-empty but malformed value (`notadomain`) is submittable (submit is only disabled while empty) and is rejected client-side by the `AddDomainInput` schema with *"That doesn't look like a domain name"*; the form stays open and no row is added.

## Conventions

Mirrors `create-link.spec.ts` / `edit-delete-link.spec.ts`: fixtures mode, `seedSession` in `beforeEach` (Domains is an authenticated `/(app)` route), accessible-name selectors only (`getByRole` / `getByPlaceholder` — no CSS, no `data-testid`, no `getByLabel` since the Field label isn't associated), one flow per file, top-of-file intent comment, unique-per-run values.

Every assertion verified against actual fixtures behavior in `web/src/lib/api/fixtures.ts` (add → `verifying`, verify → `live`). The status-table row is disambiguated from the DNS-card record row (both contain the domain string, since `dns.name = body.domain`) by anchoring on the status chip + `Check DNS` action.