### PR TITLE
fix(api,worker,infra): nudge worker to drain outbox on link write

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^9.1.0",
+    "@aws-sdk/client-lambda": "^3.1121.0",
     "@aws-sdk/client-ses": "^3.1121.0",
     "@fastify/cors": "^11.0.1",
     "@fastify/static": "^10.1.3",

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -109,6 +109,17 @@ export const EnvSchema = z.object({
   TRUSTED_PROXY_HOPS: z.coerce.number().int().min(0).default(0),
 
   LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
+
+  /* #394: on the AWS profile, a newly-created/edited link is invisible to the
+     redirect for up to ~60s — the projection_outbox row it lands in is only
+     drained on the worker's 1-minute EventBridge schedule. Setting this to the
+     deployed WorkerFn's name makes every projectionOutbox enqueue also fire an
+     async (fire-and-forget) Lambda Invoke carrying {"task":"projection"}, so
+     the drain usually runs within a second instead of waiting out the
+     schedule. Absent on every non-AWS profile (local dev, compose,
+     single-node, Kubernetes) — there the outbox is drained locally or is a
+     no-op (LINK_PROJECTION=none), so nothing to nudge. See ProjectionNudge. */
+  WORKER_FUNCTION_NAME: z.string().optional(),
 });
 
 export type Env = z.infer<typeof EnvSchema>;

--- a/apps/api/src/links/links.module.ts
+++ b/apps/api/src/links/links.module.ts
@@ -1,12 +1,13 @@
 import { Module } from "@nestjs/common";
 import { LinksController } from "./links.controller.js";
 import { LinksService } from "./links.service.js";
+import { ProjectionNudgeService } from "./projection-nudge.service.js";
 import { SafeBrowsingModule } from "../safe-browsing/safe-browsing.module.js";
 
 @Module({
   imports: [SafeBrowsingModule],
   controllers: [LinksController],
-  providers: [LinksService],
+  providers: [LinksService, ProjectionNudgeService],
   exports: [LinksService],
 })
 export class LinksModule {}

