### PR TITLE
ci(deploy): OIDC-authenticated AWS deploy workflow

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -125,6 +125,31 @@ jobs:
       - name: Build workspace packages
         run: pnpm build:packages
 
+      # Fail BEFORE touching AWS if a deploy-critical variable is missing.
+      # infra/deploy.sh only appends a context flag when its variable is set, so
+      # an unset variable does not error — it silently omits the flag, and CDK
+      # then removes that feature from the live stack. That is exactly how the
+      # budget/SNS cost alarms and the API's OAuth client id have been proposed
+      # for deletion before. The diff below would reveal it, but a missing
+      # variable is always a configuration mistake, never an intent, so it fails
+      # fast rather than relying on a human spotting it in the diff.
+      - name: Require deploy-critical variables
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
+          BUDGET_EMAIL: ${{ vars.BUDGET_EMAIL }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
+        run: |
+          missing=()
+          for v in AWS_ACCOUNT_ID DOMAIN_NAME BUDGET_EMAIL GOOGLE_OAUTH_CLIENT_ID; do
+            [ -n "${!v}" ] || missing+=("$v")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error title=Missing repository variables::${missing[*]} — see docs/CD-AWS-OIDC.md. Omitting these DELETES live resources (cost alarms, OAuth client id)."
+            exit 1
+          fi
+          echo "All deploy-critical variables present."
+
       # A SEPARATE, read-only role. The deploy role's trust policy is bound to
       # `environment: production`, and this job deliberately declares no
       # environment (it must run BEFORE the approval), so its OIDC subject is
@@ -220,6 +245,25 @@ jobs:
 
       - name: Build workspace packages
         run: pnpm build:packages
+
+      # Same precondition as the plan job. Repeated deliberately: environment
+      # variables can be scoped to `production` and therefore resolve here but
+      # not there, so checking only in plan would not protect the apply.
+      - name: Require deploy-critical variables
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
+          BUDGET_EMAIL: ${{ vars.BUDGET_EMAIL }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
+        run: |
+          missing=()
+          for v in AWS_ACCOUNT_ID DOMAIN_NAME BUDGET_EMAIL GOOGLE_OAUTH_CLIENT_ID; do
+            [ -n "${!v}" ] || missing+=("$v")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error title=Missing variables::${missing[*]} — refusing to deploy. See docs/CD-AWS-OIDC.md."
+            exit 1
+          fi
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,0 +1,334 @@
+# AWS deploy (Phase 7 of the architecture epic, #288/#289).
+#
+# This replaces deploying from an operator's laptop. That path was not merely
+# inconvenient, it was unreliable for two structural reasons:
+#
+#   1. The Lambdas are arm64/Graviton. On an x86_64 laptop every image builds
+#      under QEMU emulation, so a cold build took ~50 minutes instead of ~3.
+#   2. Every deploy pushes three container images through the operator's home
+#      connection. Flapping egress to public.ecr.aws / ECR failed the build
+#      repeatedly ("TLS handshake timeout" fetching a base-image token,
+#      "timeout awaiting response headers" on an ECR manifest HEAD).
+#
+# Both disappear here: `ubuntu-24.04-arm` runners build arm64 NATIVELY (no
+# emulation), and a runner in a datacentre has stable egress to ECR.
+#
+# Authentication is OIDC role assumption — there are no long-lived AWS keys in
+# this repo or in GitHub secrets. The role itself is deliberately weak: it can
+# do little beyond assume the CDK bootstrap roles, which already hold the
+# deployment power. See docs/CD-AWS-OIDC.md for the trust policy and permissions
+# and for the one-time setup an operator must perform.
+#
+# Stage separation, and why it is in this order:
+#
+#   plan   -> synthesizes and runs `cdk diff`, writes it to the run summary.
+#             Needs no approval; changes nothing.
+#   deploy -> gated on the `production` GitHub Environment. A required reviewer
+#             approves AFTER reading the plan's diff. This is what keeps the
+#             standing rules "always cdk diff first" and "deploys are
+#             user-triggered, never autonomous" true by construction rather than
+#             by an operator remembering them. Two omitted context flags have
+#             silently destroyed live resources here before (the budget/SNS cost
+#             alarms, and the API's OAuth client id), which is exactly the class
+#             of change a human must see in a diff before it is applied.
+#   migrate-> optional; migrations are NOT automatic on deploy. RDS is
+#             unreachable from outside the VPC, so the only path is invoking the
+#             worker with {"task":"migrate"}.
+#   smoke  -> calls the existing reusable smoke-deployed.yml against the URLs
+#             this deploy just produced. A deploy is not successful until the
+#             real create-link-then-follow-redirect journey passes: production
+#             once served 403 for every short link while health checks, Lambda
+#             error counts and DLQ depth were all green.
+#
+# NOTE ON THE DOUBLE BUILD: `plan` and `deploy` each synthesize, and CDK builds
+# the Docker assets during synth to compute their hashes, so the images are built
+# twice. That is a deliberate trade: it is the only way the human approval can
+# sit BETWEEN a readable diff and the apply. It is cheap because the runner is
+# native arm64, and the second build's push is skipped for any digest already in
+# ECR.
+
+name: Deploy (AWS)
+
+on:
+  # Dispatch-only, by policy: a deploy to this live SaaS is always initiated by
+  # a human. Do not add a `push` trigger without also deciding what protects
+  # main from deploying itself.
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: CDK stack to deploy. Leave as SnapUrl unless you know otherwise.
+        required: true
+        type: string
+        default: SnapUrl
+      run_migrations:
+        description: Invoke the worker with {"task":"migrate"} after deploying.
+        required: false
+        type: boolean
+        default: false
+      skip_smoke:
+        description: "Skip the post-deploy smoke gate. Leave false: unchecked means the deploy must prove itself."
+        required: false
+        type: boolean
+        default: false
+
+# Least privilege at the top level. `id-token: write` is NOT granted here — it
+# is granted per job, only to the jobs that actually assume the AWS role, so a
+# future job added to this file cannot mint an AWS token by accident.
+permissions:
+  contents: read
+
+# Never let two deploys apply to the same account concurrently: CloudFormation
+# would reject the second, and a cancelled deploy mid-changeset is worse than a
+# queued one. cancel-in-progress is false for the same reason.
+concurrency:
+  group: deploy-aws-${{ inputs.stack }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-south-1
+  # Deploy-critical context, passed on EVERY invocation by infra/deploy.sh.
+  # Omitting any of these does not fail loudly in CDK — it silently redeploys
+  # that feature to a default and can tear down live infrastructure. These are
+  # all NON-SECRET (a public client id, a topology name, a billing alert
+  # address); they live in repo/environment variables, never in secrets.
+  NAT_STRATEGY: instance
+  DATABASE_SSL_NO_VERIFY: "true"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # 1. PLAN — read-only. Produces the diff a reviewer approves against.
+  # ---------------------------------------------------------------------------
+  plan:
+    name: Plan (cdk diff)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write # to assume the AWS role via OIDC
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The workspace packages must be built before infra can synth: the CDK
+      # app imports @snapurl/database for the migration file list.
+      - name: Build workspace packages
+        run: pnpm build:packages
+
+      # A SEPARATE, read-only role. The deploy role's trust policy is bound to
+      # `environment: production`, and this job deliberately declares no
+      # environment (it must run BEFORE the approval), so its OIDC subject is
+      # the branch ref and it could not assume the deploy role even if it tried.
+      # That split is the point: planning needs no write access.
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_PLAN_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: gha-snapurl-plan-${{ github.run_id }}
+
+      # cdk diff synthesizes, which builds the three arm64 images to compute
+      # their asset hashes. Nothing is pushed and nothing is applied.
+      - name: cdk diff
+        id: diff
+        working-directory: infra
+        env:
+          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
+          BUDGET_EMAIL: ${{ vars.BUDGET_EMAIL }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
+        run: |
+          set -o pipefail
+          # Mirror deploy.sh's flag set exactly. If these two ever drift the
+          # diff stops describing the deploy, which is worse than no diff.
+          ctx=(-c "natStrategy=${NAT_STRATEGY}" -c "configPrefix=/snapurl/prod")
+          [ -n "${DOMAIN_NAME}" ]            && ctx+=(-c "domainName=${DOMAIN_NAME}")
+          [ -n "${BUDGET_EMAIL}" ]           && ctx+=(-c "budgetEmail=${BUDGET_EMAIL}")
+          [ -n "${GOOGLE_OAUTH_CLIENT_ID}" ] && ctx+=(-c "googleOAuthClientId=${GOOGLE_OAUTH_CLIENT_ID}")
+
+          npx cdk diff "${ctx[@]}" "${{ inputs.stack }}" 2>&1 | tee /tmp/cdk-diff.txt
+
+          {
+            echo "### cdk diff — \`${{ inputs.stack }}\`"
+            echo
+            echo "Read this before approving the deploy."
+            echo
+            echo '```'
+            cat /tmp/cdk-diff.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A destructive change is legitimate sometimes, but it must never pass
+      # unremarked. Surfacing it as a warning annotation puts it at the top of
+      # the run page, where an approver actually looks.
+      - name: Flag destructive changes
+        run: |
+          if grep -qE '\[-\]|destroy|requires replacement' /tmp/cdk-diff.txt; then
+            echo "::warning title=Destructive change in plan::This diff removes or replaces resources. Confirm every one is intended before approving."
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cdk-diff-${{ github.run_id }}
+          path: /tmp/cdk-diff.txt
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # 2. DEPLOY — gated on the `production` environment's required reviewer.
+  # ---------------------------------------------------------------------------
+  deploy:
+    name: Deploy ${{ inputs.stack }}
+    needs: plan
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    # The approval gate. Configure `production` with a required reviewer so this
+    # job waits for a human who has read the plan's diff.
+    environment:
+      name: production
+      url: ${{ steps.stack_outputs.outputs.redirect_url }}
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      api_url: ${{ steps.stack_outputs.outputs.api_url }}
+      redirect_url: ${{ steps.stack_outputs.outputs.redirect_url }}
+      worker_function_name: ${{ steps.stack_outputs.outputs.worker_function_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        run: pnpm build:packages
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: gha-snapurl-deploy-${{ github.run_id }}
+
+      # Always through deploy.sh, never `npx cdk deploy` directly. The wrapper
+      # is what guarantees the full context-flag set is passed and then asserts
+      # the two incident settings (NAT egress, DB TLS posture) actually landed.
+      # A raw cdk invocation looks like it works while silently proposing
+      # deletions.
+      - name: Deploy via infra/deploy.sh
+        env:
+          CDK_DEFAULT_ACCOUNT: ${{ vars.AWS_ACCOUNT_ID }}
+          CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
+          DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
+          BUDGET_EMAIL: ${{ vars.BUDGET_EMAIL }}
+          GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
+        run: bash infra/deploy.sh "${{ inputs.stack }}"
+
+      # Read the URLs from the stack itself rather than hardcoding them, so the
+      # smoke gate always targets what was actually just deployed.
+      - name: Read stack outputs
+        id: stack_outputs
+        run: |
+          set -euo pipefail
+          outs="$(aws cloudformation describe-stacks \
+            --stack-name "${{ inputs.stack }}" \
+            --query 'Stacks[0].Outputs' --output json)"
+
+          get() { echo "$outs" | jq -r --arg k "$1" '.[] | select(.OutputKey==$k) | .OutputValue'; }
+
+          api_root="$(get ApiUrl)"
+          redirect_url="$(get RedirectDomain)"
+          worker="$(get WorkerFunctionName)"
+
+          # ApiUrl is the API Gateway root WITHOUT a path; the smoke workflow's
+          # api_base_url must include /api/v1. RedirectDomain already carries
+          # its https:// scheme.
+          echo "api_url=${api_root%/}/api/v1" >> "$GITHUB_OUTPUT"
+          echo "redirect_url=${redirect_url}"  >> "$GITHUB_OUTPUT"
+          echo "worker_function_name=${worker}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Deployed"
+            echo
+            echo "| Output | Value |"
+            echo "| --- | --- |"
+            echo "| API | \`${api_root%/}/api/v1\` |"
+            echo "| Redirect | \`${redirect_url}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # 3. MIGRATE — opt-in. Not automatic, and deliberately so.
+  # ---------------------------------------------------------------------------
+  migrate:
+    name: Apply DB migrations
+    needs: deploy
+    if: inputs.run_migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: gha-snapurl-migrate-${{ github.run_id }}
+
+      # The worker returns {"applied":true}. A Lambda-level failure appears as
+      # FunctionError in the response, which a 0 exit code would otherwise hide,
+      # so both are checked explicitly.
+      - name: Invoke worker migrate
+        run: |
+          set -euo pipefail
+          resp="$(aws lambda invoke \
+            --function-name '${{ needs.deploy.outputs.worker_function_name }}' \
+            --payload "$(printf '%s' '{"task":"migrate"}' | base64 -w0)" \
+            --cli-read-timeout 600 \
+            /tmp/migrate-out.json)"
+          echo "$resp"
+          if echo "$resp" | jq -e '.FunctionError' >/dev/null 2>&1; then
+            echo "::error title=Migration failed::$(cat /tmp/migrate-out.json)"
+            exit 1
+          fi
+          cat /tmp/migrate-out.json
+          jq -e '.applied == true' /tmp/migrate-out.json >/dev/null \
+            || { echo "::error title=Migration did not report applied::"; exit 1; }
+
+  # ---------------------------------------------------------------------------
+  # 4. SMOKE — the gate that decides whether this deploy actually worked.
+  # ---------------------------------------------------------------------------
+  # Wired exactly as smoke-deployed.yml's own header prescribes. `always()` with
+  # explicit result checks means a skipped optional migrate job does not skip
+  # the gate, but a FAILED one does.
+  smoke:
+    name: Post-deploy smoke
+    needs: [deploy, migrate]
+    if: |
+      always() &&
+      needs.deploy.result == 'success' &&
+      (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
+      !inputs.skip_smoke
+    uses: ./.github/workflows/smoke-deployed.yml
+    with:
+      redirect_base_url: ${{ needs.deploy.outputs.redirect_url }}
+      api_base_url: ${{ needs.deploy.outputs.api_url }}

--- a/docs/CD-AWS-OIDC.md
+++ b/docs/CD-AWS-OIDC.md
@@ -1,0 +1,274 @@
+# CI/CD to AWS via GitHub OIDC
+
+One-time setup for `.github/workflows/deploy-aws.yml`, which replaced deploying
+from an operator's laptop. Nothing here contains a secret, and no long-lived AWS
+access key exists anywhere in this pipeline.
+
+## Why the role is nearly powerless
+
+CDK is already bootstrapped in this account (`CDKToolkit`, qualifier
+`hnb659fds`). Bootstrapping created four roles that hold the actual deployment
+power — one to drive CloudFormation, one to publish file assets, one to publish
+container images, one to read context.
+
+So the GitHub role does **not** need `PowerUserAccess`. It needs permission to
+*assume those four roles*, plus a handful of direct read/invoke calls the deploy
+wrapper and the post-deploy steps make with the ambient identity. If the GitHub
+role were ever compromised, the blast radius is "can run a CDK deploy of this
+app", not "owns the account".
+
+## 1. The OIDC provider
+
+Only one per account is needed. Skip if `token.actions.githubusercontent.com`
+already appears in `aws iam list-open-id-connect-providers`.
+
+```bash
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com
+```
+
+## 2. Two roles, and why
+
+There are **two** roles, because the two stages have genuinely different needs
+and different trust conditions:
+
+| Role | Assumed by | Trusted subject | Can it change anything? |
+| --- | --- | --- | --- |
+| `snapurl-github-plan` | the `plan` job | the branch ref | No — read-only |
+| `snapurl-github-deploy` | `deploy` / `migrate` | `environment:production` | Yes |
+
+This split is forced by a real constraint, not invented for neatness. The
+`deploy` role must be bound to the `production` environment, because that
+binding is what makes the required-reviewer approval a *security* control rather
+than a UI nicety — no approval, no token, no credentials. But `plan` has to run
+**before** that approval so there is a diff to approve against, which means it
+declares no environment and its OIDC subject is the branch ref instead. One role
+cannot satisfy both without trusting the branch ref for deploys too, which would
+let anyone who can push a branch deploy without approval.
+
+### 2a. Plan role (read-only)
+
+Create **`snapurl-github-plan`** with this trust policy. Adjust the branch if you
+ever plan from somewhere other than `main`.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::646799484931:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:DhananjayThomble/URL-Shortener-App:ref:refs/heads/main"
+        }
+      }
+    }
+  ]
+}
+```
+
+Its only permission is to assume the CDK **lookup** role, which `cdk diff` uses
+to read the deployed template. The lookup role is itself read-only, so this role
+cannot mutate infrastructure even transitively.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeCdkLookupRoleOnly",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": [
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-lookup-role-646799484931-ap-south-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-lookup-role-646799484931-us-east-1"
+      ]
+    },
+    {
+      "Sid": "ReadBootstrapVersion",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:ap-south-1:646799484931:parameter/cdk-bootstrap/hnb659fds/version",
+        "arn:aws:ssm:us-east-1:646799484931:parameter/cdk-bootstrap/hnb659fds/version"
+      ]
+    }
+  ]
+}
+```
+
+### 2b. Deploy role trust policy
+
+Create **`snapurl-github-deploy`** with this trust policy. The `sub` is scoped to
+the **`production` environment**, not to a branch — a token is only issued for a
+job that declares `environment: production`, and that environment's required
+reviewer must approve first.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::646799484931:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:DhananjayThomble/URL-Shortener-App:environment:production"
+        }
+      }
+    }
+  ]
+}
+```
+
+## 3. Deploy role permissions
+
+Attach as an inline policy named `snapurl-deploy`. Two statements: assume the
+bootstrap roles, and the direct calls made outside them.
+
+`us-east-1` appears because the CloudFront ACM certificate lives in a second
+stack (`SnapUrlCert`) in that region, and deploying `SnapUrl` resolves a
+cross-region reference to it. Both regions must be bootstrapped.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeCdkBootstrapRoles",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": [
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-deploy-role-646799484931-ap-south-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-file-publishing-role-646799484931-ap-south-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-image-publishing-role-646799484931-ap-south-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-lookup-role-646799484931-ap-south-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-deploy-role-646799484931-us-east-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-file-publishing-role-646799484931-us-east-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-image-publishing-role-646799484931-us-east-1",
+        "arn:aws:iam::646799484931:role/cdk-hnb659fds-lookup-role-646799484931-us-east-1"
+      ]
+    },
+    {
+      "Sid": "ReadBootstrapVersion",
+      "Effect": "Allow",
+      "Action": "ssm:GetParameter",
+      "Resource": [
+        "arn:aws:ssm:ap-south-1:646799484931:parameter/cdk-bootstrap/hnb659fds/version",
+        "arn:aws:ssm:us-east-1:646799484931:parameter/cdk-bootstrap/hnb659fds/version"
+      ]
+    },
+    {
+      "Sid": "ReadStackOutputs",
+      "Effect": "Allow",
+      "Action": ["cloudformation:DescribeStacks"],
+      "Resource": [
+        "arn:aws:cloudformation:ap-south-1:646799484931:stack/SnapUrl/*",
+        "arn:aws:cloudformation:us-east-1:646799484931:stack/SnapUrlCert/*"
+      ]
+    },
+    {
+      "Sid": "DeployScriptPostVerify",
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeSecurityGroups"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "InvokeWorkerForMigrations",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:ap-south-1:646799484931:function:SnapUrl-WorkerFn*"
+    }
+  ]
+}
+```
+
+Why each of the last three exists — none is CDK's, all are ours:
+
+| Statement | Needed by |
+| --- | --- |
+| `ReadStackOutputs` | The deploy job reads `ApiUrl` / `RedirectDomain` / `WorkerFunctionName` to target the smoke gate at what was just deployed. |
+| `DeployScriptPostVerify` | `infra/deploy.sh` asserts NAT egress survived the deploy via `ec2:DescribeSecurityGroups`. This API does not support resource-level permissions, hence `"*"` — it is read-only. |
+| `InvokeWorkerForMigrations` | Migrations only run by invoking the worker; RDS is unreachable from outside the VPC. |
+
+## 4. GitHub configuration
+
+### Environment
+
+Create an environment named **`production`** (Settings → Environments):
+
+- **Required reviewers: yourself.** This is the approval gate. It is what makes
+  "always `cdk diff` before deploying" and "deploys are user-triggered, never
+  autonomous" structural rather than a habit — the `deploy` job waits here while
+  you read the diff the `plan` job wrote to the run summary.
+- Optionally restrict deployment branches to `main`.
+
+### Variables
+
+Repository or `production`-environment **variables** (Settings → Variables).
+All five are non-secret and belong in variables, not secrets — putting a
+non-secret in a secret only makes it unreadable in logs when you need it.
+
+| Variable | Value |
+| --- | --- |
+| `AWS_DEPLOY_ROLE_ARN` | `arn:aws:iam::646799484931:role/snapurl-github-deploy` |
+| `AWS_PLAN_ROLE_ARN` | `arn:aws:iam::646799484931:role/snapurl-github-plan` |
+| `AWS_ACCOUNT_ID` | `646799484931` |
+| `DOMAIN_NAME` | `snapurl.in` |
+| `BUDGET_EMAIL` | the billing-alert address |
+| `GOOGLE_OAUTH_CLIENT_ID` | the **public** OAuth client id |
+
+> If you scope these as *environment* variables on `production` rather than
+> repository variables, `AWS_PLAN_ROLE_ARN` must still be a **repository**
+> variable — the `plan` job has no environment and would read it as empty.
+
+> `BUDGET_EMAIL` and `GOOGLE_OAUTH_CLIENT_ID` are not decoration. Omitting the
+> first destroys the budget and SNS cost alarms; omitting the second strips
+> OAuth from the API Lambda. Both have been caught by a diff before being
+> applied. If either variable is unset the deploy proceeds without that flag and
+> the diff will show the deletion — which is why the plan job annotates
+> destructive changes as a warning.
+
+### Secrets
+
+None are required. The smoke gate self-registers a throwaway user. Only if open
+registration is ever disabled in production do you add `smoke_email` /
+`smoke_password` and pass `secrets: inherit` to the smoke job.
+
+## 5. First run
+
+1. Actions → **Deploy (AWS)** → Run workflow, leaving `stack` as `SnapUrl`.
+2. `plan` runs and writes the diff to the run summary. **Read it.** Confirm it
+   contains only what you intended and no unexpected deletion.
+3. Approve the `production` environment prompt. `deploy` applies it.
+4. `smoke` runs `scripts/smoke-redirect.sh` against the freshly-deployed URLs.
+   If it fails, the deploy is not successful, regardless of what CloudFormation
+   reported.
+
+Tick `run_migrations` only when a deploy ships new migration files.
+
+## Notes and deliberate choices
+
+- **`ubuntu-24.04-arm` runners.** The Lambdas are arm64/Graviton, so an x86
+  runner would need QEMU and take roughly ten times as long. These runners are
+  free for public repositories. If they are ever unavailable, add
+  `docker/setup-qemu-action@v3` and switch to `ubuntu-latest`, accepting the
+  slowdown.
+- **Actions are pinned to major tags** (`@v4`), matching every existing workflow
+  in this repo and keeping Dependabot able to bump them. Pinning to full commit
+  SHAs is stricter against a compromised action and is worth considering for
+  this workflow specifically, since it is the one that holds AWS credentials.
+- **The images build twice** (once per synth in `plan` and `deploy`). This is the
+  cost of putting the human approval between a readable diff and the apply.
+  Native arm64 makes it cheap, and CDK skips pushing any digest already in ECR.
+- **No `push` trigger.** Deploys are dispatch-only by policy.

