### PR TITLE
fix(infra): grant CloudFront lambda:InvokeFunction on redirect Function URL

### DIFF
--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -997,6 +997,36 @@ export class SnapUrlStack extends Stack {
       comment: "SnapURL redirect edge",
     });
 
+    /* CloudFront needs BOTH lambda:InvokeFunctionUrl AND lambda:InvokeFunction
+       to reach an AWS_IAM Function URL through an Origin Access Control.
+       FunctionUrlOrigin.withOriginAccessControl() above grants only the first,
+       and that is not enough: with InvokeFunctionUrl alone every OAC-signed
+       request is refused at the auth boundary before the handler runs, so the
+       edge returns a blanket 403 for EVERY slug —
+         {"Message":"Forbidden. For troubleshooting Function URL authorization
+          issues, see: ...lambda/latest/dg/urls-auth.html"}
+       — while a direct `lambda invoke` still returns a correct 302 and the
+       function logs nothing at all, because it is never invoked. That is what
+       took production redirects down completely on 2026-09-10: every short
+       link 403'd for hours with the OAC, the resource policy SourceArn, the
+       signing config and the origin wiring all individually correct.
+       AWS documents both grants (see "Restricting access to a Lambda function
+       URL origin"): https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html
+       Do NOT drop this on the grounds that the OAC helper "already grants
+       invoke" — it grants the URL action, not the function action. SourceArn
+       scopes it to this distribution alone, so no other distribution (or
+       account) can invoke the redirect function. */
+    redirectFn.addPermission("AllowCloudFrontServicePrincipalInvokeFunction", {
+      principal: new iam.ServicePrincipal("cloudfront.amazonaws.com"),
+      action: "lambda:InvokeFunction",
+      sourceArn: Stack.of(this).formatArn({
+        service: "cloudfront",
+        region: "",
+        resource: "distribution",
+        resourceName: distribution.distributionId,
+      }),
+    });
+
     /* ---------------------------------------------------------
        Worker
        --------------------------------------------------------- */


### PR DESCRIPTION
Production redirects were fully down: every `snapurl.in/<slug>` returned HTTP 403.

## Root cause

CloudFront OAC to an `AWS_IAM` Lambda Function URL requires **two** grants to `cloudfront.amazonaws.com`:

| action | present before |
|---|---|
| `lambda:InvokeFunctionUrl` | yes |
| `lambda:InvokeFunction` | **no** |

`FunctionUrlOrigin.withOriginAccessControl()` emits only the first. With `InvokeFunctionUrl` alone the request is refused at the Function URL auth boundary **before the handler runs**, so the edge returned a blanket

```
403 {"Message":"Forbidden. For troubleshooting Function URL authorization issues, see: ...urls-auth.html"}
```

for every slug, while `aws lambda invoke` returned a correct 302 and the function logged nothing — because it was never invoked. [AWS documents both grants.](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html)

Everything else was individually correct and checked out: OAC `sigv4`/`always`/`lambda`, resource-policy `SourceArn` matching the distribution ARN, origin/behavior/OAC bindings, `OriginProtocolPolicy: https-only`, no custom error responses. `cdk diff` showed no drift, so a redeploy would not have fixed it.

## Fix

Add the second grant explicitly, scoped by `SourceArn` to this distribution so no other distribution or account can invoke the redirect function.

## Verification

The equivalent permission was applied to production out-of-band to end the outage, and redirects recovered immediately:

```
snapurl.in/BqkU4G6 -> 302 https://github.com/DhananjayThomble/URL-Shortener-App/issues
snapurl.in/k2RCcTD -> 302 https://example.com/kiro-probe
```

The redirect Lambda then showed 7 clean invocations with no errors (14–82 ms warm). This PR makes that permanent so the next `cdk deploy` cannot revert it.

`pnpm --filter infra type-check` passes. No stack-assertion test is added: `Template.fromStack` on this stack triggers the arm64 Docker image builds, which would make CI depend on binfmt emulation — a production redirect smoke gate is the better guard and is tracked separately.

## Note for the deploy

Production separately carries a `queryStringBehavior: none` drift on the redirect origin request policy from bisect debugging during the outage. Code is correct (`all()`), so deploying this branch also restores query-string forwarding — required for `?k=` unlock tokens on password-protected links and UTM/forwardQuery overrides.