--- a/apps/api/src/links/links.service.integration.test.ts
+++ b/apps/api/src/links/links.service.integration.test.ts
@@ -3,6 +3,7 @@ import { createDatabase, domains, eq, linkCounters, links, workspaces, type Data
 import { ListLinksQuery } from "@snapurl/contract";
 import { LinksService } from "./links.service.js";
 import type { SafeBrowsingService } from "../safe-browsing/safe-browsing.service.js";
+import type { ProjectionNudgeService } from "./projection-nudge.service.js";
 
 /* ============================================================
    LinksService.list against a real Postgres.
@@ -23,6 +24,11 @@ const describeDb = DATABASE_URL ? describe : describe.skip;
 const safeBrowsingStub = {
   check: async () => ({ status: "clean" as const, checkedAt: new Date().toISOString() }),
 } as unknown as SafeBrowsingService;
+
+/** #394: this suite only exercises list(), which never enqueues a projection
+ *  row, so the nudge is never called — a no-op stub is all the constructor
+ *  needs. */
+const projectionNudgeStub = { nudge: () => {} } as unknown as ProjectionNudgeService;
 
 const query = (over: Partial<ListLinksQuery> = {}) => ListLinksQuery.parse({ status: "all", ...over });
 
@@ -86,7 +92,7 @@ describeDb("LinksService.list", () => {
     db = handle.db;
     // Second arg is the read-only handle. Single-node here, so it is the same
     // db handle as the primary (matches READ_DB === DB when no replica is set).
-    service = new LinksService(db, db, safeBrowsingStub);
+    service = new LinksService(db, db, safeBrowsingStub, projectionNudgeStub);
 
     const [ws] = await db
       .insert(workspaces)

--- a/apps/api/src/links/links.service.ts
+++ b/apps/api/src/links/links.service.ts
@@ -15,6 +15,7 @@ import type {
 import { SLUG_RETRY_LIMIT, generateSlug, isSlugAvailableShape, validateRoutingChain, validateSchedule } from "@snapurl/domain";
 import { DB, READ_DB } from "../database/database.module.js";
 import { SafeBrowsingService } from "../safe-browsing/safe-browsing.service.js";
+import { ProjectionNudgeService } from "./projection-nudge.service.js";
 import { isUniqueViolation } from "../common/postgres-error.filter.js";
 import { recordActivity, type Actor } from "../common/activity.js";
 import {
@@ -39,6 +40,7 @@ export class LinksService {
     // trap that makes the distinction load-bearing.
     @Inject(READ_DB) private readonly readDb: Database,
     private readonly safeBrowsing: SafeBrowsingService,
+    private readonly projectionNudge: ProjectionNudgeService,
   ) {}
 
   private readonly logger = new Logger(LinksService.name);
@@ -834,6 +836,12 @@ export class LinksService {
      instead of silently diverging. */
   private async enqueueProjection(tx: Executor, linkId: string, operation: "upsert" | "delete") {
     await tx.insert(projectionOutbox).values({ linkId, operation, payload: { linkId, operation } });
+    /* #394: nudge the worker to drain now instead of waiting out the 1-minute
+       schedule. Fire-and-forget and safe inside an open transaction — it never
+       awaits a network round trip that could stall the commit, and a failed
+       nudge changes nothing about correctness (the row is already committed
+       to projectionOutbox by the time this runs). */
+    this.projectionNudge.nudge();
   }
 
   private async resolveDomain(workspaceId: string, domain: string) {

--- a/apps/api/src/links/projection-nudge.service.test.ts
+++ b/apps/api/src/links/projection-nudge.service.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../config/env.js";
+import { ProjectionNudgeService } from "./projection-nudge.service.js";
+
+/* LambdaClient is mocked at the module level, matching mail.service.test.ts's
+   convention for @aws-sdk/client-ses: ProjectionNudgeService is a NestJS
+   @Injectable resolved through DI (only ENV is constructor-injected), so a
+   module mock exercises the real InvokeCommand shape without adding a DI
+   surface a test would have to register a provider for. */
+const sendMock = vi.fn();
+vi.mock("@aws-sdk/client-lambda", () => ({
+  LambdaClient: vi.fn().mockImplementation(() => ({ send: sendMock })),
+  InvokeCommand: vi.fn().mockImplementation((input: unknown) => ({ input })),
+  InvocationType: { Event: "Event" },
+}));
+
+function envStub(overrides: Partial<Env>): Env {
+  return {
+    MAIL_TRANSPORT: "outbox",
+    WEB_ORIGIN: "http://localhost:3000",
+    ...overrides,
+  } as Env;
+}
+
+afterEach(() => {
+  sendMock.mockReset();
+});
+
+describe("ProjectionNudgeService", () => {
+  it("does nothing when WORKER_FUNCTION_NAME is unset (every non-AWS profile)", () => {
+    const svc = new ProjectionNudgeService(envStub({}));
+
+    svc.nudge();
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("invokes the worker function asynchronously with {task:'projection'} when set", () => {
+    sendMock.mockResolvedValueOnce({});
+    const svc = new ProjectionNudgeService(envStub({ WORKER_FUNCTION_NAME: "SnapUrl-WorkerFn-abc123" }));
+
+    svc.nudge();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const call = sendMock.mock.calls[0]![0] as { input: Record<string, unknown> };
+    expect(call.input.FunctionName).toBe("SnapUrl-WorkerFn-abc123");
+    expect(call.input.InvocationType).toBe("Event");
+    const payload = JSON.parse(Buffer.from(call.input.Payload as Uint8Array).toString("utf8"));
+    expect(payload).toEqual({ task: "projection" });
+  });
+
+  it("never throws when the invoke rejects — the outbox row is already durable regardless", async () => {
+    sendMock.mockRejectedValueOnce(new Error("Lambda throttled"));
+    const svc = new ProjectionNudgeService(envStub({ WORKER_FUNCTION_NAME: "SnapUrl-WorkerFn-abc123" }));
+
+    expect(() => svc.nudge()).not.toThrow();
+    // Let the swallowed rejection's .catch() microtask run before the test ends.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+});

--- a/apps/api/src/links/projection-nudge.service.ts
+++ b/apps/api/src/links/projection-nudge.service.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { InvocationType, InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import { ENV, type Env } from "../config/env.js";
+
+/* #394 — closing the ~60s window between "link created" and "link resolvable".
+   projectionOutbox rows are drained on the worker's 1-minute EventBridge
+   schedule (see apps/worker/src/jobs/outbox.ts), which is correct for
+   durability (a crashed worker's rows are simply picked up next tick) but
+   means a link created right after a drain tick sits unresolvable — a 404 —
+   for up to a minute. The redirect deliberately does not fall back to
+   Postgres to paper over this: leaving Postgres entirely is the point of the
+   AWS profile (#288 3b), and reintroducing it here for a bugfix would quietly
+   undo that.
+
+   Instead: every projectionOutbox insert also fires an async Invoke of the
+   worker Lambda with {"task":"projection"} (a dedicated task that runs only
+   runProjection, not the full frequent job — see apps/worker/src/lambda.ts).
+   InvocationType "Event" returns as soon as Lambda has accepted the request,
+   before the function runs, so this never adds latency to the link-create
+   response, and a failure to invoke (throttled, transient network blip) is
+   swallowed and logged — the row is still in the outbox and the next
+   scheduled drain picks it up regardless. This is a latency optimization
+   layered on an already-durable path, not a new source of truth. */
+
+@Injectable()
+export class ProjectionNudgeService {
+  private readonly logger = new Logger(ProjectionNudgeService.name);
+  private client: LambdaClient | undefined;
+
+  constructor(@Inject(ENV) private readonly env: Env) {}
+
+  /** Fire-and-forget: never throws, never awaited by the caller's transaction.
+   *  A no-op when WORKER_FUNCTION_NAME is unset (every non-AWS profile). */
+  nudge(): void {
+    const functionName = this.env.WORKER_FUNCTION_NAME;
+    if (!functionName) return;
+
+    this.client ??= new LambdaClient({});
+    this.client
+      .send(
+        new InvokeCommand({
+          FunctionName: functionName,
+          InvocationType: InvocationType.Event,
+          Payload: Buffer.from(JSON.stringify({ task: "projection" })),
+        }),
+      )
+      .catch((err: unknown) => {
+        /* Warn, not error: the outbox row is durable and the scheduled drain
+           still runs within a minute regardless. This only means the request
+           did not get to skip the queue. */
+        this.logger.warn({ err }, "projection nudge invoke failed; scheduled drain will still pick up the row");
+      });
+  }
+}

--- a/apps/worker/src/lambda.test.ts
+++ b/apps/worker/src/lambda.test.ts
@@ -170,6 +170,18 @@ describe("worker task dispatch", () => {
     expect(backfillClickPartitions).not.toHaveBeenCalled();
   });
 
+  it("dispatches the projection task to runProjection only, not runFrequent (#394)", async () => {
+    runProjection.mockResolvedValue({ processed: 2, failed: 0 } as never);
+    const result = await handler({ task: "projection" });
+    expect(runProjection).toHaveBeenCalledWith(fakeDb);
+    expect(result).toEqual({ task: "projection", outbox: { processed: 2, failed: 0 } });
+    // The on-demand nudge must not also run the click-queue/rollup work — a
+    // link-create should not pay for unrelated work just because it shares a
+    // warm container with the scheduled "frequent" job.
+    expect(runFrequent).not.toHaveBeenCalled();
+    expect(runMaintenance).not.toHaveBeenCalled();
+  });
+
   it("does not treat a frequent invocation as a backfill", async () => {
     runFrequent.mockResolvedValue({ rolled: { events: 0 } } as never);
     runProjection.mockResolvedValue({ processed: 3, failed: 0 } as never);

--- a/apps/worker/src/lambda.ts
+++ b/apps/worker/src/lambda.ts
@@ -20,6 +20,16 @@ import { backfillClickPartitions } from "./jobs/rollup.js";
  *                               (see below). A one-time adoption/repair op an
  *                               operator triggers manually, on no schedule.
  *   - `"maintenance"`        -> runMaintenance only.
+ *   - `"projection"`         -> runProjection only (#394: an on-demand drain
+ *                               the API's ProjectionNudgeService invokes right
+ *                               after enqueueing an outbox row, so a
+ *                               newly-created/edited link is usually
+ *                               resolvable within a second or two instead of
+ *                               waiting out the 1-minute schedule below. Not
+ *                               folded into "frequent" — runFrequent's queue
+ *                               drain and rollup work is unrelated to what
+ *                               this nudge is for and would make every
+ *                               link-create pay for it).
  *   - `"frequent"`           -> runProjection + runFrequent.
  *   - `"rollup"`             -> runProjection + runFrequent (back-compat alias
  *                               for the old payload; the previous handler
@@ -65,7 +75,7 @@ import { backfillClickPartitions } from "./jobs/rollup.js";
  * not the whole batch. The rollups then fold these rows as usual.
  */
 export interface WorkerEvent {
-  task?: "frequent" | "maintenance" | "rollup" | "migrate" | "backfill";
+  task?: "frequent" | "maintenance" | "rollup" | "migrate" | "backfill" | "projection";
   /** Optional per-chunk day bound for the `backfill` task, forwarded to
    *  backfillClickPartitions as its chunkSize. Omitted uses the routine's own
    *  default (CLICK_EVENTS_BACKFILL_CHUNK_DAYS). Ignored by every other task. */
@@ -153,6 +163,15 @@ export const handler = async (event: WorkerEvent | SqsEvent = {}) => {
   if (workerEvent.task === "maintenance") {
     const maintenance = await runMaintenance(db);
     return { task: "maintenance", maintenance };
+  }
+
+  if (workerEvent.task === "projection") {
+    /* #394: the on-demand nudge path. Deliberately just the drain, not
+       runFrequent's click-queue/rollup work — a link-create should not pay
+       for unrelated work just because it happens to share a warm container
+       with the scheduled job. */
+    const outbox = await runProjection(db);
+    return { task: "projection", outbox };
   }
 
   if (workerEvent.task === "backfill") {

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -1142,6 +1142,23 @@ export class SnapUrlStack extends Stack {
       description: "Hourly maintenance: partition provisioning, salt rotation, retention and pruning.",
     });
 
+    /* #394: close the ~60s window between "link created" and "link
+       resolvable" caused by the projectionOutbox drain running only on the
+       1-minute schedule above. ProjectionNudgeService (apps/api/src/links)
+       fires an async Invoke of workerFn with {"task":"projection"} right
+       after every outbox enqueue, so the drain usually runs within a second
+       instead of waiting out WorkerSchedule. Needs workerFn to already exist,
+       so this grant is issued here rather than alongside apiFn above.
+       grantInvoke covers both lambda:InvokeFunction and (harmlessly, since
+       the API calls it directly rather than through a Function URL)
+       InvokeFunctionUrl. A failed or throttled invoke is caught and logged by
+       the service, not surfaced to the link-create request, and the row is
+       still durably in projectionOutbox for WorkerSchedule to pick up
+       regardless — this is a latency optimization, not a new source of
+       truth. */
+    workerFn.grantInvoke(apiFn);
+    apiFn.addEnvironment("WORKER_FUNCTION_NAME", workerFn.functionName);
+
     /* ---------------------------------------------------------
        Secret read grants (issue #292)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: ^9.1.0
         version: 9.1.0(zod@4.4.3)
+      '@aws-sdk/client-lambda':
+        specifier: ^3.1121.0
+        version: 3.1129.0
       '@aws-sdk/client-ses':
         specifier: ^3.1121.0
         version: 3.1126.0
@@ -502,6 +505,10 @@ packages:
     resolution: {integrity: sha512-q8s4cKsn0TdQ+QByWEUeajZMFrmF2GzDovrlfWMA7Pv3GfG5sADjbWAZxJXA9JsLGb4QT5ovTpOdArNqjbojZw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-lambda@3.1129.0':
+    resolution: {integrity: sha512-FVgg8Zc50tRgmLn3RQqD/CYc8rY7siFflZoNwwOFm7JctXmAyNtnTNJZQ6LaT05DLNLGn8aBqDA8BgE6g/tQiQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-secrets-manager@3.1121.0':
     resolution: {integrity: sha512-kx66Imv5DomVdd5uwai10Dhf0zZg9Z3EODxJCYRGjmaD0GR08GkvuIPPIqE+ZmpHANCWbur9UKpgyXGJzk60pg==}
     engines: {node: '>=20.0.0'}
@@ -518,20 +525,40 @@ packages:
     resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.978.0':
+    resolution: {integrity: sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.70':
     resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.71':
+    resolution: {integrity: sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.72':
     resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.73':
+    resolution: {integrity: sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.15':
     resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    resolution: {integrity: sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.77':
     resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.78':
+    resolution: {integrity: sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.81':
@@ -542,16 +569,32 @@ packages:
     resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.83':
+    resolution: {integrity: sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.70':
     resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.71':
+    resolution: {integrity: sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.973.14':
     resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    resolution: {integrity: sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.76':
     resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    resolution: {integrity: sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.44':
@@ -580,6 +623,10 @@ packages:
     resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.45':
+    resolution: {integrity: sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.46':
     resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
     engines: {node: '>=20.0.0'}
@@ -590,6 +637,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1116.0':
     resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1129.0':
+    resolution: {integrity: sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.5':
@@ -4363,6 +4414,17 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/client-lambda@3.1129.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-node': 3.972.83
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-secrets-manager@3.1121.0':
     dependencies:
       '@aws-sdk/core': 3.977.9
@@ -4408,6 +4470,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.978.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.70':
     dependencies:
       '@aws-sdk/core': 3.977.9
@@ -4416,9 +4489,27 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.72':
     dependencies:
       '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
@@ -4442,10 +4533,35 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-login': 3.972.78
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.77':
     dependencies:
       '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.78':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
@@ -4479,9 +4595,31 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.83':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-ini': 3.973.16
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.70':
     dependencies:
       '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
@@ -4497,10 +4635,29 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/token-providers': 3.1129.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.76':
     dependencies:
       '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2
@@ -4553,6 +4710,17 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.45':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.46':
     dependencies:
       '@aws-sdk/types': 3.974.5
@@ -4569,6 +4737,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1129.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.17.2


### PR DESCRIPTION
Closes #394.

**Root cause:** the redirect resolves links from a DynamoDB projection the worker populates by draining `projection_outbox` on a 1-minute EventBridge schedule. A link created right after a drain tick is unresolvable (404) for up to ~60s.

**Fix:** `ProjectionNudgeService` (apps/api) fires an async, fire-and-forget Lambda Invoke of the worker with `{"task":"projection"}` right after every `enqueueProjection()` outbox insert (link create/edit/delete/expiry-sweep). `InvocationType: Event` returns as soon as Lambda accepts the request, so this adds no latency to the link-create response. A failed/throttled invoke is caught and logged, never surfaced to the caller — the outbox row is already durably committed and the scheduled drain still picks it up regardless. No-op when `WORKER_FUNCTION_NAME` is unset (every non-AWS profile).

Added a dedicated `"projection"` worker task that runs only `runProjection`, not the full `frequent` job (click-queue drain + rollups) — a link-create should not pay for unrelated work.

**Explicitly rejected:** a Postgres-fallback-on-miss in the redirect's resolver (one of the issue's suggested fixes). The AWS-profile redirect deliberately leaves Postgres and the VPC entirely (#288 3b) — reintroducing a DB dependency there for this bugfix would quietly undo that architecture decision.

**Known gap, left out of scope:** `ReportsService`'s abuse-flag path enqueues `projection_outbox` directly (not through `LinksService.enqueueProjection`) and does not get the nudge — it still resolves within the next scheduled drain. Can fold in as a follow-up if that latency matters.

## Verification
- `apps/api` type-check clean, build clean, 175/175 tests pass (incl. 3 new `projection-nudge.service.test.ts` cases: no-op when unset, correct Invoke shape when set, swallows a rejected invoke).
- `apps/worker` type-check clean, build clean, 103/103 tests pass (incl. new dispatch test proving `"projection"` runs only `runProjection`, not `runFrequent`/`runMaintenance`).
- `infra` type-check clean, `cdk synth` clean with the live stack's context flags.
- Not yet verified against a real deploy (that happens after merge, per the standing PR→review→CI-gate→merge→deploy flow) — will re-run the live create-link-then-follow-within-1s repro from the issue once deployed.