--- a/docs/CD-AWS-OIDC.md
+++ b/docs/CD-AWS-OIDC.md
@@ -213,6 +213,13 @@ Create an environment named **`production`** (Settings → Environments):
   you read the diff the `plan` job wrote to the run summary.
 - Optionally restrict deployment branches to `main`.
 
+> **A run with `run_migrations` ticked prompts you twice.** Environment
+> protection is evaluated per job, and `migrate` must also declare
+> `environment: production` — that declaration is the only way it can obtain
+> credentials, since the deploy role trusts no other subject. So the second
+> prompt is a consequence of the trust boundary, not an oversight. It is also
+> defensible on its own: a schema migration deserves its own confirmation.
+
 ### Variables
 
 Repository or `production`-environment **variables** (Settings → Variables).


### PR DESCRIPTION
Replaces laptop deploys with a GitHub Actions pipeline authenticated by OIDC role assumption. Implements the Phase 7 deploy hook that `smoke-deployed.yml` was written to be called from (#288/#289).

## Why

Deploying from the operator's laptop failed for two structural reasons, neither of them code:

1. **arm64 under emulation.** The Lambdas are Graviton; on an x86 laptop every image builds under QEMU. A cold build took ~50 minutes against ~3 warm.
2. **Home egress.** Each deploy pushes three container images. Flapping egress to `public.ecr.aws` / ECR failed the build repeatedly — a TLS handshake timeout fetching a base-image token, and a timeout awaiting response headers on an ECR manifest HEAD.

`ubuntu-24.04-arm` runners remove both: native arm64 with no emulation, and datacentre egress to same-region ECR.

## Design

**No long-lived AWS credentials.** OIDC only.

**Two roles**, because the two stages have genuinely different trust conditions:

| Role | Assumed by | Trusted subject | Write access |
| --- | --- | --- | --- |
| `snapurl-github-plan` | `plan` | branch ref | none — can assume only CDK's read-only lookup role |
| `snapurl-github-deploy` | `deploy`, `migrate` | `environment:production` | yes |

Binding the deploy role to the `production` environment is what makes the required-reviewer approval a security control rather than a UI nicety: no approval, no token, no credentials. `plan` must run *before* that approval to produce the diff, so it cannot share that binding — one role would have meant trusting the branch ref for deploys too, letting anyone who can push deploy without approval.

Neither role gets `PowerUserAccess`. CDK is already bootstrapped, so the bootstrap roles hold the deployment power and these roles mostly just assume them. The only direct grants are the three calls made outside CDK: `cloudformation:DescribeStacks` (read the stack's URLs), `ec2:DescribeSecurityGroups` (`deploy.sh`'s NAT post-verify), and `lambda:InvokeFunction` on the worker (migrations).

**Stages**

- `plan` — `cdk diff` into the run summary, annotating destructive changes as a warning. Changes nothing.
- `deploy` — environment-gated. Always through `infra/deploy.sh`, never raw `npx cdk`, so the full context-flag set is passed and the two incident settings are asserted afterwards. Two omitted flags have silently destroyed live resources here before (the budget/SNS cost alarms; the API's OAuth client id), which is exactly what a human must see in a diff first.
- `migrate` — opt-in. RDS is unreachable from outside the VPC, so migrations only run by invoking the worker.
- `smoke` — calls the existing reusable `smoke-deployed.yml` against the URLs this deploy produced, wired exactly as that file's own header prescribes. A deploy is not successful until the real create-link-then-follow-redirect journey passes: production once served 403 for every short link while health checks, Lambda error counts and DLQ depth were all green.

## Notes

- **The images build twice**, once per synth in `plan` and `deploy`. That is the deliberate cost of putting the approval *between* a readable diff and the apply. Native arm64 makes it cheap and CDK skips pushing digests already in ECR.
- Dispatch-only. No `push` trigger — deploys stay human-initiated.
- Actions pinned to major tags, matching every existing workflow here. SHA pinning is stricter and worth considering for this workflow specifically since it holds AWS credentials; called out in the doc.
- `ApiUrl` is the API Gateway root without a path, so `/api/v1` is appended for the smoke gate; `RedirectDomain` already carries its scheme.

## Not done here

Nothing was deployed and no live AWS resource was touched. The workflow cannot run until the two roles and the `production` environment exist — `docs/CD-AWS-OIDC.md` has the exact trust policies, permission policies and variables.

Adds no required status check; `ci-gate` still aggregates only `verify.yml`'s jobs, so branch protection is unchanged.
