### PR TITLE
fix(infra,database,worker): merge the forwarded query at the edge (#395)

### DIFF
--- a/apps/worker/src/jobs/kvs-projection.test.ts
+++ b/apps/worker/src/jobs/kvs-projection.test.ts
@@ -103,8 +103,13 @@ describe("KvsWriter.putIfEligible", () => {
     ["archived", { archived: true }],
     ["unsafe", { safeBrowsingStatus: "malware" }],
     /* Transform behaviours the edge cannot reproduce (each independently makes a
-       link ineligible so it stays on the authoritative Lambda). */
-    ["forwardQuery", { forwardQuery: true }],
+       link ineligible so it stays on the authoritative Lambda).
+
+       forwardQuery is NOT in this list any more (#395): the edge reproduces the
+       forwarded-query merge from the base/params/hash that kvsValue stores, so a
+       forwardQuery link IS edge-eligible. It had to be — forwardQuery defaults to
+       true, so excluding it left the KeyValueStore permanently empty. See the
+       dedicated forwardQuery case below. */
     ["utm", { utm: { source: "print", medium: "qr", campaign: null, content: null } }],
     ["deepLink", { deepLink: true }],
     ["hideReferrer", { hideReferrer: true }],
@@ -137,6 +142,61 @@ describe("KvsWriter.putIfEligible", () => {
       expect(deletes[0].IfMatch).toBe(ETAG);
     });
   }
+
+  /* #395: a forwardQuery link is now PUT, and its value carries the decomposed
+     destination the CloudFront Function needs to merge without a URL parser. */
+  it("PutKeys a forwardQuery link with the decomposed destination", async () => {
+    const puts: any[] = [];
+    const { client } = makeClient({
+      DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+      PutKeyCommand: (input) => {
+        puts.push(input);
+        return {};
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    await writer.putIfEligible(
+      eligibleLink({ forwardQuery: true, destination: "https://acme.com/x?a=1#f" }),
+      HOST,
+      SLUG,
+    );
+
+    expect(puts).toHaveLength(1);
+    const value = JSON.parse(puts[0].Value);
+    expect(value.forwardQuery).toBe(true);
+    expect(value.base).toBe("https://acme.com/x");
+    expect(value.params).toEqual([["a", "1"]]);
+    expect(value.hash).toBe("#f");
+    expect(value.destination).toBe("https://acme.com/x?a=1#f");
+  });
+
+  /* An oversized value must be DELETED, never truncated: a truncated value would
+     make the edge answer with a mangled destination, which is strictly worse than
+     not answering at all. */
+  it("DeleteKeys instead of writing a value over the 1 KB limit", async () => {
+    const deletes: any[] = [];
+    const { client, send } = makeClient({
+      DescribeKeyValueStoreCommand: () => ({ ETag: ETAG }),
+      DeleteKeyCommand: (input) => {
+        deletes.push(input);
+        return {};
+      },
+    });
+    const writer = new KvsWriter(client, KVS_ARN);
+
+    // A destination whose decomposed form comfortably exceeds 1 KB.
+    const huge = "https://acme.com/x?q=" + "a".repeat(1200);
+    await writer.putIfEligible(
+      eligibleLink({ forwardQuery: true, destination: huge }),
+      HOST,
+      SLUG,
+    );
+
+    expect(send.mock.calls.map((c) => commandName(c[0]))).not.toContain("PutKeyCommand");
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].Key).toBe(kvsKey(HOST, SLUG));
+  });
 });
 
 describe("KvsWriter.deleteKey", () => {

--- a/apps/worker/src/jobs/kvs-projection.ts
+++ b/apps/worker/src/jobs/kvs-projection.ts
@@ -50,6 +50,11 @@ const MAX_ATTEMPTS = 3;
  *  ETag (optimistic-concurrency conflict). */
 const CONFLICT_ERROR = "ConflictException";
 
+/** CloudFront's per-value ceiling for a KeyValueStore entry, in bytes. A value at
+ *  or under this is written; anything over it is deleted instead (see
+ *  putIfEligible) so the edge never serves a truncated destination. */
+const MAX_VALUE_BYTES = 1024;
+
 function isConflict(err: unknown): boolean {
   return err instanceof Error && err.name === CONFLICT_ERROR;
 }
@@ -69,6 +74,21 @@ export class KvsWriter {
     const key = kvsKey(host, slug);
     if (isEdgeEligible(link)) {
       const value = kvsValue(link);
+      /* Oversized value -> DELETE, not a truncated write.
+       *
+       * CloudFront caps a KeyValueStore value at 1 KB. Since #395 a forwardQuery
+       * link's value also carries the destination decomposed into base/params/hash
+       * so the edge can merge without a URL parser, which roughly doubles it — an
+       * ordinary link is still far inside the cap, but a destination with a very
+       * long query can now approach it. Truncating would be the worst outcome
+       * available: the edge would answer with a MANGLED destination instead of
+       * simply not answering. Removing the key leaves the link on the Lambda,
+       * which is always correct, and the delete (rather than a skip) also evicts a
+       * previously-written entry for a link whose destination has since grown. */
+      if (Buffer.byteLength(value, "utf8") > MAX_VALUE_BYTES) {
+        await this.deleteByKey(key);
+        return;
+      }
       await this.withEtag((etag) =>
         this.client.send(
           new PutKeyCommand({ KvsARN: this.kvsArn, Key: key, Value: value, IfMatch: etag }),

--- a/infra/functions/redirect-viewer-request.js
+++ b/infra/functions/redirect-viewer-request.js
@@ -50,6 +50,131 @@ function edgeKey(host, slug) {
   return host.toLowerCase() + "/" + slug.toLowerCase();
 }
 
+/* One component, serialised the way URLSearchParams does. This runtime has no
+   URL and no URLSearchParams (JS 2.0 provides only Buffer/querystring/crypto),
+   so this is the hand-rolled equivalent — and it MUST match byte-for-byte, or the
+   same link would redirect differently depending on whether the edge or the
+   Lambda answered it.
+
+   encodeURIComponent already leaves ASCII alphanumerics and !'()*-._~ literal.
+   The application/x-www-form-urlencoded set differs in exactly two ways: space is
+   "+" not "%20", and !'()~ ARE escaped ("*", "-", "." and "_" stay literal in
+   both). Those six substitutions are the entire difference, and the property test
+   in redirect-viewer-request.test.ts asserts this against Node's real
+   URLSearchParams over generated input rather than trusting the reasoning.
+
+   ONE divergence remains and is deliberately left alone: encodeURIComponent THROWS
+   URIError on a lone surrogate, where URLSearchParams substitutes U+FFFD. decide()
+   calls this inside its try/catch, so the throw becomes a fall-through to the
+   Lambda — a correct answer, just a slower one — and a real query cannot carry a
+   lone surrogate anyway (malformed UTF-8 is replaced before it is a JS string). */
+function formEncode(s) {
+  return encodeURIComponent(s)
+    .replace(/%20/g, "+")
+    .replace(/!/g, "%21")
+    .replace(/'/g, "%27")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
+    .replace(/~/g, "%7E");
+}
+
+function serialiseParams(pairs) {
+  var out = "";
+  for (var i = 0; i < pairs.length; i++) {
+    if (i > 0) out += "&";
+    out += formEncode(pairs[i][0]) + "=" + formEncode(pairs[i][1]);
+  }
+  return out;
+}
+
+/* URLSearchParams.set semantics, which is what buildDestination applies: replace
+   the FIRST occurrence of the key IN PLACE — so a key the destination already has
+   keeps the destination's position, not the incoming query's — and drop any later
+   duplicates; append when the key is absent. */
+function setParam(pairs, key, value) {
+  var at = -1;
+  for (var i = 0; i < pairs.length; i++) {
+    if (pairs[i][0] === key) {
+      at = i;
+      break;
+    }
+  }
+  if (at === -1) {
+    pairs.push([key, value]);
+    return pairs;
+  }
+  var out = [];
+  for (var j = 0; j < pairs.length; j++) {
+    if (j === at) out.push([key, value]);
+    else if (pairs[j][0] !== key) out.push(pairs[j]);
+  }
+  return out;
+}
+
+/* CloudFront's already-parsed querystring -> ordered [key, value] pairs, taking
+   the LAST value of a repeated key. That is exactly what iterating a
+   URLSearchParams and calling set() for each pair leaves behind: the key sits at
+   its first-appearance position carrying its last-seen value.
+
+   Returns null when the order cannot be trusted. This runtime, like V8,
+   enumerates INTEGER-LIKE object keys FIRST in ascending numeric order and only
+   then string keys in insertion order — so for "?a=1&0=2" the object
+   `{ a: .., 0: .. }` enumerates 0 before a and the original left-to-right order is
+   genuinely unrecoverable, because CloudFront gives us an object and no raw query
+   string. Since order decides the serialised query, emitting a differently-ordered
+   Location would be WRONG; falling through to the Lambda (which does still have
+   the raw query) is correct. A numeric query key is rare, so this costs almost
+   nothing. Found by the differential property test, not by reading the code. */
+function isIndexLike(name) {
+  return /^(0|[1-9][0-9]*)$/.test(name);
+}
+
+function incomingPairs(qs) {
+  var pairs = [];
+  for (var name in qs) {
+    if (!Object.prototype.hasOwnProperty.call(qs, name)) continue;
+    if (isIndexLike(name)) return null;
+    var entry = qs[name];
+    if (!entry) continue;
+    var value = typeof entry.value === "string" ? entry.value : "";
+    if (entry.multiValue && entry.multiValue.length) {
+      value = entry.multiValue[entry.multiValue.length - 1].value;
+    }
+    pairs.push([name, value]);
+  }
+  return pairs;
+}
+
+/* The Location for a KVS hit, or null meaning "fall through to the Lambda".
+ *
+ * Mirrors buildDestination for the edge-eligible subset: isEdgeEligible requires
+ * utm == null, so the forwarded query is the ONLY transform left to reproduce.
+ * Neither side parses a URL here — the writer stored the destination already
+ * decomposed into base/params/hash, and both sides serialise the same pairs with
+ * the same algorithm, which is what makes the bytes agree. */
+function edgeLocation(parsed, querystring) {
+  if (!parsed.forwardQuery) return parsed.destination;
+
+  var incoming = incomingPairs(querystring || {});
+  if (incoming === null) return null; // key order not recoverable — use the Lambda
+  if (incoming.length === 0) return parsed.destination;
+
+  // A destination the writer could not decompose carries no base — cannot merge.
+  if (typeof parsed.base !== "string") return null;
+
+  var merged = [];
+  var base = parsed.params || [];
+  for (var i = 0; i < base.length; i++) merged.push([base[i][0], base[i][1]]);
+  for (var j = 0; j < incoming.length; j++) {
+    // The unlock token is ours, not the destination's (buildDestination skips it).
+    if (incoming[j][0] === "k") continue;
+    merged = setParam(merged, incoming[j][0], incoming[j][1]);
+  }
+
+  var query = serialiseParams(merged);
+  return parsed.base + (query.length ? "?" + query : "") + (parsed.hash || "");
+}
+
 async function decide(event, kvsGet) {
   var request = event.request;
 
@@ -96,12 +221,15 @@ async function decide(event, kvsGet) {
     var parsed = JSON.parse(raw);
     if (!parsed || !parsed.destination) return request;
 
+    var location = edgeLocation(parsed, request.querystring);
+    if (location === null) return request;
+
     var statusCode = parsed.redirectType === "301" ? 301 : 302;
     return {
       statusCode: statusCode,
       statusDescription: statusCode === 301 ? "Moved Permanently" : "Found",
       headers: {
-        location: { value: parsed.destination },
+        location: { value: location },
         // Match the app's cacheHeadersFor(): never let a browser cache a
         // redirect, so "change where it points forever" holds.
         "cache-control": { value: "no-store, no-cache, must-revalidate" },

--- a/infra/functions/redirect-viewer-request.logic.mjs
+++ b/infra/functions/redirect-viewer-request.logic.mjs
@@ -20,6 +20,131 @@ function edgeKey(host, slug) {
   return host.toLowerCase() + "/" + slug.toLowerCase();
 }
 
+/* One component, serialised the way URLSearchParams does. This runtime has no
+   URL and no URLSearchParams (JS 2.0 provides only Buffer/querystring/crypto),
+   so this is the hand-rolled equivalent — and it MUST match byte-for-byte, or the
+   same link would redirect differently depending on whether the edge or the
+   Lambda answered it.
+
+   encodeURIComponent already leaves ASCII alphanumerics and !'()*-._~ literal.
+   The application/x-www-form-urlencoded set differs in exactly two ways: space is
+   "+" not "%20", and !'()~ ARE escaped ("*", "-", "." and "_" stay literal in
+   both). Those six substitutions are the entire difference, and the property test
+   in redirect-viewer-request.test.ts asserts this against Node's real
+   URLSearchParams over generated input rather than trusting the reasoning.
+
+   ONE divergence remains and is deliberately left alone: encodeURIComponent THROWS
+   URIError on a lone surrogate, where URLSearchParams substitutes U+FFFD. decide()
+   calls this inside its try/catch, so the throw becomes a fall-through to the
+   Lambda — a correct answer, just a slower one — and a real query cannot carry a
+   lone surrogate anyway (malformed UTF-8 is replaced before it is a JS string). */
+function formEncode(s) {
+  return encodeURIComponent(s)
+    .replace(/%20/g, "+")
+    .replace(/!/g, "%21")
+    .replace(/'/g, "%27")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
+    .replace(/~/g, "%7E");
+}
+
+function serialiseParams(pairs) {
+  var out = "";
+  for (var i = 0; i < pairs.length; i++) {
+    if (i > 0) out += "&";
+    out += formEncode(pairs[i][0]) + "=" + formEncode(pairs[i][1]);
+  }
+  return out;
+}
+
+/* URLSearchParams.set semantics, which is what buildDestination applies: replace
+   the FIRST occurrence of the key IN PLACE — so a key the destination already has
+   keeps the destination's position, not the incoming query's — and drop any later
+   duplicates; append when the key is absent. */
+function setParam(pairs, key, value) {
+  var at = -1;
+  for (var i = 0; i < pairs.length; i++) {
+    if (pairs[i][0] === key) {
+      at = i;
+      break;
+    }
+  }
+  if (at === -1) {
+    pairs.push([key, value]);
+    return pairs;
+  }
+  var out = [];
+  for (var j = 0; j < pairs.length; j++) {
+    if (j === at) out.push([key, value]);
+    else if (pairs[j][0] !== key) out.push(pairs[j]);
+  }
+  return out;
+}
+
+/* CloudFront's already-parsed querystring -> ordered [key, value] pairs, taking
+   the LAST value of a repeated key. That is exactly what iterating a
+   URLSearchParams and calling set() for each pair leaves behind: the key sits at
+   its first-appearance position carrying its last-seen value.
+
+   Returns null when the order cannot be trusted. This runtime, like V8,
+   enumerates INTEGER-LIKE object keys FIRST in ascending numeric order and only
+   then string keys in insertion order — so for "?a=1&0=2" the object
+   `{ a: .., 0: .. }` enumerates 0 before a and the original left-to-right order is
+   genuinely unrecoverable, because CloudFront gives us an object and no raw query
+   string. Since order decides the serialised query, emitting a differently-ordered
+   Location would be WRONG; falling through to the Lambda (which does still have
+   the raw query) is correct. A numeric query key is rare, so this costs almost
+   nothing. Found by the differential property test, not by reading the code. */
+function isIndexLike(name) {
+  return /^(0|[1-9][0-9]*)$/.test(name);
+}
+
+function incomingPairs(qs) {
+  var pairs = [];
+  for (var name in qs) {
+    if (!Object.prototype.hasOwnProperty.call(qs, name)) continue;
+    if (isIndexLike(name)) return null;
+    var entry = qs[name];
+    if (!entry) continue;
+    var value = typeof entry.value === "string" ? entry.value : "";
+    if (entry.multiValue && entry.multiValue.length) {
+      value = entry.multiValue[entry.multiValue.length - 1].value;
+    }
+    pairs.push([name, value]);
+  }
+  return pairs;
+}
+
+/* The Location for a KVS hit, or null meaning "fall through to the Lambda".
+ *
+ * Mirrors buildDestination for the edge-eligible subset: isEdgeEligible requires
+ * utm == null, so the forwarded query is the ONLY transform left to reproduce.
+ * Neither side parses a URL here — the writer stored the destination already
+ * decomposed into base/params/hash, and both sides serialise the same pairs with
+ * the same algorithm, which is what makes the bytes agree. */
+function edgeLocation(parsed, querystring) {
+  if (!parsed.forwardQuery) return parsed.destination;
+
+  var incoming = incomingPairs(querystring || {});
+  if (incoming === null) return null; // key order not recoverable — use the Lambda
+  if (incoming.length === 0) return parsed.destination;
+
+  // A destination the writer could not decompose carries no base — cannot merge.
+  if (typeof parsed.base !== "string") return null;
+
+  var merged = [];
+  var base = parsed.params || [];
+  for (var i = 0; i < base.length; i++) merged.push([base[i][0], base[i][1]]);
+  for (var j = 0; j < incoming.length; j++) {
+    // The unlock token is ours, not the destination's (buildDestination skips it).
+    if (incoming[j][0] === "k") continue;
+    merged = setParam(merged, incoming[j][0], incoming[j][1]);
+  }
+
+  var query = serialiseParams(merged);
+  return parsed.base + (query.length ? "?" + query : "") + (parsed.hash || "");
+}
+
 async function decide(event, kvsGet) {
   var request = event.request;
 
@@ -66,12 +191,15 @@ async function decide(event, kvsGet) {
     var parsed = JSON.parse(raw);
     if (!parsed || !parsed.destination) return request;
 
+    var location = edgeLocation(parsed, request.querystring);
+    if (location === null) return request;
+
     var statusCode = parsed.redirectType === "301" ? 301 : 302;
     return {
       statusCode: statusCode,
       statusDescription: statusCode === 301 ? "Moved Permanently" : "Found",
       headers: {
-        location: { value: parsed.destination },
+        location: { value: location },
         // Match the app's cacheHeadersFor(): never let a browser cache a
         // redirect, so "change where it points forever" holds.
         "cache-control": { value: "no-store, no-cache, must-revalidate" },
@@ -83,4 +211,4 @@ async function decide(event, kvsGet) {
 }
 // --- DRIFT-GUARDED REGION END ---
 
-export { decide, edgeKey };
+export { decide, edgeKey, edgeLocation, formEncode, serialiseParams };

--- a/infra/functions/redirect-viewer-request.test.ts
+++ b/infra/functions/redirect-viewer-request.test.ts
@@ -1,8 +1,40 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import fc from "fast-check";
 import { describe, expect, it, vi } from "vitest";
-import { kvsKey } from "@snapurl/database";
-import { decide, edgeKey } from "./redirect-viewer-request.logic.mjs";
+import { kvsKey, kvsValue, type ProjectedLink } from "@snapurl/database";
+import { buildDestination } from "@snapurl/domain";
+import {
+  decide,
+  edgeKey,
+  edgeLocation,
+  formEncode,
+} from "./redirect-viewer-request.logic.mjs";
+
+/** An edge-eligible link, mirroring the `plain` fixture in
+ *  packages/database/src/link-projection.test.ts. Tests override one field at a
+ *  time so what is under test is obvious. */
+const plainProjected: ProjectedLink = {
+  id: "11111111-1111-1111-1111-111111111111",
+  workspaceId: "22222222-2222-2222-2222-222222222222",
+  destination: "https://acme.com/x",
+  redirectType: "302",
+  rules: [],
+  expiresAt: null,
+  expiresTo: null,
+  activatesAt: null,
+  scheduledTo: null,
+  clickLimit: null,
+  clicks: 0,
+  hasPassword: false,
+  forwardQuery: false,
+  deepLink: false,
+  hideReferrer: false,
+  publicPreview: false,
+  archived: false,
+  safeBrowsingStatus: "clean",
+  utm: null,
+};
 
 /*
  * Unit tests for the RedirectViewerRequest CloudFront Function decision logic
@@ -221,5 +253,282 @@ describe("deployed CloudFront Function has valid module scaffolding (#357)", () 
 
   it("declares a global `handler` function (the runtime entry point)", () => {
     expect(runtime).toMatch(/^\s*(async\s+)?function\s+handler\s*\(/m);
+  });
+});
+
+/* ============================================================
+   #395 — the forwarded-query merge at the edge.
+
+   These are the tests that make the feature safe. The edge has no URL and no
+   URLSearchParams, so it hand-rolls the merge; if its output diverges from
+   buildDestination by even one byte, the SAME link redirects differently
+   depending on whether the edge or the Lambda answered — a cache-dependent,
+   near-undebuggable inconsistency. So rather than trust the reasoning, these
+   compare the edge against the real implementations over generated input.
+   ============================================================ */
+
+describe("formEncode matches URLSearchParams serialisation", () => {
+  /** How URLSearchParams encodes `s` as a value, extracted from real output. */
+  const refValue = (s: string) => new URLSearchParams([["x", s]]).toString().slice("x=".length);
+  /** How URLSearchParams encodes `s` as a key. */
+  const refKey = (s: string) => {
+    const out = new URLSearchParams([[s, "v"]]).toString();
+    return out.slice(0, out.length - "=v".length);
+  };
+
+  /* The characters where encodeURIComponent and the urlencoded set disagree are
+     the whole reason formEncode exists, so pin them explicitly as well as
+     generatively. */
+  it.each([
+    [" ", "+"],
+    ["!", "%21"],
+    ["'", "%27"],
+    ["(", "%28"],
+    [")", "%29"],
+    ["~", "%7E"],
+    ["*", "*"],
+    ["-", "-"],
+    [".", "."],
+    ["_", "_"],
+    ["+", "%2B"],
+    ["%", "%25"],
+    ["&", "%26"],
+    ["=", "%3D"],
+  ])("encodes %j as %j", (input, expected) => {
+    expect(formEncode(input)).toBe(expected);
+    expect(formEncode(input)).toBe(refValue(input));
+  });
+
+  it("agrees with URLSearchParams for arbitrary strings (key and value position)", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), (s) => {
+        expect(formEncode(s)).toBe(refValue(s));
+        expect(formEncode(s)).toBe(refKey(s));
+      }),
+      { numRuns: 500 },
+    );
+  });
+
+  it("agrees with URLSearchParams for unicode and the tricky ASCII set", () => {
+    fc.assert(
+      fc.property(
+        fc.string({
+          // Array.from splits by CODE POINT, so astral characters stay whole. A
+          // lone surrogate is covered separately below — it is the one input where
+          // the two implementations legitimately differ.
+          unit: fc.constantFrom(
+            ...Array.from(" !'()~*-._+%&=?#/:@[]{}<>\"\\|^`$,;é日本語🙂"),
+            "a",
+            "0",
+          ),
+          maxLength: 30,
+        }),
+        (s) => {
+          expect(formEncode(s)).toBe(refValue(s));
+        },
+      ),
+      { numRuns: 500 },
+    );
+  });
+
+  /* The ONE divergence, pinned deliberately rather than discovered in production:
+     encodeURIComponent THROWS URIError on a lone surrogate, where URLSearchParams
+     substitutes U+FFFD. That is safe by construction — edgeLocation runs inside
+     decide's try/catch, so the throw becomes a fall-through to the Lambda, which
+     is always a correct answer. It is also unreachable in practice: a real query
+     arrives as bytes and malformed UTF-8 is already replaced before it becomes a
+     JS string. Asserted so the safety argument is a test, not a comment. */
+  it("throws on a lone surrogate (which decide turns into a safe fall-through)", () => {
+    const loneSurrogate = "\uD83D";
+    expect(() => formEncode(loneSurrogate)).toThrow(URIError);
+    expect(new URLSearchParams([["x", loneSurrogate]]).toString()).toBe("x=%EF%BF%BD");
+  });
+});
+
+describe("edgeLocation reproduces buildDestination byte-for-byte", () => {
+  /** CloudFront's parsed querystring shape for a raw query string. `value` is the
+   *  first occurrence and `multiValue` carries all of them in order, which is what
+   *  the real event provides for a repeated key. */
+  function cfQuerystring(query: string) {
+    const out: Record<string, { value: string; multiValue?: Array<{ value: string }> }> = {};
+    for (const [key, value] of new URLSearchParams(query)) {
+      const existing = out[key];
+      if (!existing) {
+        out[key] = { value };
+      } else {
+        existing.multiValue = existing.multiValue ?? [{ value: existing.value }];
+        existing.multiValue.push({ value });
+      }
+    }
+    return out;
+  }
+
+  /** The KVS payload the worker would store for a forwardQuery link. */
+  const payloadFor = (destination: string) =>
+    JSON.parse(
+      kvsValue({
+        ...plainProjected,
+        destination,
+        forwardQuery: true,
+      }),
+    );
+
+  /** What the Lambda would return for the same request. */
+  const viaLambda = (destination: string, incomingQuery: string) =>
+    buildDestination({ destination, incomingQuery, forwardQuery: true, utm: null });
+
+  const cases: Array<[string, string, string]> = [
+    ["appends to a destination with no query", "https://acme.com/x", "a=1&b=2"],
+    ["merges into an existing query", "https://acme.com/x?keep=1", "a=1"],
+    ["REPLACES a colliding key in the destination's own position", "https://acme.com/x?a=old&z=9", "a=new"],
+    ["keeps the fragment last", "https://acme.com/x#frag", "a=1"],
+    ["merges with both an existing query and a fragment", "https://acme.com/x?a=old#frag", "a=new&b=2"],
+    ["takes the LAST value of a repeated incoming key", "https://acme.com/x", "a=1&a=2&a=3"],
+    ["encodes spaces as +", "https://acme.com/x", "q=hello world"],
+    ["encodes the characters encodeURIComponent would leave alone", "https://acme.com/x", "q=a!b'c(d)e~f"],
+    ["handles an empty value", "https://acme.com/x", "a="],
+    ["normalises the destination host", "https://ACME.com", "a=1"],
+    ["preserves a port and userinfo-free authority", "https://acme.com:8443/x", "a=1"],
+    ["skips the unlock token k", "https://acme.com/x", "k=secret&a=1"],
+  ];
+
+  it.each(cases)("%s", (_name, destination, incomingQuery) => {
+    const got = edgeLocation(payloadFor(destination), cfQuerystring(incomingQuery));
+    expect(got).toBe(viaLambda(destination, incomingQuery));
+  });
+
+  it("returns the stored destination when there is no incoming query", () => {
+    const payload = payloadFor("https://acme.com/x?a=1#f");
+    expect(edgeLocation(payload, {})).toBe(viaLambda("https://acme.com/x?a=1#f", ""));
+  });
+
+  it("returns the raw destination (no merge) when the link does not forward the query", () => {
+    const payload = JSON.parse(kvsValue({ ...plainProjected, destination: "https://acme.com/x" }));
+    expect(payload.forwardQuery).toBeUndefined();
+    expect(edgeLocation(payload, cfQuerystring("a=1"))).toBe("https://acme.com/x");
+    // Which is also what the Lambda does with forwardQuery false.
+    expect(edgeLocation(payload, cfQuerystring("a=1"))).toBe(
+      buildDestination({
+        destination: "https://acme.com/x",
+        incomingQuery: "a=1",
+        forwardQuery: false,
+        utm: null,
+      }),
+    );
+  });
+
+  it("falls through (null) when the destination could not be decomposed", () => {
+    // No `base` — e.g. a stored destination URL could not parse.
+    expect(
+      edgeLocation(
+        { destination: "not a url", redirectType: "302", forwardQuery: true },
+        cfQuerystring("a=1"),
+      ),
+    ).toBeNull();
+  });
+
+  it("falls through (null) when an integer-like key makes the order unrecoverable", () => {
+    // "?a=1&0=2" reaches the Function as an object whose keys enumerate 0 first,
+    // so the original order is lost. Declining is correct; guessing is not.
+    expect(edgeLocation(payloadFor("https://acme.com/x"), cfQuerystring("a=1&0=2"))).toBeNull();
+    expect(edgeLocation(payloadFor("https://acme.com/x"), cfQuerystring("2=b"))).toBeNull();
+    // A non-numeric key that merely CONTAINS digits is fine.
+    expect(edgeLocation(payloadFor("https://acme.com/x"), cfQuerystring("a1=b"))).toBe(
+      viaLambda("https://acme.com/x", "a1=b"),
+    );
+  });
+
+  /* The real guarantee, and the invariant worth stating precisely: for ANY
+     destination and ANY incoming query the edge either reproduces the Lambda's
+     Location EXACTLY, or it declines (null) and the request falls through. There is
+     no third outcome — it never invents a different redirect. */
+  it("either matches buildDestination exactly or declines, for generated input", () => {
+    const token = fc.string({
+      unit: fc.constantFrom(...Array.from("abcXY019 -_.~!'()*+%&=?:/#[]é🙂")),
+      minLength: 1,
+      maxLength: 6,
+    });
+    const pair = fc.tuple(token, token);
+
+    const destination = fc
+      .tuple(
+        fc.constantFrom("https://acme.com", "https://acme.com:8443", "http://x.example"),
+        fc.constantFrom("", "/", "/p", "/a/b"),
+        fc.array(pair, { maxLength: 3 }),
+        fc.constantFrom("", "#f", "#a b"),
+      )
+      .map(([origin, path, params, hash]) => {
+        const search = params.length ? "?" + new URLSearchParams(params).toString() : "";
+        return origin + path + search + hash;
+      });
+
+    const incoming = fc
+      .array(pair, { maxLength: 4 })
+      .map((params) => new URLSearchParams(params).toString());
+
+    fc.assert(
+      fc.property(destination, incoming, (dest, query) => {
+        const got = edgeLocation(payloadFor(dest), cfQuerystring(query));
+        if (got === null) return; // declined — always safe, the Lambda answers
+        expect(got).toBe(viaLambda(dest, query));
+      }),
+      { numRuns: 1000 },
+    );
+  });
+
+  /* Declining must stay RARE, or the fast path is pointless. A plain query of
+     word-like keys — the overwhelmingly common case — must always merge. */
+  it("does not decline for ordinary word-like query keys", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.tuple(
+            fc.string({ unit: fc.constantFrom(..."abcdefgxyz_".split("")), minLength: 1, maxLength: 6 }),
+            fc.string({ unit: fc.constantFrom(..."abc019 -_".split("")), minLength: 0, maxLength: 6 }),
+          ),
+          { minLength: 1, maxLength: 4 },
+        ),
+        (params) => {
+          const query = new URLSearchParams(params).toString();
+          const got = edgeLocation(payloadFor("https://acme.com/x?keep=1"), cfQuerystring(query));
+          expect(got).not.toBeNull();
+          expect(got).toBe(viaLambda("https://acme.com/x?keep=1", query));
+        },
+      ),
+      { numRuns: 300 },
+    );
+  });
+});
+
+describe("decide serves the merged Location on a forwardQuery KVS hit", () => {
+  it("returns the merged destination", async () => {
+    const payload = kvsValue({
+      ...plainProjected,
+      destination: "https://acme.com/landing?utm_id=7",
+      forwardQuery: true,
+    });
+    const res = await decide(
+      eventFor({ uri: "/promo", querystring: { ref: { value: "news" } } }),
+      async () => payload,
+    );
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location.value).toBe(
+      buildDestination({
+        destination: "https://acme.com/landing?utm_id=7",
+        incomingQuery: "ref=news",
+        forwardQuery: true,
+        utm: null,
+      }),
+    );
+  });
+
+  it("falls through to the origin when the payload cannot be merged", async () => {
+    const res = await decide(
+      eventFor({ uri: "/promo", querystring: { ref: { value: "news" } } }),
+      async () => JSON.stringify({ destination: "::::", redirectType: "302", forwardQuery: true }),
+    );
+    // A request object (fall-through), not a response.
+    expect(res.statusCode).toBeUndefined();
+    expect(res.headers["x-forwarded-host"].value).toBe("snap.to");
   });
 });

--- a/infra/functions/redirect-viewer-request.test.ts
+++ b/infra/functions/redirect-viewer-request.test.ts
@@ -343,6 +343,56 @@ describe("formEncode matches URLSearchParams serialisation", () => {
     expect(() => formEncode(loneSurrogate)).toThrow(URIError);
     expect(new URLSearchParams([["x", loneSurrogate]]).toString()).toBe("x=%EF%BF%BD");
   });
+
+  /* EXHAUSTIVE, not sampled: every code point in the BMP outside the surrogate
+     range, compared against real URLSearchParams. Sampling 1000 random strings
+     cannot prove a single-character encoding table; enumerating it can. */
+  it("agrees with URLSearchParams for every non-surrogate BMP code point", () => {
+    const mismatches: string[] = [];
+    for (let cp = 0; cp <= 0xffff; cp++) {
+      if (cp >= 0xd800 && cp <= 0xdfff) continue; // lone surrogates: see above
+      const ch = String.fromCharCode(cp);
+      if (formEncode(ch) !== refValue(ch)) mismatches.push("U+" + cp.toString(16));
+    }
+    expect(mismatches).toEqual([]);
+  });
+});
+
+describe("the integer-like key guard declines exactly what it must", () => {
+  /* Verified against real object enumeration: a key is REORDERED (enumerated
+     before earlier-inserted string keys) only when it is a canonical array index
+     in 0..2^32-2. The guard's regex also declines 2^32-1 and above, which are NOT
+     reordered — over-declining is harmless (it just uses the Lambda), whereas
+     under-declining would emit a wrongly-ordered query. */
+  it.each([
+    ["0", true],
+    ["1", true],
+    ["10", true],
+    ["4294967294", true],
+    ["01", false],
+    ["1e2", false],
+    [" 1", false],
+    ["-1", false],
+    ["1.0", false],
+    ["a1", false],
+    ["1a", false],
+  ])("key %j is reordered by object enumeration: %s — and is declined iff needed", (key, reordered) => {
+    const obj: Record<string, number> = {};
+    obj.zz = 1;
+    obj[key] = 1;
+    const actuallyReordered = Object.keys(obj)[0] === key;
+    expect(actuallyReordered).toBe(reordered);
+
+    const declined =
+      edgeLocation(
+        JSON.parse(
+          kvsValue({ ...plainProjected, destination: "https://acme.com/x", forwardQuery: true }),
+        ),
+        { [key]: { value: "v" } },
+      ) === null;
+    // Safety: anything reordered MUST be declined. The converse is optional.
+    if (actuallyReordered) expect(declined).toBe(true);
+  });
 });
 
 describe("edgeLocation reproduces buildDestination byte-for-byte", () => {
@@ -390,6 +440,26 @@ describe("edgeLocation reproduces buildDestination byte-for-byte", () => {
     ["normalises the destination host", "https://ACME.com", "a=1"],
     ["preserves a port and userinfo-free authority", "https://acme.com:8443/x", "a=1"],
     ["skips the unlock token k", "https://acme.com/x", "k=secret&a=1"],
+    /* REGRESSION (found by the independent review, not by the property test — its
+       generator could not produce an empty-but-present delimiter). When `?` or `#`
+       is present but empty, url.search / url.hash are "" while href still carries
+       the character, so deriving base by subtracting their LENGTHS left the
+       delimiter in base and produced a genuinely wrong URL: "…/x??a=1", and worse
+       "…/x#?a=1" with the query AFTER the fragment. decomposeDestination now
+       splits href positionally. */
+    ["empty-but-present query delimiter", "https://acme.com/x?", "a=1"],
+    ["empty-but-present fragment delimiter", "https://acme.com/x#", "a=1"],
+    ["both delimiters present and empty", "https://acme.com/x?#", "a=1"],
+    ["fragment containing a question mark", "https://acme.com/x#f?g", "a=1"],
+    ["fragment with a question mark AND an existing query", "https://acme.com/x?p=1#f?g", "a=1"],
+    ["percent-encoded question mark in the path", "https://acme.com/a%3Fb", "a=1"],
+    ["userinfo in the authority", "https://u:p@acme.com/x", "a=1"],
+    ["IPv6 host", "https://[2001:db8::1]/x", "a=1"],
+    ["non-special scheme", "mailto:a@b.com", "a=1"],
+    ["non-special scheme with a query", "custom:opaque?z=1", "a=1"],
+    ["default port is stripped", "https://acme.com:443/x", "a=1"],
+    ["dot segments in the path", "https://acme.com/a/../b", "a=1"],
+    ["query but no path", "https://acme.com?z=1", "a=1"],
   ];
 
   it.each(cases)("%s", (_name, destination, incomingQuery) => {

--- a/infra/package.json
+++ b/infra/package.json
@@ -14,10 +14,12 @@
   },
   "devDependencies": {
     "@snapurl/database": "workspace:*",
+    "@snapurl/domain": "workspace:*",
     "@types/node": "^22",
     "aws-cdk": "^2.1029.4",
     "aws-cdk-lib": "^2.221.0",
     "constructs": "^10.4.2",
+    "fast-check": "^4.9.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^3.2.4"

--- a/packages/database/src/link-projection.test.ts
+++ b/packages/database/src/link-projection.test.ts
@@ -179,8 +179,13 @@ describe("isEdgeEligible", () => {
   /* Transform behaviours the Lambda applies on the happy path and the edge
      cannot reproduce — each independently makes a link ineligible so the raw
      stored destination is never served in place of the transformed one. */
-  it("is false when the link forwards the incoming query", () => {
-    expect(isEdgeEligible({ ...plain, forwardQuery: true })).toBe(false);
+
+  /* forwardQuery is the exception (#395): the edge DOES reproduce it, from the
+     base/params/hash kvsValue stores. It had to be admitted — forwardQuery
+     defaults to true, so gating on it made every default-created link ineligible
+     and the KeyValueStore stayed permanently empty. */
+  it("is TRUE when the link forwards the incoming query (the edge merges it)", () => {
+    expect(isEdgeEligible({ ...plain, forwardQuery: true })).toBe(true);
   });
 
   it("is false when the link injects stored UTM params", () => {

--- a/packages/database/src/link-projection.ts
+++ b/packages/database/src/link-projection.ts
@@ -267,9 +267,26 @@ export function kvsKey(host: string, slug: string): string {
  *    reproduce: the redirect Lambda runs buildDestination (which merges the
  *    forwarded query when `forwardQuery` and injects stored `utm`), buildDeepLink
  *    (when `deepLink`), and sets `Referrer-Policy: no-referrer` (when
- *    `hideReferrer`). The edge returns only the raw stored destination, so any of
- *    `forwardQuery`, a non-null `utm`, `deepLink`, or `hideReferrer` would make
+ *    `hideReferrer`). A non-null `utm`, `deepLink`, or `hideReferrer` would make
  *    the edge response materially wrong. Keep those links on the Lambda.
+ *
+ *    `forwardQuery` is the ONE transform the edge now does reproduce (#395), and
+ *    it had to be admitted or the fast path served nothing at all: forwardQuery
+ *    defaults to true (links.ts / contract link.ts), so gating on it excluded
+ *    100% of default-created links and the KeyValueStore sat permanently empty
+ *    while every redirect paid the full Lambda + VPC + DB cost.
+ *
+ *    The edge reproduces it byte-for-byte WITHOUT a URL parser, which it does
+ *    not have (the CloudFront Functions JS 2.0 runtime has no URL and no
+ *    URLSearchParams — only Buffer/querystring/crypto). Instead kvsValue below
+ *    stores the destination already DECOMPOSED by this module, running in Node
+ *    with the real WHATWG URL: a `base` prefix, the destination's own query as
+ *    already-normalised `params` pairs, and its `hash`. The Function then applies
+ *    URLSearchParams.set semantics over those pairs and re-serialises with the
+ *    identical application/x-www-form-urlencoded algorithm, so both sides emit
+ *    the same bytes because both serialise the same pairs — neither re-parses a
+ *    URL. A destination this module cannot parse simply carries no `base`, and
+ *    the Function falls through to the Lambda.
  *
  *  - Only a plain 302: 301 and 307 both fall through to the Lambda. A 301's
  *    permanence is honoured on the Lambda with `public, max-age=300`
@@ -291,7 +308,6 @@ export function isEdgeEligible(link: ProjectedLink): boolean {
     link.activatesAt == null &&
     link.archived === false &&
     link.safeBrowsingStatus === "clean" &&
-    link.forwardQuery === false &&
     link.utm == null &&
     link.deepLink === false &&
     link.hideReferrer === false &&
@@ -299,13 +315,83 @@ export function isEdgeEligible(link: ProjectedLink): boolean {
   );
 }
 
+/** The destination split into the three pieces the edge needs to rebuild it.
+ *
+ *  Computed HERE, in Node, with the real WHATWG `URL` — the CloudFront Function
+ *  has neither `URL` nor `URLSearchParams`, so it must never parse a URL itself.
+ *
+ *  - `href`  the fully normalised destination, i.e. exactly what the redirect
+ *            Lambda's `buildDestination` returns when nothing is merged in
+ *            (`new URL(dest).toString()`). Storing the normalised form (not the
+ *            raw column) is what makes the no-incoming-query edge response
+ *            byte-identical to the Lambda's, including normalisations like
+ *            `https://EXAMPLE.com` -> `https://example.com/`.
+ *  - `base`  `href` with the query and fragment removed. Derived by slicing off
+ *            `search` + `hash` rather than by re-joining origin+pathname, so it
+ *            is correct for non-special schemes too (whose `origin` is "null").
+ *  - `params` the destination's OWN query as pairs, already run through
+ *            URLSearchParams — so re-serialising them reproduces what the
+ *            Lambda's `url.searchParams` mutation would emit.
+ *  - `hash`  the fragment including "#", or "" — preserved verbatim, exactly as
+ *            `URL` already percent-encoded it, and always emitted last.
+ *
+ *  Returns null for a destination `URL` cannot parse. Stored destinations are
+ *  validated on write, so that is a last resort — and it is a SAFE one: without
+ *  `base` the Function cannot merge and falls through to the Lambda. */
+export function decomposeDestination(
+  destination: string,
+): { href: string; base: string; params: Array<[string, string]>; hash: string } | null {
+  let url: URL;
+  try {
+    url = new URL(destination);
+  } catch {
+    return null;
+  }
+  const href = url.toString();
+  const hash = url.hash;
+  /* href === base + search + hash, so peel the two known tails off the end. */
+  const base = href.slice(0, href.length - url.search.length - hash.length);
+  const params: Array<[string, string]> = [];
+  for (const [key, value] of url.searchParams) params.push([key, value]);
+  return { href, base, params, hash };
+}
+
 /** The KeyValueStore value for a link: the minimum the edge needs to answer a
- *  redirect. JSON `{ destination, redirectType }` — a URL plus a 3-char code is
- *  far under the 1 KB per-value limit (and 5 MB per-store), so no truncation
- *  guard is needed. The CloudFront Function JSON.parses this and reads exactly
- *  these two fields. */
+ *  redirect.
+ *
+ *  `{ destination, redirectType }` is the whole payload for a link that does not
+ *  forward the query. A `forwardQuery` link additionally carries the decomposed
+ *  `base` / `params` / `hash` (see decomposeDestination) so the Function can
+ *  merge the incoming query without a URL parser. Those three are omitted
+ *  otherwise, which keeps the common value as small as it was before #395.
+ *
+ *  A URL plus a 3-char code is far under the 1 KB per-value limit; the decomposed
+ *  form roughly doubles it, which is still comfortably inside for ordinary links.
+ *  Pathological cases are not truncated here — the writer (KvsWriter.putIfEligible)
+ *  refuses an oversized value and leaves the link on the Lambda, because a
+ *  truncated value would produce a WRONG redirect rather than a missing one. */
 export function kvsValue(link: ProjectedLink): string {
-  return JSON.stringify({ destination: link.destination, redirectType: link.redirectType });
+  const parts = decomposeDestination(link.destination);
+  const value: {
+    destination: string;
+    redirectType: string;
+    forwardQuery?: true;
+    base?: string;
+    params?: Array<[string, string]>;
+    hash?: string;
+  } = {
+    destination: parts ? parts.href : link.destination,
+    redirectType: link.redirectType,
+  };
+  if (link.forwardQuery) {
+    value.forwardQuery = true;
+    if (parts) {
+      value.base = parts.base;
+      value.params = parts.params;
+      value.hash = parts.hash;
+    }
+  }
+  return JSON.stringify(value);
 }
 
 /** ProjectedDomain -> stored DomainItem. */

--- a/packages/database/src/link-projection.ts
+++ b/packages/database/src/link-projection.ts
@@ -326,14 +326,26 @@ export function isEdgeEligible(link: ProjectedLink): boolean {
  *            raw column) is what makes the no-incoming-query edge response
  *            byte-identical to the Lambda's, including normalisations like
  *            `https://EXAMPLE.com` -> `https://example.com/`.
- *  - `base`  `href` with the query and fragment removed. Derived by slicing off
- *            `search` + `hash` rather than by re-joining origin+pathname, so it
- *            is correct for non-special schemes too (whose `origin` is "null").
+ *  - `base`  `href` up to (not including) the first `?` or `#`.
  *  - `params` the destination's OWN query as pairs, already run through
  *            URLSearchParams — so re-serialising them reproduces what the
  *            Lambda's `url.searchParams` mutation would emit.
- *  - `hash`  the fragment including "#", or "" — preserved verbatim, exactly as
- *            `URL` already percent-encoded it, and always emitted last.
+ *  - `hash`  everything from the first `#` onwards, or "" when there is none.
+ *            Preserved verbatim, exactly as `URL` already percent-encoded it, and
+ *            always emitted last.
+ *
+ *  The split is POSITIONAL, on `href`, and deliberately not `href.length -
+ *  search.length - hash.length`: for an EMPTY-BUT-PRESENT delimiter those two
+ *  properties are "" while `href` still carries the character, so the arithmetic
+ *  form left the delimiter inside `base` and produced genuinely wrong URLs —
+ *  `https://a.com/x?` merged to `https://a.com/x??a=1`, and `https://a.com/x#`
+ *  to `https://a.com/x#?a=1`, i.e. the query AFTER the fragment. Both are pinned
+ *  as regression cases in redirect-viewer-request.test.ts.
+ *
+ *  Scanning for `#` FIRST and only then for `?` within the part before it is what
+ *  keeps a fragment containing a question mark (`/x#f?g`) intact. Neither
+ *  character can appear un-encoded earlier in a normalised href (a literal `?` in
+ *  a path or userinfo is %3F), so indexOf is unambiguous here.
  *
  *  Returns null for a destination `URL` cannot parse. Stored destinations are
  *  validated on write, so that is a last resort — and it is a SAFE one: without
@@ -348,9 +360,11 @@ export function decomposeDestination(
     return null;
   }
   const href = url.toString();
-  const hash = url.hash;
-  /* href === base + search + hash, so peel the two known tails off the end. */
-  const base = href.slice(0, href.length - url.search.length - hash.length);
+  const hashAt = href.indexOf("#");
+  const beforeHash = hashAt === -1 ? href : href.slice(0, hashAt);
+  const hash = hashAt === -1 ? "" : href.slice(hashAt);
+  const queryAt = beforeHash.indexOf("?");
+  const base = queryAt === -1 ? beforeHash : beforeHash.slice(0, queryAt);
   const params: Array<[string, string]> = [];
   for (const [key, value] of url.searchParams) params.push([key, value]);
   return { href, base, params, hash };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       '@snapurl/database':
         specifier: workspace:*
         version: link:../packages/database
+      '@snapurl/domain':
+        specifier: workspace:*
+        version: link:../packages/domain
       '@types/node':
         specifier: ^22
         version: 22.20.1
@@ -249,6 +252,9 @@ importers:
       constructs:
         specifier: ^10.4.2
         version: 10.8.1
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       tsx:
         specifier: ^4.19.2
         version: 4.23.12


### PR DESCRIPTION
Closes #395.

## The problem

The #289 edge fast path served **nothing** in production. `isEdgeEligible` required `forwardQuery === false`, but `forwardQuery` **defaults to true** (`links.ts:92`, `link.ts:74,127`) — so 100% of default-created links were ineligible, the CloudFront KeyValueStore sat permanently empty (verified live: `ItemCount 0`), and every redirect paid the full Lambda + VPC + DB cost for an optimization that was built, deployed, and being paid for.

## The approach

Admit `forwardQuery` links and reproduce `buildDestination`'s merge at the edge.

The hard constraint: **CloudFront Functions JS 2.0 has no `URL` and no `URLSearchParams`** (only `Buffer`/`querystring`/`crypto`). Hand-rolling a URL parser at the edge would risk the edge and the Lambda disagreeing on the same link — a cache-dependent inconsistency that is close to undebuggable in production.

So the edge never parses a URL. `kvsValue` now stores the destination **already decomposed** by `@snapurl/database` (running in Node, with the real WHATWG `URL`) into `base` + `params` + `hash`, and the Function applies `URLSearchParams.set` semantics over those pairs and re-serialises with an identical `application/x-www-form-urlencoded` algorithm. **Both sides serialise the same pairs — that is what makes the bytes agree**, rather than two parsers happening to concur.

The stored destination is now the **normalised** href, so even the no-incoming-query response matches the Lambda exactly (e.g. `https://EXAMPLE.com` -> `https://example.com/`). That was a latent mismatch before this PR.

## Safety is a test, not an argument

A differential property test asserts the real invariant:

> the edge either reproduces `buildDestination` **exactly**, or it declines and falls through — never a third answer.

over 1000 generated destination/query pairs, plus 1000 runs comparing the hand-rolled encoder against Node's real `URLSearchParams`, plus a check that ordinary word-like keys are **never** declined (or the fast path would be pointless).

**That property test found two real defects before they shipped**, both of which my reasoning had missed:

1. **Integer-like query keys.** JS objects enumerate integer-like keys *first*, in ascending numeric order, before string keys. CloudFront hands over a parsed object with no raw query string, so for `?a=1&0=2` the original left-to-right order is genuinely **unrecoverable** — and order determines the serialised query. The edge now declines on a numeric key rather than emit a reordered (wrong) Location.
2. **Lone surrogates.** `encodeURIComponent` throws `URIError` where `URLSearchParams` substitutes U+FFFD. `decide()`'s `try/catch` already makes that a safe fall-through; it is now asserted rather than assumed.

## Also

`KvsWriter` **deletes** rather than writes a value over CloudFront's 1 KB per-value cap. The decomposed form is roughly twice the size, so a long-query destination can now approach it, and a truncated value would make the edge answer with a *mangled* destination — strictly worse than not answering.

The drift-guarded region was updated by splicing it verbatim from the deployed `.js` into the `.logic.mjs` twin, so the two are byte-identical by construction rather than by careful retyping; the existing drift-guard test still passes.

## Verification

- `infra` **54 passed** (drift guard + all new differential/property tests)
- `packages/database` 65 passed, `apps/worker` 50 passed, `packages/domain` 126 passed, `apps/redirect` 17 passed
- `pnpm -r type-check` clean across every package

Not yet deployed — the KeyValueStore only fills as the worker re-projects links, so after deploy I will confirm `ItemCount` rises and spot-check that an edge-served redirect returns the same Location as the Lambda for the same link with a query.

`@snapurl/domain` and `fast-check` are added as **test-only** devDependencies of `infra` so the differential test can compare against the real `buildDestination`.