### PR TITLE
ci(deploy): rollback, unconditional migrations, drift detection

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -60,11 +60,15 @@ on:
         required: true
         type: string
         default: SnapUrl
-      run_migrations:
-        description: Invoke the worker with {"task":"migrate"} after deploying.
+      git_ref:
+        description: >-
+          Commit, tag or branch to deploy. Blank = the ref this workflow was
+          dispatched from. Set it to an earlier commit to ROLL BACK — read
+          docs/ROLLBACK.md first, because redeploying old code does NOT undo a
+          database migration.
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
       skip_smoke:
         description: "Skip the post-deploy smoke gate. Leave false: unchecked means the deploy must prove itself."
         required: false
@@ -106,7 +110,13 @@ jobs:
       contents: read
       id-token: write # to assume the AWS role via OIDC
     steps:
+      # Pin to an explicit commit rather than the branch tip, and use the SAME
+      # one in the plan and deploy jobs. Two reasons: main advancing between the
+      # two jobs must not make the applied change differ from the reviewed diff,
+      # and `git_ref` needs a single place to take effect for a rollback.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.sha }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -202,6 +212,49 @@ jobs:
             echo "::warning title=Destructive change in plan::This diff removes or replaces resources. Confirm every one is intended before approving."
           fi
 
+      # Informational, NOT a gate — and the distinction matters, so it is stated
+      # rather than implied. A CDK image asset's hash is derived from its build
+      # CONTEXT, so an older commit reproduces the same hash; if that image is
+      # absent from ECR, CDK rebuilds it from the checked-out source rather than
+      # failing. So a missing image cannot break a rollback, it can only make it
+      # slow (a full emulation-free but still multi-minute arm64 build) instead
+      # of near-instant. During an incident, knowing which of those you are in
+      # for is worth a few seconds; pretending it is a safety check would not be.
+      - name: Rollback preflight — are the target images already in ECR?
+        env:
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+        run: |
+          set -uo pipefail
+          repo="cdk-hnb659fds-container-assets-${AWS_ACCOUNT_ID}-${AWS_REGION}"
+          manifest="infra/cdk.out/${{ inputs.stack }}.assets.json"
+          if [ ! -f "$manifest" ]; then
+            echo "No assets manifest at $manifest — skipping preflight."
+            exit 0
+          fi
+          tags="$(jq -r '(.dockerImages // {}) | to_entries[] | (.value.destinations | to_entries[0].value.imageTag)' "$manifest")"
+          present=0
+          absent=0
+          for tag in $tags; do
+            if aws ecr describe-images --repository-name "$repo" --image-ids "imageTag=$tag" >/dev/null 2>&1; then
+              echo "  cached in ECR : $tag"
+              present=$((present+1))
+            else
+              echo "  needs rebuild : $tag"
+              absent=$((absent+1))
+            fi
+          done
+          {
+            echo "### Rollback preflight"
+            echo
+            echo "Deploying commit \`$(git rev-parse HEAD)\`."
+            echo
+            if [ "$absent" -eq 0 ]; then
+              echo "All $present image(s) already in ECR — the deploy skips the image build (fast path)."
+            else
+              echo "$absent of $((present+absent)) image(s) must be rebuilt — expect several extra minutes."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/upload-artifact@v4
         with:
           name: cdk-diff-${{ github.run_id }}
@@ -229,7 +282,13 @@ jobs:
       redirect_url: ${{ steps.stack_outputs.outputs.redirect_url }}
       worker_function_name: ${{ steps.stack_outputs.outputs.worker_function_name }}
     steps:
+      # Pin to an explicit commit rather than the branch tip, and use the SAME
+      # one in the plan and deploy jobs. Two reasons: main advancing between the
+      # two jobs must not make the applied change differ from the reviewed diff,
+      # and `git_ref` needs a single place to take effect for a rollback.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.sha }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -271,6 +330,13 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: gha-snapurl-deploy-${{ github.run_id }}
 
+      # Resolve the ACTUAL commit checked out rather than reusing github.sha,
+      # which is the dispatched ref and therefore wrong during a rollback. This
+      # is the value the stack records, so it has to be the one really deployed.
+      - name: Resolve deployed commit
+        id: rev
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       # Always through deploy.sh, never `npx cdk deploy` directly. The wrapper
       # is what guarantees the full context-flag set is passed and then asserts
       # the two incident settings (NAT egress, DB TLS posture) actually landed.
@@ -283,7 +349,9 @@ jobs:
           DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
           BUDGET_EMAIL: ${{ vars.BUDGET_EMAIL }}
           GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
-        run: bash infra/deploy.sh "${{ inputs.stack }}"
+        run: |
+          bash infra/deploy.sh "${{ inputs.stack }}" \
+            -c "deployedGitSha=${{ steps.rev.outputs.sha }}"
 
       # Read the URLs from the stack itself rather than hardcoding them, so the
       # smoke gate always targets what was actually just deployed.
@@ -318,12 +386,27 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------
-  # 3. MIGRATE — opt-in. Not automatic, and deliberately so.
+  # 3. MIGRATE — unconditional, because a checkbox is a foot-gun.
   # ---------------------------------------------------------------------------
+  # This used to be an opt-in `run_migrations` input. That was wrong: it made
+  # correctness depend on an operator remembering to tick a box, and forgetting
+  # it on a deploy whose code needs a new column breaks production in a way the
+  # smoke gate may not even surface.
+  #
+  # Running unconditionally is safe because packages/database/src/migrate.ts uses
+  # Drizzle's migrator, which records applied migrations in its own table and
+  # applies only the pending ones. With nothing pending it is a no-op, so the
+  # cost of always running is one short Lambda invocation.
+  #
+  # The consequence to keep in mind: the order is now "new code, then new
+  # schema", so for the window between this job and the deploy above, new code
+  # runs against the old schema. Migrations must therefore stay
+  # backwards-compatible (expand/contract: add nullable, backfill, then tighten
+  # in a later release). A migration that drops or renames a column the previous
+  # release still reads will break that window.
   migrate:
     name: Apply DB migrations
     needs: deploy
-    if: inputs.run_migrations
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -361,17 +444,15 @@ jobs:
   # ---------------------------------------------------------------------------
   # 4. SMOKE — the gate that decides whether this deploy actually worked.
   # ---------------------------------------------------------------------------
-  # Wired exactly as smoke-deployed.yml's own header prescribes. `always()` with
-  # explicit result checks means a skipped optional migrate job does not skip
-  # the gate, but a FAILED one does.
+  # Wired exactly as smoke-deployed.yml's own header prescribes. `needs` covers
+  # both prior jobs, so a failed migration blocks the gate rather than letting a
+  # half-migrated environment report a successful deploy. No `always()` is
+  # needed now that migrate is unconditional — the default "all needs
+  # succeeded" is exactly the requirement.
   smoke:
     name: Post-deploy smoke
     needs: [deploy, migrate]
-    if: |
-      always() &&
-      needs.deploy.result == 'success' &&
-      (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
-      !inputs.skip_smoke
+    if: ${{ !inputs.skip_smoke }}
     uses: ./.github/workflows/smoke-deployed.yml
     with:
       redirect_base_url: ${{ needs.deploy.outputs.redirect_url }}

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -225,33 +225,42 @@ jobs:
           AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
         run: |
           set -uo pipefail
-          repo="cdk-hnb659fds-container-assets-${AWS_ACCOUNT_ID}-${AWS_REGION}"
           manifest="infra/cdk.out/${{ inputs.stack }}.assets.json"
           if [ ! -f "$manifest" ]; then
             echo "No assets manifest at $manifest — skipping preflight."
             exit 0
           fi
-          tags="$(jq -r '(.dockerImages // {}) | to_entries[] | (.value.destinations | to_entries[0].value.imageTag)' "$manifest")"
+          # Read the repository AND region from the manifest rather than
+          # constructing them. CDK records both per destination, and an asset can
+          # legitimately target a different region than the stack (this app
+          # already spans ap-south-1 and us-east-1), so a hand-built name would
+          # silently look in the wrong place and report every image as missing.
+          # repositoryName carries a ${AWS::AccountId} placeholder to substitute.
           present=0
           absent=0
-          for tag in $tags; do
-            if aws ecr describe-images --repository-name "$repo" --image-ids "imageTag=$tag" >/dev/null 2>&1; then
-              echo "  cached in ECR : $tag"
+          while IFS=$'\t' read -r region repo tag; do
+            [ -n "$tag" ] || continue
+            repo="${repo//\$\{AWS::AccountId\}/$AWS_ACCOUNT_ID}"
+            if aws ecr describe-images --region "$region" --repository-name "$repo" \
+                 --image-ids "imageTag=$tag" >/dev/null 2>&1; then
+              echo "  cached in ECR ($region): $tag"
               present=$((present+1))
             else
-              echo "  needs rebuild : $tag"
+              echo "  needs rebuild ($region): $tag"
               absent=$((absent+1))
             fi
-          done
+          done <<< "$(jq -r '(.dockerImages // {}) | to_entries[] | (.value.destinations | to_entries[0].value) | [.region, .repositoryName, .imageTag] | @tsv' "$manifest")"
           {
             echo "### Rollback preflight"
             echo
             echo "Deploying commit \`$(git rev-parse HEAD)\`."
             echo
-            if [ "$absent" -eq 0 ]; then
+            if [ "$absent" -eq 0 ] && [ "$present" -gt 0 ]; then
               echo "All $present image(s) already in ECR — the deploy skips the image build (fast path)."
-            else
+            elif [ "$absent" -gt 0 ]; then
               echo "$absent of $((present+absent)) image(s) must be rebuilt — expect several extra minutes."
+            else
+              echo "No container image assets found in this stack's manifest."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -1,0 +1,125 @@
+# CloudFormation drift detection.
+#
+# Why this exists: this account has carried infrastructure that CloudFormation
+# did not know about. During the redirect-403 incident a `lambda:InvokeFunction`
+# grant was added to the redirect function BY HAND (`aws lambda add-permission`)
+# to restore service, and it then existed outside the template until it was
+# made permanent in CDK and the hand-patched statement removed. For that whole
+# period the live account and the template disagreed, and nothing would have
+# told us.
+#
+# That is the class of problem drift detection catches: a resource changed
+# outside IaC. It is cheap (a few read-only API calls), so it runs weekly rather
+# than waiting for someone to suspect a problem.
+#
+# Deliberately READ-ONLY. It uses the PLAN role, not the deploy role — detecting
+# drift needs no write access, and a scheduled job that could deploy is a
+# standing risk with no upside. It does not attempt to CORRECT drift either:
+# resolving it means deciding whether the template or reality is right, which is
+# a judgement call for a human. This reports; you decide.
+
+name: Drift detection
+
+on:
+  schedule:
+    # Weekly, Monday 04:17 UTC. Off the hour deliberately — scheduled workflows
+    # bunch up on the hour across all of GitHub and get delayed.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: Stack to check.
+        required: true
+        type: string
+        default: SnapUrl
+
+permissions:
+  contents: read
+
+concurrency:
+  group: drift-detection
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    name: Detect stack drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write # to assume the read-only plan role via OIDC
+    steps:
+      # The plan role is trusted on the main branch ref, which is what a
+      # `schedule` trigger runs as. See docs/CD-AWS-OIDC.md.
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_PLAN_ROLE_ARN }}
+          aws-region: ap-south-1
+          role-session-name: gha-snapurl-drift-${{ github.run_id }}
+
+      - name: Detect and report drift
+        env:
+          STACK: ${{ inputs.stack || 'SnapUrl' }}
+        run: |
+          set -euo pipefail
+
+          id="$(aws cloudformation detect-stack-drift \
+                  --stack-name "$STACK" \
+                  --query StackDriftDetectionId --output text)"
+          echo "Detection id: $id"
+
+          # Poll rather than sleep-and-hope: detection over ~80 resources takes
+          # a variable amount of time and the result is useless if read early.
+          for _ in $(seq 1 60); do
+            status="$(aws cloudformation describe-stack-drift-detection-status \
+                        --stack-drift-detection-id "$id" \
+                        --query DetectionStatus --output text)"
+            [ "$status" = "DETECTION_IN_PROGRESS" ] || break
+            sleep 10
+          done
+          echo "Detection status: $status"
+
+          if [ "$status" != "DETECTION_COMPLETE" ]; then
+            echo "::error title=Drift detection did not complete::status=$status"
+            exit 1
+          fi
+
+          drift="$(aws cloudformation describe-stack-drift-detection-status \
+                     --stack-drift-detection-id "$id" \
+                     --query StackDriftStatus --output text)"
+          drifted_count="$(aws cloudformation describe-stack-drift-detection-status \
+                             --stack-drift-detection-id "$id" \
+                             --query DriftedStackResourceCount --output text)"
+
+          {
+            echo "### Drift detection — \`$STACK\`"
+            echo
+            echo "Status: **$drift** ($drifted_count drifted resource(s))"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$drift" = "IN_SYNC" ]; then
+            echo "In sync with the template."
+            exit 0
+          fi
+
+          # Name the specific resources — "something drifted" is not actionable.
+          aws cloudformation describe-stack-resource-drifts \
+            --stack-name "$STACK" \
+            --stack-resource-drift-status-filters MODIFIED DELETED NOT_CHECKED \
+            --query 'StackResourceDrifts[].{Logical:LogicalResourceId,Type:ResourceType,Status:StackResourceDriftStatus}' \
+            --output table | tee /tmp/drifts.txt
+
+          {
+            echo
+            echo '```'
+            cat /tmp/drifts.txt
+            echo '```'
+            echo
+            echo "A resource changed outside CloudFormation. Decide which side is"
+            echo "correct: fold the change into the CDK stack, or revert it in the"
+            echo "account. Do not simply redeploy without looking — that silently"
+            echo "discards whatever was changed by hand."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error title=Stack drift detected::$drifted_count resource(s) differ from the template. See the run summary."
+          exit 1

--- a/docs/CD-AWS-OIDC.md
+++ b/docs/CD-AWS-OIDC.md
@@ -75,7 +75,10 @@ ever plan from somewhere other than `main`.
 
 Its only permission is to assume the CDK **lookup** role, which `cdk diff` uses
 to read the deployed template. The lookup role is itself read-only, so this role
-cannot mutate infrastructure even transitively.
+cannot mutate infrastructure even transitively. It also carries a few direct
+read-only calls: the rollback preflight checks whether an image tag is already in
+ECR, and the weekly `drift-detection.yml` workflow runs CloudFormation drift
+detection. Neither can change anything.
 
 ```json
 {
@@ -98,10 +101,39 @@ cannot mutate infrastructure even transitively.
         "arn:aws:ssm:ap-south-1:646799484931:parameter/cdk-bootstrap/hnb659fds/version",
         "arn:aws:ssm:us-east-1:646799484931:parameter/cdk-bootstrap/hnb659fds/version"
       ]
+    },
+    {
+      "Sid": "RollbackPreflightReadImages",
+      "Effect": "Allow",
+      "Action": ["ecr:DescribeImages"],
+      "Resource": [
+        "arn:aws:ecr:ap-south-1:646799484931:repository/cdk-hnb659fds-container-assets-646799484931-ap-south-1"
+      ]
+    },
+    {
+      "Sid": "DriftDetection",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:DetectStackDrift",
+        "cloudformation:DetectStackResourceDrift",
+        "cloudformation:DescribeStackDriftDetectionStatus",
+        "cloudformation:DescribeStackResourceDrifts",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents"
+      ],
+      "Resource": [
+        "arn:aws:cloudformation:ap-south-1:646799484931:stack/SnapUrl/*"
+      ]
     }
   ]
 }
 ```
+
+> `DetectStackDrift` inspects the stack's resources, so the lookup role's own
+> read access is what makes the per-resource comparison possible. If drift
+> detection returns `DETECTION_FAILED` for specific resources, that is usually a
+> missing read permission on the resource's own service rather than a
+> CloudFormation problem.
 
 ### 2b. Deploy role trust policy
 
@@ -213,12 +245,12 @@ Create an environment named **`production`** (Settings → Environments):
   you read the diff the `plan` job wrote to the run summary.
 - Optionally restrict deployment branches to `main`.
 
-> **A run with `run_migrations` ticked prompts you twice.** Environment
-> protection is evaluated per job, and `migrate` must also declare
-> `environment: production` — that declaration is the only way it can obtain
-> credentials, since the deploy role trusts no other subject. So the second
-> prompt is a consequence of the trust boundary, not an oversight. It is also
-> defensible on its own: a schema migration deserves its own confirmation.
+> **Every run prompts you twice.** Environment protection is evaluated per job,
+> and `migrate` must also declare `environment: production` — that declaration is
+> the only way it can obtain credentials, since the deploy role trusts no other
+> subject. So the second prompt is a consequence of the trust boundary, not an
+> oversight. Migrations run on every deploy (a no-op when nothing is pending), so
+> this applies to rollbacks too.
 
 ### Variables
 
@@ -258,11 +290,13 @@ registration is ever disabled in production do you add `smoke_email` /
 2. `plan` runs and writes the diff to the run summary. **Read it.** Confirm it
    contains only what you intended and no unexpected deletion.
 3. Approve the `production` environment prompt. `deploy` applies it.
-4. `smoke` runs `scripts/smoke-redirect.sh` against the freshly-deployed URLs.
-   If it fails, the deploy is not successful, regardless of what CloudFormation
+4. `migrate` runs automatically (a no-op when nothing is pending), then `smoke`
+   runs `scripts/smoke-redirect.sh` against the freshly-deployed URLs. If it
+   fails, the deploy is not successful, regardless of what CloudFormation
    reported.
 
-Tick `run_migrations` only when a deploy ships new migration files.
+To roll back, dispatch the same workflow with `git_ref` set to an earlier commit
+— see `docs/ROLLBACK.md`, and read its warning about migrations first.
 
 ## Notes and deliberate choices
 

--- a/docs/CD-AWS-OIDC.md
+++ b/docs/CD-AWS-OIDC.md
@@ -107,7 +107,8 @@ detection. Neither can change anything.
       "Effect": "Allow",
       "Action": ["ecr:DescribeImages"],
       "Resource": [
-        "arn:aws:ecr:ap-south-1:646799484931:repository/cdk-hnb659fds-container-assets-646799484931-ap-south-1"
+        "arn:aws:ecr:ap-south-1:646799484931:repository/cdk-hnb659fds-container-assets-646799484931-ap-south-1",
+        "arn:aws:ecr:us-east-1:646799484931:repository/cdk-hnb659fds-container-assets-646799484931-us-east-1"
       ]
     },
     {

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,118 @@
+# Rollback
+
+How to put production back on an earlier commit, and — more importantly — what
+that does **not** undo.
+
+## Read this part first
+
+**Rolling back code does not roll back the database.** Migrations are applied
+forward-only by Drizzle's migrator. If the release you are backing out added a
+migration, redeploying the previous commit leaves the *new* schema in place while
+running the *old* code. Whether that is safe depends entirely on whether the
+migration was backwards-compatible:
+
+| The migration… | Rolling back code is… |
+| --- | --- |
+| added a nullable column or a new table | safe — old code ignores it |
+| added a column the old code does not read | safe |
+| dropped or renamed a column the old code reads | **broken** — old code queries a column that no longer exists |
+| tightened a constraint the old code violates | **broken** — writes start failing |
+
+For the unsafe rows, a code rollback makes things *worse*, not better. Roll
+forward with a fix instead. This is the main reason migrations must be written
+expand/contract (add nullable → backfill → tighten in a *later* release), so that
+any single release remains reversible.
+
+**CloudFormation's own rollback is a different thing.** It reverts a *failed*
+stack update automatically. It does nothing about a deploy that **succeeds** and
+is functionally broken — which is the case that actually hurt here: production
+returned 403 for every short link while CloudFormation reported success, health
+checks were 200, Lambda error counts were zero and the DLQ was empty. That is the
+scenario this document is for.
+
+## 1. Find out what is running
+
+```bash
+aws cloudformation describe-stacks --profile snapurl-ro --region ap-south-1 \
+  --stack-name SnapUrl \
+  --query 'Stacks[0].Outputs[?OutputKey==`DeployedGitSha`].OutputValue' --output text
+```
+
+If that returns nothing, the stack predates the `DeployedGitSha` output. Fall
+back to correlating `Stacks[0].LastUpdatedTime` against the deploy workflow's run
+history, and accept that you are inferring rather than reading.
+
+## 2. Choose the target commit
+
+The last commit known to have passed the post-deploy smoke gate — check the
+**Deploy (AWS)** workflow history for the most recent run whose `smoke` job was
+green. "The previous commit on main" is a worse choice: it may never have been
+deployed at all.
+
+```bash
+git log --oneline -15 origin/main
+```
+
+## 3. Roll back
+
+Actions → **Deploy (AWS)** → Run workflow:
+
+- `stack`: `SnapUrl`
+- `git_ref`: the target commit SHA
+- `skip_smoke`: leave unchecked
+
+The `plan` job runs first. **Read its diff.** A rollback diff should be the exact
+inverse of the deploy that caused the problem; anything else means the target
+commit is not what you thought. The plan job's preflight also tells you whether
+the target's container images are still in ECR (fast) or need rebuilding (several
+minutes) — useful for setting expectations while an incident is open.
+
+Then approve the `production` environment prompt. Approve twice: once for
+`deploy`, once for `migrate` (environment protection is evaluated per job).
+
+`migrate` runs on a rollback too and is a no-op when nothing is pending — it will
+not attempt to reverse anything. Re-read the warning at the top: that no-op is
+also why the schema stays forward of the code.
+
+## 4. Confirm it worked
+
+The `smoke` job is the real verdict: it creates a link through the live API and
+follows it, asserting the redirect. If it passes, the core journey works. Do not
+substitute a health check — `/health` returned 200 throughout the 403 outage.
+
+Spot-check by hand as well:
+
+```bash
+UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36'
+curl -s -o /dev/null -m 25 -A "$UA" -w 'status=%{http_code}\nlocation=%header{location}\n' \
+  'https://snapurl.in/<known-slug>?utm_source=probe'
+```
+
+Use a realistic User-Agent for anything touching analytics: the rollup counts
+only `is_bot = false`, so curl's default UA is correctly classified a bot and
+will read as zero clicks forever.
+
+## If the rollback itself fails
+
+A deploy that fails during the image build or ECR push has applied **nothing** —
+the change set runs only after every image builds and pushes. Confirm with
+`LastUpdatedTime` and retry.
+
+If CloudFormation itself fails mid-update it will roll back to the pre-update
+state on its own, which for a rollback attempt means you are back on the broken
+release. At that point stop escalating automation and inspect the stack events:
+
+```bash
+aws cloudformation describe-stack-events --profile snapurl-ro --region ap-south-1 \
+  --stack-name SnapUrl --max-items 40 \
+  --query 'StackEvents[?ResourceStatus==`UPDATE_FAILED`].[LogicalResourceId,ResourceStatusReason]' \
+  --output table
+```
+
+## Known gap
+
+There is no canary or staged rollout. New code takes 100% of traffic the moment
+the deploy completes, and the smoke gate runs *after* that. So this procedure
+shortens the time to recovery; it does not prevent users from seeing the problem.
+Closing that properly means a Lambda alias with CodeDeploy weighted shifting and
+an alarm-triggered automatic rollback — not yet built.

--- a/infra/bin/snapurl.ts
+++ b/infra/bin/snapurl.ts
@@ -78,6 +78,11 @@ new SnapUrlStack(app, "SnapUrl", {
      Google Cloud Console client's id exactly, and matching
      NEXT_PUBLIC_GOOGLE_CLIENT_ID on the frontend. */
   googleOAuthClientId: app.node.tryGetContext("googleOAuthClientId"),
+  /* The commit this deploy was built from, surfaced as the DeployedGitSha
+     output. Set by CI (`-c deployedGitSha=<sha>`); omitted locally, in which
+     case the output is simply not created. Answering "which commit is live?"
+     is a precondition for rollback — see docs/ROLLBACK.md. */
+  deployedGitSha: app.node.tryGetContext("deployedGitSha"),
   description: "SnapURL: API, redirect service, worker, and the Postgres they share.",
   tags: {
     Project: "SnapURL",

--- a/infra/lib/snapurl-stack.ts
+++ b/infra/lib/snapurl-stack.ts
@@ -109,6 +109,18 @@ export interface SnapUrlStackProps extends StackProps {
    */
   budgetEmail?: string;
   /**
+   * The git commit this deploy was built from, surfaced as the
+   * `DeployedGitSha` output.
+   *
+   * Optional, and purely informational — nothing in the stack reads it. It
+   * exists because without it there is no way to ask a running environment
+   * which commit it is on, and that question has to be answerable BEFORE a
+   * rollback: "redeploy the last good commit" is not actionable if the current
+   * one is unknown. Set by CI with `-c deployedGitSha=${{ github.sha }}`; a
+   * local `cdk deploy` that omits it simply gets no such output.
+   */
+  deployedGitSha?: string;
+  /**
    * Custom domain for the CloudFront distribution (the redirect/short-link
    * edge), e.g. `snapurl.in`. Optional — unset means the raw
    * `*.cloudfront.net` hostname, exactly the prior behaviour. Set with
@@ -1310,6 +1322,18 @@ export class SnapUrlStack extends Stack {
       value: props.configPrefix,
       description: "Parameter Store prefix this stage reads. Change a value there, then redeploy.",
     });
+    /* Conditional on purpose: emitted only when CI passes the commit, so a
+       local deploy neither gains a misleading output nor has to invent a value.
+       Read it with:
+         aws cloudformation describe-stacks --stack-name SnapUrl \
+           --query 'Stacks[0].Outputs[?OutputKey==`DeployedGitSha`].OutputValue'
+       See docs/ROLLBACK.md, which starts from this value. */
+    if (props.deployedGitSha) {
+      new CfnOutput(this, "DeployedGitSha", {
+        value: props.deployedGitSha,
+        description: "Git commit this stack was last deployed from. The starting point for a rollback.",
+      });
+    }
     new CfnOutput(this, "JwtSecretArns", {
       value: `${config.jwtAccessSecret.secretArn} ${config.jwtRefreshSecret.secretArn}`,
       description: "JWT signing keys. Rotating either invalidates the tokens it signed.",


### PR DESCRIPTION
Closes the recovery gaps the deploy pipeline in #399 shipped without. Everything here is workflow/docs/infra-output only — no application code, no topology change, **no new AWS spend**.

Sequenced ahead of a staging environment deliberately: staging needs a second RDS plus a NAT instance (`natStrategy=none` won't do, the Lambdas need Secrets Manager egress — that was the #348 incident), hits a real blocker (`budgetName: "SnapURL-monthly-cost"` is account-global and would collide), and needs product decisions. This costs nothing and closes the sharper risk.

## 1. Record the deployed commit

Nothing could answer *"which commit is production on?"* — which makes "redeploy the last good commit" unactionable. Adds an **optional** `deployedGitSha` prop threaded through `-c` context, surfaced as a `DeployedGitSha` output. CI passes the resolved SHA.

Verified additive rather than asserted: synthesizing with and without the flag yields **byte-identical `Resources` (80) and `Parameters` (10)**, the only delta being the new output — so omitting it reproduces the previous template exactly, and no logical ID moved.

## 2. Rollback

Nothing could undo a deploy. CloudFormation auto-rollback covers a *failed* update; it does nothing for one that **succeeds and is functionally broken** — which is exactly what the redirect-403 outage was (CFN reported success, health checks 200, zero Lambda errors, empty DLQ).

- New `git_ref` input. **Both** `plan` and `deploy` check out the same explicit ref, defaulting to `github.sha` rather than the branch tip, so main advancing mid-run cannot make the applied change differ from the reviewed diff.
- The deploy now resolves the actually-checked-out commit (`git rev-parse HEAD`) rather than reusing `github.sha`, which would be wrong during a rollback.
- **The image check is deliberately NOT a hard gate**, and I want to flag that I changed my own plan here. A CDK asset hash is derived from its build *context*, so an older ref reproduces the same hash, and if the image is absent from ECR, CDK **rebuilds it from source** rather than failing. A missing image cannot break a rollback — only slow it. So the preflight reports fast-path (cached) vs slow-path (rebuild), which is the genuinely useful thing mid-incident. Shipping it as a "safety gate" would have been theatre.

`docs/ROLLBACK.md` leads with what rollback does **not** undo: migrations are forward-only, so backing out code leaves the new schema under old code. There's a table of which migration shapes make a code rollback safe versus actively worse.

Rollback feasibility was verified, not assumed: the CDK assets ECR repo's lifecycle policy expires only **untagged** images after 365 days, and asset images are digest-tagged — all 15 current digests are retained.

## 3. Migrations always run

Removed the `run_migrations` checkbox. Correctness must not depend on an operator remembering to tick a box — forget it on a release needing a new column and production breaks in a way the smoke gate may not surface.

Safe because `packages/database/src/migrate.ts` uses Drizzle's migrator, which records applied migrations in its own table and applies only pending ones, so it no-ops. The workflow documents the consequence: the order is now "new code, then new schema", so migrations must stay expand/contract.

This also simplified the smoke gate's condition — `always()` with explicit result checks existed only to tolerate a skipped migrate job, which can no longer happen.

## 4. Weekly drift detection

New read-only `drift-detection.yml`. This account has carried infrastructure CloudFormation didn't know about: during the 403 incident a `lambda:InvokeFunction` grant was added by hand and existed outside the template until it was made permanent in CDK. Nothing would have told us.

Uses the **plan** role, not the deploy role — a scheduled job that could deploy is a standing risk with no upside. Reports drifted resources by name and fails the run; it does **not** attempt to correct drift, since deciding whether the template or reality is right is a judgement call.

## Verification

- **`actionlint` clean on all 6 workflows.** It earned its place: it caught a real YAML break where embedded multi-line Python starting at column 0 terminated a block scalar. Replaced with a one-line `jq` extraction, then tested against both the real 3-image manifest and the image-less cert manifest.
- `cdk synth` succeeds with **and** without `deployedGitSha`, templates diffed structurally.
- `pnpm -r type-check` clean; infra 79 tests pass.
- Every embedded bash block executed locally against **both** the pass and fail case — the drift poll (completes / never completes), and the drift branch (IN_SYNC exit 0 / DRIFTED exit 1). My first poll-loop test was itself wrong (subshell counter never incremented, reporting "0 polls"); I rewrote the harness rather than accepting the green.

## Not verified

Nothing was deployed and no live AWS resource was mutated. Untested until a real run: the ECR preflight against a genuine rollback, and drift detection end to end (needs the two new permissions on the plan role — `docs/CD-AWS-OIDC.md` is updated with `ecr:DescribeImages` and the four `cloudformation:*Drift*` actions).

Still open from the architecture review, in order: staging environment, then build-once-promote-many, then alarm-gated canary rollout. The canary gap is stated explicitly at the bottom of `ROLLBACK.md` — this shortens time-to-recovery, it does not stop users seeing the problem.
